### PR TITLE
StringSegment: better performance

### DIFF
--- a/src/Primitives/src/Resources.resx
+++ b/src/Primitives/src/Resources.resx
@@ -121,7 +121,7 @@
     <value>Offset and length are out of bounds for the string or length is greater than the number of characters from index to the end of the string.</value>
   </data>
   <data name="Argument_InvalidOffsetLengthStringSegment" xml:space="preserve">
-    <value>Offset and length are out of bounds for this stringsegment or length is greater than the number of characters to the end of this stringsegment.</value>
+    <value>Offset and length are out of bounds for this StringSegment or length is greater than the number of characters to the end of this StringSegment.</value>
   </data>
   <data name="Capacity_CannotChangeAfterWriteStarted" xml:space="preserve">
     <value>Cannot change capacity after write started.</value>

--- a/src/Primitives/src/Resources.resx
+++ b/src/Primitives/src/Resources.resx
@@ -120,6 +120,9 @@
   <data name="Argument_InvalidOffsetLength" xml:space="preserve">
     <value>Offset and length are out of bounds for the string or length is greater than the number of characters from index to the end of the string.</value>
   </data>
+  <data name="Argument_InvalidOffsetLengthStringSegment" xml:space="preserve">
+    <value>Offset and length are out of bounds for this stringsegment or length is greater than the number of characters to the end of this stringsegment.</value>
+  </data>
   <data name="Capacity_CannotChangeAfterWriteStarted" xml:space="preserve">
     <value>Cannot change capacity after write started.</value>
   </data>

--- a/src/Primitives/src/StringSegment.cs
+++ b/src/Primitives/src/StringSegment.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="buffer">The original <see cref="string"/> used as buffer.</param>
         /// <param name="offset">The offset of the segment within the <paramref name="buffer"/>.</param>
         /// <param name="length">The length of the segment.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public StringSegment(string buffer, int offset, int length)
         {
             // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
@@ -49,32 +48,6 @@ namespace Microsoft.Extensions.Primitives
             Buffer = buffer;
             Offset = offset;
             Length = length;
-        }
-
-        private static void ThrowInvalidArguments(string buffer, int offset, int length)
-        {
-            // Only have single throw in method so is marked as "does not return" and isn't inlined to caller
-            throw GetInvalidArgumentException(buffer, offset, length);
-        }
-
-        private static Exception GetInvalidArgumentException(string buffer, int offset, int length)
-        {
-            if (buffer == null)
-            {
-                return ThrowHelper.GetArgumentNullException(ExceptionArgument.buffer);
-            }
-
-            if (offset < 0)
-            {
-                return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
-
-            if (length < 0)
-            {
-                return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
-            }
-
-            return ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLength);
         }
 
         /// <summary>
@@ -99,13 +72,13 @@ namespace Microsoft.Extensions.Primitives
         {
             get
             {
-                if (!HasValue)
+                if (HasValue)
                 {
-                    return null;
+                    return Buffer.Substring(Offset, Length);
                 }
                 else
                 {
-                    return Buffer.Substring(Offset, Length);
+                    return null;
                 }
             }
         }
@@ -188,11 +161,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
         /// <returns><code>true</code> if the current object is equal to the other parameter; otherwise, <code>false</code>.</returns>
-        public bool Equals(StringSegment other)
-        {
-            return Equals(other, StringComparison.Ordinal);
-        }
-
+        public bool Equals(StringSegment other) => Equals(other, StringComparison.Ordinal);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
@@ -202,13 +171,12 @@ namespace Microsoft.Extensions.Primitives
         /// <returns><code>true</code> if the current object is equal to the other parameter; otherwise, <code>false</code>.</returns>
         public bool Equals(StringSegment other, StringComparison comparisonType)
         {
-            int textLength = other.Length;
-            if (Length != textLength)
+            if (Length != other.Length)
             {
                 return false;
             }
 
-            return string.Compare(Buffer, Offset, other.Buffer, other.Offset, textLength, comparisonType) == 0;
+            return string.Compare(Buffer, Offset, other.Buffer, other.Offset, other.Length, comparisonType) == 0;
         }
 
         // This handles StringSegment.Equals(string, StringSegment, StringComparison) and StringSegment.Equals(StringSegment, string, StringComparison)
@@ -242,6 +210,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="text">The <see cref="string"/> to compare with the current <see cref="StringSegment"/>.</param>
         /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
         /// <returns><code>true</code> if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(string text, StringComparison comparisonType)
         {
             if (text == null)
@@ -264,17 +233,11 @@ namespace Microsoft.Extensions.Primitives
         /// However this is required to ensure we retain any behavior (such as hash code randomization) that
         /// string.GetHashCode has.
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            if (!HasValue)
-            {
-                return 0;
-            }
-            else
-            {
-                // TODO: PERF; Note that .NET Core strings use randomized hash codes for security reasons.
-                return Value.GetHashCode();
-            }
+            // TODO: PERF; Note that .NET Core strings use randomized hash codes for security reasons.
+            return Value?.GetHashCode() ?? 0;
         }
 
         /// <summary>
@@ -283,10 +246,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="left">The first <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
         /// <param name="right">The second <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
         /// <returns><code>true</code> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <code>false</code>.</returns>
-        public static bool operator ==(StringSegment left, StringSegment right)
-        {
-            return left.Equals(right);
-        }
+        public static bool operator ==(StringSegment left, StringSegment right) => left.Equals(right);
 
         /// <summary>
         /// Checks if two specified <see cref="StringSegment"/> have different values.
@@ -294,20 +254,14 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="left">The first <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
         /// <param name="right">The second <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
         /// <returns><code>true</code> if the value of <paramref name="left"/> is different from the value of <paramref name="right"/>; otherwise, <code>false</code>.</returns>
-        public static bool operator !=(StringSegment left, StringSegment right)
-        {
-            return !left.Equals(right);
-        }
+        public static bool operator !=(StringSegment left, StringSegment right) => !left.Equals(right);
 
         // PERF: Do NOT add a implicit converter from StringSegment to String. That would negate most of the perf safety.
         /// <summary>
         /// Creates a new <see cref="StringSegment"/> from the given <see cref="string"/>.
         /// </summary>
         /// <param name="value">The <see cref="string"/> to convert to a <see cref="StringSegment"/></param>
-        public static implicit operator StringSegment(string value)
-        {
-            return new StringSegment(value);
-        }
+        public static implicit operator StringSegment(string value) => new StringSegment(value);
 
         /// <summary>
         /// Creates a see <see cref="ReadOnlySpan{T}"/> from the given <see cref="StringSegment"/>.
@@ -327,6 +281,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="text">The <see cref="string"/>to compare.</param>
         /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
         /// <returns><code>true</code> if <paramref name="text"/> matches the beginning of this <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool StartsWith(string text, StringComparison comparisonType)
         {
             if (text == null)
@@ -334,13 +289,15 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
             }
 
-            var textLength = text.Length;
-            if (!HasValue || Length < textLength)
+            bool result = false;
+            int textLength = text.Length;
+
+            if (HasValue && Length >= textLength)
             {
-                return false;
+                result = string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
             }
 
-            return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
+            return result;
         }
 
         /// <summary>
@@ -349,6 +306,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="text">The <see cref="string"/>to compare.</param>
         /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
         /// <returns><code>true</code> if <paramref name="text"/> matches the end of this <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool EndsWith(string text, StringComparison comparisonType)
         {
             if (text == null)
@@ -356,13 +314,16 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
             }
 
-            var textLength = text.Length;
-            if (!HasValue || Length < textLength)
+            bool result = false;
+            int textLength = text.Length;
+            int comparisonLength = Offset + Length - textLength;
+
+            if (HasValue && comparisonLength > 0)
             {
-                return false;
+                result = string.Compare(Buffer, comparisonLength, text, 0, textLength, comparisonType) == 0;
             }
 
-            return string.Compare(Buffer, Offset + Length - textLength, text, 0, textLength, comparisonType) == 0;
+            return result;
         }
 
         /// <summary>
@@ -372,10 +333,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <returns>A <see cref="string"/> that is equivalent to the substring of remaining length that begins at
         /// <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
-        public string Substring(int offset)
-        {
-            return Substring(offset, Length - offset);
-        }
+        public string Substring(int offset) => Substring(offset, Length - offset);
 
         /// <summary>
         /// Retrieves a substring from this <see cref="StringSegment"/>.
@@ -385,21 +343,12 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="length">The number of characters in the substring.</param>
         /// <returns>A <see cref="string"/> that is equivalent to the substring of length <paramref name="length"/> that begins at
         /// <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string Substring(int offset, int length)
         {
-            if (!HasValue)
+            if (!HasValue || offset < 0 || offset + length > Length || length < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
-
-            if (offset < 0 || offset + length > Length)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
-
-            if (length < 0 || Offset + offset + length > Buffer.Length)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                ThrowInvalidArguments(offset, length);
             }
 
             return Buffer.Substring(Offset + offset, length);
@@ -412,10 +361,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <returns>A <see cref="StringSegment"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/>
         /// whose length is the remainder.</returns>
-        public StringSegment Subsegment(int offset)
-        {
-            return Subsegment(offset, Length - offset);
-        }
+        public StringSegment Subsegment(int offset) => Subsegment(offset, Length - offset);
 
         /// <summary>
         /// Retrieves a <see cref="StringSegment"/> that represents a substring from this <see cref="StringSegment"/>.
@@ -426,19 +372,9 @@ namespace Microsoft.Extensions.Primitives
         /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of length <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
         public StringSegment Subsegment(int offset, int length)
         {
-            if (!HasValue)
+            if (!HasValue || offset < 0 || offset + length > Length || length < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
-
-            if (offset < 0 || offset + length > Length)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
-
-            if (length < 0 || Offset + offset + length > Buffer.Length)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                ThrowInvalidArguments(offset, length);
             }
 
             return new StringSegment(Buffer, Offset + offset, length);
@@ -452,26 +388,28 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="start">The zero-based index position at which the search starts. </param>
         /// <param name="count">The number of characters to examine.</param>
         /// <returns>The zero-based index position of <paramref name="c"/> from the beginning of the <see cref="StringSegment"/> if that character is found, or -1 if it is not.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int IndexOf(char c, int start, int count)
         {
-            if (start < 0 || Offset + start > Buffer.Length)
+            var offset = Offset + start;
+
+            if (!HasValue || start < 0 || offset > Buffer.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
-            if (count < 0 || Offset + start + count > Buffer.Length)
+            if (count < 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
             }
-            var index = Buffer.IndexOf(c, start + Offset, count);
+
+            var index = Buffer.IndexOf(c, offset, count);
             if (index != -1)
             {
-                return index - Offset;
+                index -= Offset;
             }
-            else
-            {
-                return index;
-            }
+
+            return index;
         }
 
         /// <summary>
@@ -481,20 +419,14 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="c">The Unicode character to seek.</param>
         /// <param name="start">The zero-based index position at which the search starts. </param>
         /// <returns>The zero-based index position of <paramref name="c"/> from the beginning of the <see cref="StringSegment"/> if that character is found, or -1 if it is not.</returns>
-        public int IndexOf(char c, int start)
-        {
-            return IndexOf(c, start, Length - start);
-        }
+        public int IndexOf(char c, int start) => IndexOf(c, start, Length - start);
 
         /// <summary>
         /// Gets the zero-based index of the first occurrence of the character <paramref name="c"/> in this <see cref="StringSegment"/>.
         /// </summary>
         /// <param name="c">The Unicode character to seek.</param>
         /// <returns>The zero-based index position of <paramref name="c"/> from the beginning of the <see cref="StringSegment"/> if that character is found, or -1 if it is not.</returns>
-        public int IndexOf(char c)
-        {
-            return IndexOf(c, 0, Length);
-        }
+        public int IndexOf(char c) => IndexOf(c, 0, Length);
 
         /// <summary>
         /// Reports the zero-based index of the first occurrence in this instance of any character in a specified array
@@ -506,30 +438,31 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="count">The number of character positions to examine.</param>
         /// <returns>The zero-based index position of the first occurrence in this instance where any character in anyOf
         /// was found; -1 if no character in anyOf was found.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int IndexOfAny(char[] anyOf, int startIndex, int count)
         {
-            if (!HasValue)
+            var index = -1;
+
+            if (HasValue)
             {
-                return -1;
+                if (startIndex < 0 || Offset + startIndex > Buffer.Length)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                }
+
+                if (count < 0 || Offset + startIndex + count > Buffer.Length)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
+                }
+
+                index = Buffer.IndexOfAny(anyOf, Offset + startIndex, count);
+                if (index != -1)
+                {
+                    index -= Offset;
+                }
             }
 
-            if (startIndex < 0 || Offset + startIndex > Buffer.Length)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            }
-
-            if (count < 0 || Offset + startIndex + count > Buffer.Length)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
-            }
-
-            var index = Buffer.IndexOfAny(anyOf, Offset + startIndex, count);
-            if (index == -1)
-            {
-                return index;
-            }
-
-            return index - Offset;
+            return index;
         }
 
         /// <summary>
@@ -564,67 +497,78 @@ namespace Microsoft.Extensions.Primitives
         /// <returns>The zero-based index position of value if that character is found, or -1 if it is not.</returns>
         public int LastIndexOf(char value)
         {
-            if (!HasValue)
+            var index = -1;
+
+            if (HasValue)
             {
-                return -1;
+                index = Buffer.LastIndexOf(value, Offset + Length - 1, Length);
+                if (index != -1)
+                {
+                    index -= Offset;
+                }
             }
 
-            var index = Buffer.LastIndexOf(value, Offset + Length - 1, Length);
-            if (index == -1)
-            {
-                return -1;
-            }
-
-            return index - Offset;
+            return index;
         }
 
         /// <summary>
         /// Removes all leading and trailing whitespaces.
         /// </summary>
         /// <returns>The trimmed <see cref="StringSegment"/>.</returns>
-        public StringSegment Trim()
-        {
-            return TrimStart().TrimEnd();
-        }
+        public StringSegment Trim() => TrimStart().TrimEnd();
 
         /// <summary>
         /// Removes all leading whitespaces.
         /// </summary>
         /// <returns>The trimmed <see cref="StringSegment"/>.</returns>
-        public StringSegment TrimStart()
+        public unsafe StringSegment TrimStart()
         {
             var trimmedStart = Offset;
-            while (trimmedStart < Offset + Length)
-            {
-                if (!char.IsWhiteSpace(Buffer, trimmedStart))
-                {
-                    break;
-                }
+            var length = Offset + Length;
 
-                trimmedStart++;
+            fixed (char* p = Buffer)
+            {
+                while (trimmedStart < length)
+                {
+                    char c = p[trimmedStart];
+
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        break;
+                    }
+
+                    trimmedStart++;
+                }
             }
 
-            return new StringSegment(Buffer, trimmedStart, Offset + Length - trimmedStart);
+            return new StringSegment(Buffer, trimmedStart, length - trimmedStart);
         }
 
         /// <summary>
         /// Removes all trailing whitespaces.
         /// </summary>
         /// <returns>The trimmed <see cref="StringSegment"/>.</returns>
-        public StringSegment TrimEnd()
+        public unsafe StringSegment TrimEnd()
         {
-            var trimmedEnd = Offset + Length - 1;
-            while (trimmedEnd >= Offset)
-            {
-                if (!char.IsWhiteSpace(Buffer, trimmedEnd))
-                {
-                    break;
-                }
+            var offset = Offset;
+            var trimmedEnd = offset + Length - 1;
 
-                trimmedEnd--;
+            fixed (char* p = Buffer)
+            {
+                while (trimmedEnd >= offset)
+                {
+                    char c = p[trimmedEnd];
+
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        break;
+                    }
+
+                    trimmedEnd--;
+                }
             }
 
-            return new StringSegment(Buffer, Offset, trimmedEnd - Offset + 1);
+            return new StringSegment(Buffer, offset, trimmedEnd - offset + 1);
         }
 
         /// <summary>
@@ -646,7 +590,14 @@ namespace Microsoft.Extensions.Primitives
         /// <returns></returns>
         public static bool IsNullOrEmpty(StringSegment value)
         {
-            return !value.HasValue || value.Length == 0;
+            var res = false;
+
+            if (!value.HasValue || value.Length == 0)
+            {
+                res = true;
+            }
+
+            return res;
         }
 
         /// <summary>
@@ -656,6 +607,43 @@ namespace Microsoft.Extensions.Primitives
         public override string ToString()
         {
             return Value ?? string.Empty;
+        }
+
+        // Methods that do no return (i.e. throw) are not inlined
+        // https://github.com/dotnet/coreclr/pull/6103
+        private static void ThrowInvalidArguments(string buffer, int offset, int length)
+        {
+            if (buffer == null)
+            {
+                throw ThrowHelper.GetArgumentNullException(ExceptionArgument.buffer);
+            }
+
+            if (offset < 0)
+            {
+                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
+            }
+
+            if (length < 0)
+            {
+                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+
+            throw ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLength);
+        }
+
+        private void ThrowInvalidArguments(int offset, int length)
+        {
+            if (!HasValue)
+            {
+                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
+            }
+
+            if (offset < 0 || offset + length > Length)
+            {
+                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
+            }
+
+            throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
         }
     }
 }

--- a/src/Primitives/src/StringSegment.cs
+++ b/src/Primitives/src/StringSegment.cs
@@ -614,42 +614,53 @@ namespace Microsoft.Extensions.Primitives
         // https://github.com/dotnet/coreclr/pull/6103
         private static void ThrowInvalidArguments(string buffer, int offset, int length)
         {
-            if (buffer == null)
-            {
-                throw ThrowHelper.GetArgumentNullException(ExceptionArgument.buffer);
-            }
+            // Only have single throw in method so is marked as "does not return" and isn't inlined to caller
+            throw GetInvalidArgumentsException();
 
-            if (offset < 0)
+            Exception GetInvalidArgumentsException()
             {
-                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
+                if (buffer == null)
+                {
+                    return ThrowHelper.GetArgumentNullException(ExceptionArgument.buffer);
+                }
 
-            if (length < 0)
-            {
-                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
-            }
+                if (offset < 0)
+                {
+                    return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
+                }
 
-            throw ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLength);
+                if (length < 0)
+                {
+                    return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
+                }
+
+                return ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLength);
+            }
         }
 
         private void ThrowInvalidArguments(int offset, int length)
         {
-            if (!HasValue)
-            {
-                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
+            throw GetInvalidArgumentsException(HasValue);
 
-            if (offset < 0)
+            Exception GetInvalidArgumentsException(bool hasValue)
             {
-                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
+                if (!hasValue)
+                {
+                    return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
+                }
 
-            if (length < 0)
-            {
-                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
-            }
+                if (offset < 0)
+                {
+                    return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
+                }
 
-            throw ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLengthStringSegment);
+                if (length < 0)
+                {
+                    return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
+                }
+
+                return ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLengthStringSegment);
+            }
         }
     }
 }

--- a/src/Primitives/src/StringSegment.cs
+++ b/src/Primitives/src/StringSegment.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="buffer">The original <see cref="string"/> used as buffer.</param>
         /// <param name="offset">The offset of the segment within the <paramref name="buffer"/>.</param>
         /// <param name="length">The length of the segment.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public StringSegment(string buffer, int offset, int length)
         {
             // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
@@ -346,7 +347,7 @@ namespace Microsoft.Extensions.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string Substring(int offset, int length)
         {
-            if (!HasValue || offset < 0 || offset + length > Length || length < 0)
+            if (!HasValue || offset < 0 || length < 0 || (uint)(offset + length) > (uint)Length)
             {
                 ThrowInvalidArguments(offset, length);
             }
@@ -372,7 +373,7 @@ namespace Microsoft.Extensions.Primitives
         /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of length <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
         public StringSegment Subsegment(int offset, int length)
         {
-            if (!HasValue || offset < 0 || offset + length > Length || length < 0)
+            if (!HasValue || offset < 0 || length < 0 || (uint)(offset + length) > (uint)Length)
             {
                 ThrowInvalidArguments(offset, length);
             }
@@ -393,7 +394,7 @@ namespace Microsoft.Extensions.Primitives
         {
             var offset = Offset + start;
 
-            if (!HasValue || start < 0 || offset > Buffer.Length)
+            if (!HasValue || start < 0 || (uint)offset > (uint)Buffer.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
@@ -638,12 +639,17 @@ namespace Microsoft.Extensions.Primitives
                 throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
             }
 
-            if (offset < 0 || offset + length > Length)
+            if (offset < 0)
             {
                 throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset);
             }
 
-            throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
+            if (length < 0)
+            {
+                throw ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+
+            throw ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLengthStringSegment);
         }
     }
 }

--- a/src/Primitives/src/ThrowHelper.cs
+++ b/src/Primitives/src/ThrowHelper.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Extensions.Primitives
     internal enum ExceptionResource
     {
         Argument_InvalidOffsetLength,
+        Argument_InvalidOffsetLengthStringSegment,
         Capacity_CannotChangeAfterWriteStarted,
         Capacity_NotEnough,
         Capacity_NotUsedEntirely

--- a/src/Primitives/test/StringSegmentTest.cs
+++ b/src/Primitives/test/StringSegmentTest.cs
@@ -92,8 +92,7 @@ namespace Microsoft.Extensions.Primitives
         public void StringSegmentConstructor_NegativeOffset_Throws()
         {
             // Arrange, Act and Assert
-            // offset + length = 0 for the test
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("lengthof9", -1, 1));
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("", -1, 0));
             Assert.Contains("offset", exception.Message);
         }
 
@@ -101,8 +100,7 @@ namespace Microsoft.Extensions.Primitives
         public void StringSegmentConstructor_NegativeLength_Throws()
         {
             // Arrange, Act and Assert
-            // offset + length = 0 for the test
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("lengthof9", 1, -1));
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("", 0, -1));
             Assert.Contains("length", exception.Message);
         }
 

--- a/src/Primitives/test/StringSegmentTest.cs
+++ b/src/Primitives/test/StringSegmentTest.cs
@@ -92,7 +92,8 @@ namespace Microsoft.Extensions.Primitives
         public void StringSegmentConstructor_NegativeOffset_Throws()
         {
             // Arrange, Act and Assert
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("", -1, 0));
+            // offset + length = 0 for the test
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("lengthof9", -1, 1));
             Assert.Contains("offset", exception.Message);
         }
 
@@ -100,7 +101,8 @@ namespace Microsoft.Extensions.Primitives
         public void StringSegmentConstructor_NegativeLength_Throws()
         {
             // Arrange, Act and Assert
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("", 0, -1));
+            // offset + length = 0 for the test
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new StringSegment("lengthof9", 1, -1));
             Assert.Contains("length", exception.Message);
         }
 
@@ -643,17 +645,8 @@ namespace Microsoft.Extensions.Primitives
             var segment = new StringSegment("Hello, World!", 1, 3);
 
             // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(-1, 1));
-        }
-
-        [Fact]
-        public void StringSegment_Substring_InvalidOffsetAndLength()
-        {
-            // Arrange
-            var segment = new StringSegment("Hello, World!", 1, 3);
-
-            // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(2, 3));
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(-1, 1));
+            Assert.Equal("offset", exception.ParamName);
         }
 
         [Fact]
@@ -663,7 +656,30 @@ namespace Microsoft.Extensions.Primitives
             var segment = new StringSegment("Hello, World!", 1, 3);
 
             // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(0, -1));
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(0, -1));
+            Assert.Equal("length", exception.ParamName);
+        }
+
+        [Fact]
+        public void StringSegment_Substring_InvalidOffsetAndLength()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => segment.Substring(2, 3));
+            Assert.Contains("bounds", exception.Message);
+        }
+
+        [Fact]
+        public void StringSegment_Substring_OffsetAndLengthOverflows()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => segment.Substring(1, int.MaxValue));
+            Assert.Contains("bounds", exception.Message);
         }
 
         [Fact]
@@ -711,7 +727,19 @@ namespace Microsoft.Extensions.Primitives
             var segment = new StringSegment("Hello, World!", 1, 3);
 
             // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => segment.Subsegment(-1, 1));
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => segment.Subsegment(-1, 1));
+            Assert.Equal("offset", exception.ParamName);
+        }
+
+        [Fact]
+        public void StringSegment_Subsegment_InvalidLength()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => segment.Subsegment(0, -1));
+            Assert.Equal("length", exception.ParamName);
         }
 
         [Fact]
@@ -721,7 +749,19 @@ namespace Microsoft.Extensions.Primitives
             var segment = new StringSegment("Hello, World!", 1, 3);
 
             // Act & Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() => segment.Subsegment(2, 3));
+            var exception = Assert.Throws<ArgumentException>(() => segment.Subsegment(2, 3));
+            Assert.Contains("bounds", exception.Message);
+        }
+
+        [Fact]
+        public void StringSegment_Subsegment_OffsetAndLengthOverflows()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => segment.Subsegment(1, int.MaxValue));
+            Assert.Contains("bounds", exception.Message);
         }
 
         public static TheoryData<StringSegment, StringSegmentComparer> CompareLesserData
@@ -861,6 +901,29 @@ namespace Microsoft.Extensions.Primitives
 
             // Assert
             Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void IndexOf_NegativeStart_OutOfRangeThrows()
+        {
+            // Arrange
+            const string buffer = "Hello, World!, Hello people!";
+            var segment = new StringSegment(buffer, 3, buffer.Length - 3);
+
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => segment.IndexOf('!', -1, 3));
+        }
+
+        [Fact]
+        public void IndexOf_StartOverflowsWithOffset_OutOfRangeThrows()
+        {
+            // Arrange
+            const string buffer = "Hello, World!, Hello people!";
+            var segment = new StringSegment(buffer, 3, buffer.Length - 3);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => segment.IndexOf('!', int.MaxValue, 3));
+            Assert.Equal("start", exception.ParamName);
         }
 
         [Fact]

--- a/src/Primitives/test/StringSegmentTest.cs
+++ b/src/Primitives/test/StringSegmentTest.cs
@@ -347,6 +347,23 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        public void StringSegment_EqualsObject_Valid()
+        {
+            var segment1 = new StringSegment("My Car Is Cool", 3, 3);
+            var segment2 = new StringSegment("Your Carport is blue", 5, 3);
+
+            Assert.True(segment1.Equals((object)segment2));
+        }
+
+        [Fact]
+        public void StringSegment_EqualsNull_Invalid()
+        {
+            var segment1 = new StringSegment("My Car Is Cool", 3, 3);
+
+            Assert.False(segment1.Equals(null as object));
+        }
+
+        [Fact]
         public void StringSegment_StaticEquals_Valid()
         {
             var segment1 = new StringSegment("My Car Is Cool", 3, 3);
@@ -637,6 +654,16 @@ namespace Microsoft.Extensions.Primitives
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(2, 3));
+        }
+
+        [Fact]
+        public void StringSegment_Substring_InvalidLength()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => segment.Substring(0, -1));
         }
 
         [Fact]


### PR DESCRIPTION
# Description

* JIT produces better code
* enabled inlining on more methods
* mostly micro-optimizations

# Benchmarks

## Overview

``` ini

BenchmarkDotNet=v0.10.11, OS=ubuntu 17.10
Processor=Intel Xeon CPU 2.60GHz, ProcessorCount=2
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
  Job-DNRIOU : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT

RemoveOutliers=False  Runtime=Core  Server=True  
Toolchain=.NET Core 2.0  LaunchCount=3  RunStrategy=Throughput  
TargetCount=10  WarmupCount=5  

```
|                Method |       Mean |     Error |    StdDev |            Op/s |  Gen 0 | Allocated |
|---------------------- |-----------:|----------:|----------:|----------------:|-------:|----------:|
|           Ctor_String |  6.1409 ns | 0.0188 ns | 0.0281 ns |   162,842,294.7 |      - |       0 B |
|              GetValue |  3.0951 ns | 0.0474 ns | 0.0709 ns |   323,092,110.5 |      - |       0 B |
|               Indexer |  0.2666 ns | 0.0134 ns | 0.0201 ns | 3,750,293,266.8 |      - |       0 B |
| Equals_Object_Invalid |  3.7666 ns | 0.3823 ns | 0.5722 ns |   265,489,382.6 |      - |       0 B |
|   Equals_Object_Valid | 11.6428 ns | 0.0364 ns | 0.0544 ns |    85,889,775.5 |      - |       0 B |
|          Equals_Valid |  5.6707 ns | 0.0348 ns | 0.0520 ns |   176,346,164.4 |      - |       0 B |
|         Equals_String |  5.7977 ns | 0.0231 ns | 0.0346 ns |   172,481,418.0 |      - |       0 B |
|           GetHashCode | 22.9720 ns | 0.1092 ns | 0.1634 ns |    43,531,342.3 |      - |       0 B |
|            StartsWith | 13.2762 ns | 0.0566 ns | 0.0847 ns |    75,322,957.9 |      - |       0 B |
|              EndsWith | 12.8829 ns | 0.0591 ns | 0.0885 ns |    77,622,457.0 |      - |       0 B |
|             SubString | 20.7859 ns | 0.1463 ns | 0.2190 ns |    48,109,488.1 | 0.0005 |      32 B |
|            SubSegment | 24.9102 ns | 0.0548 ns | 0.0820 ns |    40,144,255.7 |      - |       0 B |
|               IndexOf |  6.3147 ns | 0.0751 ns | 0.1124 ns |   158,359,446.9 |      - |       0 B |
|            IndexOfAny | 18.7092 ns | 0.1530 ns | 0.2290 ns |    53,449,551.3 |      - |       0 B |
|           LastIndexOf |  9.3210 ns | 0.0415 ns | 0.0622 ns |   107,285,050.6 |      - |       0 B |
|                  Trim | 78.5879 ns | 0.3100 ns | 0.4640 ns |    12,724,602.2 |      - |       0 B |
|             TrimStart | 43.0461 ns | 0.1081 ns | 0.1617 ns |    23,230,898.6 |      - |       0 B |
|               TrimEnd | 45.1374 ns | 0.1594 ns | 0.2385 ns |    22,154,559.9 |      - |       0 B |


## Details

[Code for benchmarks](https://github.com/gfoidl/Benchmarks/tree/e04edcb91c0bf2fea1a46c2afa8db9d321ca3773/aspnet/Common/StringSegment/StringSegment)

### Ctor (string)

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------- |---------:|----------:|----------:|-------:|---------:|
| Default | 2.013 ns | 0.0359 ns | 0.0318 ns |   1.00 |     0.00 |
|     New | 1.648 ns | 0.0280 ns | 0.0262 ns |   0.82 |     0.02 |

### Value

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------- |---------:|----------:|----------:|-------:|---------:|
| Default | 2.787 ns | 0.1408 ns | 0.1317 ns |   1.00 |     0.00 |
|     New | 2.560 ns | 0.0773 ns | 0.0685 ns |   0.92 |     0.05 |

### Equals (valid)

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 4.935 ns | 0.0395 ns | 0.0350 ns |   1.00 |
|     New | 4.884 ns | 0.0298 ns | 0.0264 ns |   0.99 |

### Equals (string)

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 7.097 ns | 0.0796 ns | 0.0744 ns |   1.00 |
|     New | 5.013 ns | 0.0540 ns | 0.0505 ns |   0.71 |

### GetHashCode

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD | Allocated |
|-------- |---------:|----------:|----------:|-------:|---------:|----------:|
| Default | 16.46 ns | 0.3662 ns | 0.3919 ns |   1.00 |     0.00 |       0 B |
|     New | 16.18 ns | 0.3075 ns | 0.2876 ns |   0.98 |     0.03 |       0 B |

### StartsWith

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 14.18 ns | 0.2111 ns | 0.1974 ns |   1.00 |
|     New | 12.31 ns | 0.0919 ns | 0.0860 ns |   0.87 |

### EndsWith

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 13.42 ns | 0.1648 ns | 0.1542 ns |   1.00 |
|     New | 11.56 ns | 0.1644 ns | 0.1538 ns |   0.86 |

### Substring

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------- |---------:|----------:|----------:|-------:|---------:|
| Default | 13.91 ns | 0.3772 ns | 0.7532 ns |   1.00 |     0.00 |
|     New | 11.53 ns | 0.3217 ns | 0.4716 ns |   0.83 |     0.06 |

### Subsegment

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------- |---------:|----------:|----------:|-------:|---------:|
| Default | 4.865 ns | 0.1125 ns | 0.1053 ns |   1.00 |     0.00 |
|     New | 4.642 ns | 0.0430 ns | 0.0381 ns |   0.95 |     0.02 |

### IndexOf

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------- |---------:|----------:|----------:|-------:|---------:|
| Default | 15.23 ns | 0.3410 ns | 0.4188 ns |   1.00 |     0.00 |
|     New | 13.14 ns | 0.2340 ns | 0.2074 ns |   0.86 |     0.03 |

### IndexOfAny

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 35.26 ns | 0.2703 ns | 0.2528 ns |   1.00 |
|     New | 34.36 ns | 0.2044 ns | 0.1812 ns |   0.97 |

### LastIndexOf

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 15.58 ns | 0.1433 ns | 0.1341 ns |   1.00 |
|     New | 14.98 ns | 0.1969 ns | 0.1842 ns |   0.96 |

### TrimStart

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled |
|-------- |---------:|----------:|----------:|-------:|
| Default | 80.59 ns | 0.7632 ns | 0.6373 ns |   1.00 |
|     New | 69.57 ns | 0.6849 ns | 0.6407 ns |   0.86 |

### TrimEnd

``` ini

BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=2742187 Hz, Resolution=364.6724 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT


```
|  Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |
|-------- |---------:|----------:|----------:|-------:|---------:|
| Default | 50.26 ns | 1.0791 ns | 1.0094 ns |   1.00 |     0.00 |
|     New | 43.75 ns | 0.5553 ns | 0.5195 ns |   0.87 |     0.02 |

# Discussion

## Span-based implementation

I tried a [Span-based version](https://github.com/gfoidl/Benchmarks/blob/disc/stringsegment-span/aspnet/Common/StringSegment/StringSegment/StringSegments/StringSegment2.cs) for `IndexOf`, but this doubled the time. So this approach was discontinued in this PR.