### PR TITLE
Update branding to 3.0.0-preview

### DIFF
--- a/version.props
+++ b/version.props
@@ -3,8 +3,10 @@
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseLabel>alpha1</PreReleaseLabel>
-    <PreReleaseBrandingLabel>Alpha 1</PreReleaseBrandingLabel>
+    <!-- This is used for versioning files and packages, e.g. "3.0.0-preview-181031-01". -->
+    <PreReleaseLabel>preview</PreReleaseLabel>
+    <!-- This is used for 'human friendly' branding, e.g. "3.0.0 Preview Build 181031-01". -->
+    <PreReleaseBrandingLabel>Preview</PreReleaseBrandingLabel>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>


### PR DESCRIPTION
We were using alpha1 as a placeholder. The latest guidance from PMs is to label pre-release packages as 3.0.0-preview-$(buildnumber).

cc @mmitche 