### PR TITLE
Tag non-final builds

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,7 +1,11 @@
-<Project>
+<Project InitialTargets="TagDailyBuild">
   <PropertyGroup>
     <BuildDependsOn Condition="'$(Configuration)' == 'Release' AND '$(OS)' == 'Windows_NT' AND $(PublishType.Contains('blob'))" >$(BuildDependsOn);PublishToProdCon</BuildDependsOn>
   </PropertyGroup>
+
+  <Target Name="TagDailyBuild" Condition=" '$(IsFinalBuild)' != 'true' AND '$(CI)' == 'true' ">
+    <Message Importance="high" Text="##vso[build.addbuildtag]daily-build" />
+  </Target>
 
   <Target Name="PublishToProdCon">
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\eng\ProdConPublish.csproj"


### PR DESCRIPTION
Testing if tags can be set on PRs.

This adds a tag to AzDO builds so we can modify the release pipeline based on whether 'IsFinalBuild' was true or not.