### PR TITLE
Eliminate use of method groups in PropertyHelper

### DIFF
--- a/src/Shared/src/PropertyHelper/PropertyHelper.cs
+++ b/src/Shared/src/PropertyHelper/PropertyHelper.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Extensions.Internal
             ConcurrentDictionary<Type, PropertyHelper[]> allPropertiesCache,
             ConcurrentDictionary<Type, PropertyHelper[]> visiblePropertiesCache)
         {
-            if (visiblePropertiesCache.TryGetValue(type, out PropertyHelper[] result))
+            if (visiblePropertiesCache.TryGetValue(type, out var result))
             {
                 return result;
             }
@@ -495,7 +495,7 @@ namespace Microsoft.Extensions.Internal
             // part of the sequence of properties returned by this method.
             type = Nullable.GetUnderlyingType(type) ?? type;
 
-            if (!cache.TryGetValue(type, out PropertyHelper[] helpers))
+            if (!cache.TryGetValue(type, out var helpers))
             {
                 // We avoid loading indexed properties using the Where statement.
                 var properties = type.GetRuntimeProperties().Where(p => IsInterestingProperty(p));

--- a/src/Shared/src/PropertyHelper/PropertyHelper.cs
+++ b/src/Shared/src/PropertyHelper/PropertyHelper.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Internal
 {
@@ -145,7 +144,7 @@ namespace Microsoft.Extensions.Internal
         /// </returns>
         public static PropertyHelper[] GetProperties(Type type)
         {
-            return GetProperties(type, CreateInstance, PropertiesCache);
+            return GetProperties(type, (p) => CreateInstance(p), PropertiesCache);
         }
 
         /// <summary>
@@ -164,7 +163,7 @@ namespace Microsoft.Extensions.Internal
         /// </returns>
         public static PropertyHelper[] GetVisibleProperties(TypeInfo typeInfo)
         {
-            return GetVisibleProperties(typeInfo.AsType(), CreateInstance, PropertiesCache, VisiblePropertiesCache);
+            return GetVisibleProperties(typeInfo.AsType(), (p) => CreateInstance(p), PropertiesCache, VisiblePropertiesCache);
         }
 
         /// <summary>
@@ -183,7 +182,7 @@ namespace Microsoft.Extensions.Internal
         /// </returns>
         public static PropertyHelper[] GetVisibleProperties(Type type)
         {
-            return GetVisibleProperties(type, CreateInstance, PropertiesCache, VisiblePropertiesCache);
+            return GetVisibleProperties(type, (p) => CreateInstance(p), PropertiesCache, VisiblePropertiesCache);
         }
 
         /// <summary>
@@ -348,8 +347,10 @@ namespace Microsoft.Extensions.Internal
 
             if (value != null)
             {
-                foreach (var helper in GetProperties(value.GetType()))
+                var properties = GetProperties(value.GetType());
+                for (var i = 0; i < properties.Length; i++)
                 {
+                    var helper = properties[i];
                     dictionary[helper.Name] = helper.GetValue(value);
                 }
             }
@@ -420,8 +421,7 @@ namespace Microsoft.Extensions.Internal
             ConcurrentDictionary<Type, PropertyHelper[]> allPropertiesCache,
             ConcurrentDictionary<Type, PropertyHelper[]> visiblePropertiesCache)
         {
-            PropertyHelper[] result;
-            if (visiblePropertiesCache.TryGetValue(type, out result))
+            if (visiblePropertiesCache.TryGetValue(type, out PropertyHelper[] result))
             {
                 return result;
             }
@@ -429,9 +429,9 @@ namespace Microsoft.Extensions.Internal
             // The simple and common case, this is normal POCO object - no need to allocate.
             var allPropertiesDefinedOnType = true;
             var allProperties = GetProperties(type, createPropertyHelper, allPropertiesCache);
-            foreach (var propertyHelper in allProperties)
+            for (var i = 0; i < allProperties.Length; i++)
             {
-                if (propertyHelper.Property.DeclaringType != type)
+                if (allProperties[i].Property.DeclaringType != type)
                 {
                     allPropertiesDefinedOnType = false;
                     break;
@@ -497,18 +497,17 @@ namespace Microsoft.Extensions.Internal
             // part of the sequence of properties returned by this method.
             type = Nullable.GetUnderlyingType(type) ?? type;
 
-            PropertyHelper[] helpers;
-            if (!cache.TryGetValue(type, out helpers))
+            if (!cache.TryGetValue(type, out PropertyHelper[] helpers))
             {
                 // We avoid loading indexed properties using the Where statement.
-                var properties = type.GetRuntimeProperties().Where(IsInterestingProperty);
+                var properties = type.GetRuntimeProperties().Where(p => IsInterestingProperty(p));
 
                 var typeInfo = type.GetTypeInfo();
                 if (typeInfo.IsInterface)
                 {
                     // Reflection does not return information about inherited properties on the interface itself.
                     properties = properties.Concat(typeInfo.ImplementedInterfaces.SelectMany(
-                        interfaceType => interfaceType.GetRuntimeProperties().Where(IsInterestingProperty)));
+                        interfaceType => interfaceType.GetRuntimeProperties().Where(p => IsInterestingProperty(p))));
                 }
 
                 helpers = properties.Select(p => createPropertyHelper(p)).ToArray();
@@ -518,17 +517,17 @@ namespace Microsoft.Extensions.Internal
             return helpers;
         }
 
-        
+
         private static bool IsInterestingProperty(PropertyInfo property)
         {
             // For improving application startup time, do not use GetIndexParameters() api early in this check as it
             // creates a copy of parameter array and also we would like to check for the presence of a get method
             // and short circuit asap.
-            return 
+            return
                 property.GetMethod != null &&
                 property.GetMethod.IsPublic &&
                 !property.GetMethod.IsStatic &&
-                
+
                 // PropertyHelper can't work with ref structs.
                 !IsRefStructProperty(property) &&
 

--- a/src/Shared/src/PropertyHelper/PropertyHelper.cs
+++ b/src/Shared/src/PropertyHelper/PropertyHelper.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.Internal
         /// </returns>
         public static PropertyHelper[] GetProperties(Type type)
         {
-            return GetProperties(type, (p) => CreateInstance(p), PropertiesCache);
+            return GetProperties(type, p => CreateInstance(p), PropertiesCache);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.Internal
         /// </returns>
         public static PropertyHelper[] GetVisibleProperties(TypeInfo typeInfo)
         {
-            return GetVisibleProperties(typeInfo.AsType(), (p) => CreateInstance(p), PropertiesCache, VisiblePropertiesCache);
+            return GetVisibleProperties(typeInfo.AsType(), p => CreateInstance(p), PropertiesCache, VisiblePropertiesCache);
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Microsoft.Extensions.Internal
         /// </returns>
         public static PropertyHelper[] GetVisibleProperties(Type type)
         {
-            return GetVisibleProperties(type, (p) => CreateInstance(p), PropertiesCache, VisiblePropertiesCache);
+            return GetVisibleProperties(type, p => CreateInstance(p), PropertiesCache, VisiblePropertiesCache);
         }
 
         /// <summary>
@@ -347,10 +347,8 @@ namespace Microsoft.Extensions.Internal
 
             if (value != null)
             {
-                var properties = GetProperties(value.GetType());
-                for (var i = 0; i < properties.Length; i++)
+                foreach (var helper in GetProperties(value.GetType()))
                 {
-                    var helper = properties[i];
                     dictionary[helper.Name] = helper.GetValue(value);
                 }
             }

--- a/src/Shared/src/PropertyHelper/PropertyHelper.cs
+++ b/src/Shared/src/PropertyHelper/PropertyHelper.cs
@@ -427,9 +427,9 @@ namespace Microsoft.Extensions.Internal
             // The simple and common case, this is normal POCO object - no need to allocate.
             var allPropertiesDefinedOnType = true;
             var allProperties = GetProperties(type, createPropertyHelper, allPropertiesCache);
-            for (var i = 0; i < allProperties.Length; i++)
+            foreach (var propertyHelper in allProperties)
             {
-                if (allProperties[i].Property.DeclaringType != type)
+                if (propertyHelper.Property.DeclaringType != type)
                 {
                     allPropertiesDefinedOnType = false;
                     break;
@@ -514,7 +514,6 @@ namespace Microsoft.Extensions.Internal
 
             return helpers;
         }
-
 
         private static bool IsInterestingProperty(PropertyInfo property)
         {


### PR DESCRIPTION
Eliminates use of method groups.
Improves performance and reduces allocations.

**Before:**

|             Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------- |----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|      GetProperties |  36.32 ns | 0.5481 ns | 0.5127 ns |      0.0209 |           - |           - |                88 B |
| ObjectToDictionary | 612.34 ns | 2.0398 ns | 1.8082 ns |      0.1459 |           - |           - |               616 B |

**After:**

|             Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------- |----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|      GetProperties |  30.36 ns | 0.0877 ns | 0.0820 ns |      0.0057 |           - |           - |                24 B |
| ObjectToDictionary | 605.01 ns | 1.7149 ns | 1.6041 ns |      0.1307 |           - |           - |               552 B |

Benchmark is available [here](https://gist.github.com/drieseng/89ec31cd5a8911ec576852f19cc38803).