### PR TITLE
Prepare the repo for the 2.1.7 patch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,6 @@
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
   </PropertyGroup>
 
-  <Import Project="eng\Baseline.props" />
   <Import Project="eng\Dependencies.props" />
   <Import Project="eng\PatchConfig.props" />
   <Import Project="eng\ProjectReferences.props" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,6 +9,39 @@
     <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
+  <!-- Properties which should be set after the project has been evaluated -->
+  <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">
+    <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
+    <IsPackable Condition="'$(IsPackable)' == '' AND ( '$(IsTestProject)' == 'true' OR '$(IsTestAssetProject)' == 'true' OR '$(IsBenchmarkProject)' == 'true' OR '$(IsSampleProject)' == 'true' ) ">false</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="eng\Baseline.props" />
+
+  <PropertyGroup Condition=" '$(IsPackable)' != 'false' AND '$(IsServicingBuild)' == 'true' ">
+    <IsPackable>$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsPackable)' != 'true' AND '$(BaselinePackageVersion)' != '' ">
+    <!-- This keeps assembly versions consistent across patches. If a package is not included in a patch, its assembly version should stay at the baseline. -->
+    <AssemblyVersion>$(BaselinePackageVersion).0</AssemblyVersion>
+    <!--
+      Ideally, we would also set the project version to match the baseline in case NuGet turns a ProjectReference into a nuspec depenendency, but
+      NuGet does not currently handle conflicts between packages and projects which have the same package id/version.
+
+      See https://github.com/NuGet/Home/issues/6795
+    -->
+    <!-- <Version>$(BaselinePackageVersion)</Version> -->
+    <!-- <PackageVersion>$(BaselinePackageVersion)</PackageVersion> -->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Implementation projects are the projects which produce nuget packages or shipping assemblies. -->
+    <IsImplementationProject Condition=" '$(IsImplementationProject)' == '' AND '$(IsTestAssetProject)' != 'true' AND '$(IsTestProject)' != 'true' AND '$(IsBenchmarkProject)' != 'true' AND '$(IsSampleProject)' != 'true' ">true</IsImplementationProject>
+
+    <!-- Suppress KoreBuild warnings about the mismatch of repo version and local project version. The versioning in this mega repo is sufficiently complicated that KoreBuild's validation isn't helpful. -->
+    <VerifyVersion>false</VerifyVersion>
+  </PropertyGroup>
+
   <Import Project="eng\targets\Packaging.targets" Condition=" '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="eng\targets\ResolveReferences.targets" Condition=" '$(DisableReferenceRestrictions)' != 'true' AND '$(MSBuildProjectExtension)' == '.csproj' " />
 </Project>

--- a/docs/preparing-patch-updates.md
+++ b/docs/preparing-patch-updates.md
@@ -1,0 +1,16 @@
+Preparing new servicing updates
+===============================
+
+In order to prepare this repo to build a new servicing update, the following changes need to be made.
+
+* Increment the patch version in the [version.props](/version.props) file in the repository root.
+
+    ```diff
+    -  <PatchVersion>7</PatchVersion>
+    +  <PatchVersion>8</PatchVersion>
+    ```
+
+* Update the package baselines. This is used to ensure packages keep a consistent set of dependencies between releases.
+  See [eng/tools/BaselineGenerator/](/eng/tools/BaselineGenerator/README.md) for instructions on how to run this tool.
+
+* Update the list of packages in [eng/PatchConfig.props](/eng/PatchConfig.props) to list which packages should be patching in this release.

--- a/eng/Baseline.props
+++ b/eng/Baseline.props
@@ -1,5 +1,9 @@
 ﻿<!-- Auto generated. Do not edit manually, use eng/tools/BaselineGenerator/ to recreate. -->
 <Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <ExtensionsBaselineVersion>2.1.6</ExtensionsBaselineVersion>
+  </PropertyGroup>
   <!-- Package: Microsoft.Extensions.Caching.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Caching.Abstractions' ">
     <BaselinePackageVersion>2.1.2</BaselinePackageVersion>
@@ -308,7 +312,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.ObjectPool-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ObjectPool' ">
-    <BaselinePackageVersion>2.1.1</BaselinePackageVersion>
+    <BaselinePackageVersion>2.1.6</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.ObjectPool' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.Extensions.Options.ConfigurationExtensions-->
@@ -331,10 +335,10 @@
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Primitives-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Primitives' ">
-    <BaselinePackageVersion>2.1.1</BaselinePackageVersion>
+    <BaselinePackageVersion>2.1.6</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Primitives' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="System.Memory" Version="[4.5.1, )" />
-    <BaselinePackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="[4.5.1, )" />
+    <BaselinePackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="[4.5.2, )" />
   </ItemGroup>
 </Project>

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -6,9 +6,9 @@
   <!-- These package versions may be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Auto">
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15839</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15844</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreAppPackageVersion>2.1.6-servicing-27017-02</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.1.6</MicrosoftNETCoreAppPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <SystemDataSqlClientPackageVersion>4.5.1</SystemDataSqlClientPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0</SystemDiagnosticsDiagnosticSourcePackageVersion>

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -1,5 +1,10 @@
 <Project>
 
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.7' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.6' ">
     <PackagesInPatch>
       Microsoft.Extensions.ObjectPool;

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -1,46 +1,10 @@
 <Project>
 
-  <PropertyGroup>
-    <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
-    <IsPackable Condition="'$(IsPackable)' == '' AND ( '$(IsTestAssetProject)' == 'true' OR '$(IsBenchmarkProject)' == 'true' OR '$(IsSampleProject)' == 'true' ) ">false</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(IsPackable)' != 'false' AND '$(IsServicingBuild)' == 'true' ">
-    <IsPackable>$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(IsPackable)' == 'false' AND '$(BaselinePackageVersion)' != '' ">
-    <!-- This keeps assembly and package versions consistent across patches. If a package is not included in a patch, its version should stay at the baseline. -->
-    <Version>$(BaselinePackageVersion).0</Version>
-    <AssemblyVersion>$(BaselinePackageVersion).0</AssemblyVersion>
-    <PackageVersion>$(BaselinePackageVersion)</PackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Implementation projects are the projects which produce nuget packages ans shipping assemblies. These need to carefully control for versions to ensure our patching rules are followed. -->
-    <IsImplementationProject Condition=" '$(IsImplementationProject)' == '' AND '$(IsTestAssetProject)' != 'true' AND '$(IsTestProject)' != 'true' AND '$(IsBenchmarkProject)' != 'true' AND '$(IsSampleProject)' != 'true' ">true</IsImplementationProject>
-
-    <!--
-      Projects should only use the latest package references when:
-        * preparing a new major or minor release (i.e. a non-servicing builds)
-        * when a project is a test or sample project
-        * when a package is releasing a new patch (we like to update external dependencies in patches when possible)
-    -->
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsServicingBuild)' != 'true'  ">true</UseLatestPackageReferences>
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseLatestPackageReferences>
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' == 'true' AND ( '$(IsServicingBuild)' != 'true' OR '$(IsPackable)' == 'true' ) ">true</UseLatestPackageReferences>
-    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' ">false</UseLatestPackageReferences>
-
-    <!--
-      Projects should only use the project references instead of baseline package references when:
-        * preparing a new major or minor release (i.e. a non-servicing builds)
-        * when a project is a test or sample project
-
-      We don't use project references between components in servicing builds between compontents to preserve the baseline as much as possible.
-    -->
-    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsServicingBuild)' != 'true'  ">true</UseProjectReferences>
-    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseProjectReferences>
-    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">false</UseProjectReferences>
-  </PropertyGroup>
+  <Target Name="EnsureBaselineIsUpdated"
+          Condition="'$(IsServicingBuild)' == 'true' AND '$(ExtensionsBaselineVersion)' != '$(PreviousExtensionsReleaseVersion)'"
+          BeforeTargets="BeforeBuild">
+    <Error Text="The package baseline ($(ExtensionsBaselineVersion)) is out of date with the latest release of this repo ($(PreviousExtensionsReleaseVersion)).
+                 See $(RepositoryRoot)eng\tools\BaselineGenerator\README.md for instructions on updating this baseline." />
+  </Target>
 
 </Project>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -48,6 +48,11 @@
     <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
   </ItemGroup>
 
+  <!-- Ensure package output paths are available. -->
+  <Target Name="CreatePackageOutputPath" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="$(PackageOutputPath)" />
+  </Target>
+
   <Target Name="ResolveCustomReferences" BeforeTargets="CollectPackageReferences;ResolveAssemblyReferencesDesignTime;ResolveAssemblyReferences" Condition=" '$(TargetFramework)' != '' ">
     <ItemGroup>
       <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(_ProjectReferenceByAssemblyName)" />

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -7,6 +7,30 @@
     </ResolveReferencesDependsOn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Projects should only use the latest package references when:
+        * preparing a new major or minor release (i.e. a non-servicing builds)
+        * when a project is a test or sample project
+        * when a package is releasing a new patch (we like to update external dependencies in patches when possible)
+    -->
+    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsServicingBuild)' != 'true'  ">true</UseLatestPackageReferences>
+    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseLatestPackageReferences>
+    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' AND '$(IsImplementationProject)' == 'true' AND ( '$(IsServicingBuild)' != 'true' OR '$(IsPackable)' == 'true' ) ">true</UseLatestPackageReferences>
+    <UseLatestPackageReferences Condition=" '$(UseLatestPackageReferences)' == '' ">false</UseLatestPackageReferences>
+
+    <!--
+      Projects should only use the project references instead of baseline package references when:
+        * preparing a new major or minor release (i.e. a non-servicing builds)
+        * when a project is a test or sample project
+
+      We don't use project references between components in servicing builds between compontents to preserve the baseline as much as possible.
+    -->
+    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsServicingBuild)' != 'true'  ">true</UseProjectReferences>
+    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' AND '$(IsImplementationProject)' != 'true' ">true</UseProjectReferences>
+    <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">false</UseProjectReferences>
+  </PropertyGroup>
+
   <ItemGroup>
     <_ImplicitPackageReference Include="@(PackageReference->WithMetadataValue('IsImplicitlyDefined', 'true'))" />
     <_ExplicitPackageReference Include="@(PackageReference)" Exclude="@(_ImplicitPackageReference)" />
@@ -32,34 +56,39 @@
         MSBuild does not provide a way to join on matching identities in a Condition,
         but you can do a cartesian product of two item groups and filter out mismatched id's in a second pass.
       -->
-      <_PackageReferenceWithVersion Include="@(Reference)" Condition=" '$(UseLatestPackageReferences)' == 'true' ">
+      <_LatestPackageReferenceWithVersion Include="@(Reference)" Condition=" '$(UseLatestPackageReferences)' == 'true' ">
         <Id>%(LatestPackageReference.Identity)</Id>
         <Version>%(LatestPackageReference.Version)</Version>
-      </_PackageReferenceWithVersion>
-      <_PackageReferenceWithVersion Remove="@(_PackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
+      </_LatestPackageReferenceWithVersion>
+      <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
 
-      <!-- Remove reference items that have been resolved to a PackageReference. -->
-      <Reference Remove="@(_PackageReferenceWithVersion)" />
+      <!-- Remove reference items that have been resolved to a LatestPackageReference item. -->
+      <Reference Remove="@(_LatestPackageReferenceWithVersion)" />
+      <PackageReference Include="@(_LatestPackageReferenceWithVersion)" IsImplicitlyDefined="true" />
 
-      <_PackageReferenceWithVersion Include="@(Reference)" Condition=" '$(IsServicingBuild)' == 'true' OR '$(UseLatestPackageReferences)' != 'true' ">
+      <_BaselinePackageReferenceWithVersion Include="@(Reference)" Condition=" '$(IsServicingBuild)' == 'true' OR '$(UseLatestPackageReferences)' != 'true' ">
         <Id>%(BaselinePackageReference.Identity)</Id>
         <Version>%(BaselinePackageReference.Version)</Version>
-      </_PackageReferenceWithVersion>
+      </_BaselinePackageReferenceWithVersion>
 
-      <_PackageReferenceWithVersion Remove="@(_PackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
+      <_BaselinePackageReferenceWithVersion Remove="@(_BaselinePackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
 
-      <PackageReference Include="@(_PackageReferenceWithVersion)" IsImplicitlyDefined="true" />
-
-      <Reference Remove="@(_PackageReferenceWithVersion)" />
+      <!-- Remove reference items that have been resolved to a BaselinePackageReference item. -->
+      <PackageReference Include="@(_BaselinePackageReferenceWithVersion)" IsImplicitlyDefined="true" />
+      <Reference Remove="@(_BaselinePackageReferenceWithVersion)" />
 
       <!-- Free up memory for unnecessary items -->
-      <_PackageReferenceWithVersion Remove="@(_PackageReferenceWithVersion)" />
-      <_ExplicitPackageReference Remove="@(_ExplicitPackageReference)" />
+      <_BaselinePackageReferenceWithVersion Remove="@(_BaselinePackageReferenceWithVersion)" />
+      <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" />
       <_ImplicitPackageReference Remove="@(_ImplicitPackageReference)" />
     </ItemGroup>
 
     <Error Condition="@(_ExplicitPackageReference->Count()) != 0"
            Text="PackageReference items are not allowed. Use &lt;Reference&gt; instead. " />
+
+    <ItemGroup>
+      <_ExplicitPackageReference Remove="@(_ExplicitPackageReference)" />
+    </ItemGroup>
 
     <Warning Condition="@(UnusedBaselinePackageReference->Count()) != 0"
              Text="Package references changed since the last release. This could be a breaking change. References removed:%0A - @(UnusedBaselinePackageReference, '%0A -')" />

--- a/eng/tools/BaselineGenerator/Program.cs
+++ b/eng/tools/BaselineGenerator/Program.cs
@@ -54,9 +54,14 @@ namespace PackageBaselineGenerator
                 ? _output.Value()
                 : Path.Combine(Directory.GetCurrentDirectory(), "Baseline.props");
 
+            var baselineVersion = input.Root.Attribute("Version").Value;
+
             var doc = new XDocument(
                 new XComment(" Auto generated. Do not edit manually, use eng/tools/BaselineGenerator/ to recreate. "),
-                new XElement("Project"));
+                new XElement("Project",
+                    new XElement("PropertyGroup",
+                        new XElement("MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)"),
+                        new XElement("ExtensionsBaselineVersion", baselineVersion))));
 
             var client = new HttpClient();
 

--- a/eng/tools/BaselineGenerator/README.md
+++ b/eng/tools/BaselineGenerator/README.md
@@ -5,5 +5,6 @@ This tool is used to generate an MSBuild file which sets the "baseline" against 
 
 ## Usage
 
-1. Add to the [baseline.xml](./baseline.xml) a list of package ID's and their latest released versions.
+1. Add to the [baseline.xml](./baseline.xml) a list of package ID's and their latest released versions. The source of this information can typically
+  be found in the build.xml file generated during ProdCon builds. See https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1.6/build.xml for example.
 2. Run `dotnet run` on this project.

--- a/eng/tools/BaselineGenerator/baseline.xml
+++ b/eng/tools/BaselineGenerator/baseline.xml
@@ -1,4 +1,4 @@
-<Baseline>
+<Baseline Version="2.1.6">
   <Package Id="Microsoft.Extensions.Caching.Abstractions" Version="2.1.2" />
   <Package Id="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
   <Package Id="Microsoft.Extensions.Caching.Redis" Version="2.1.2" />
@@ -34,8 +34,8 @@
   <Package Id="Microsoft.Extensions.Logging.Testing" Version="2.1.1" />
   <Package Id="Microsoft.Extensions.Logging.TraceSource" Version="2.1.1" />
   <Package Id="Microsoft.Extensions.Logging" Version="2.1.1" />
-  <Package Id="Microsoft.Extensions.ObjectPool" Version="2.1.1" />
+  <Package Id="Microsoft.Extensions.ObjectPool" Version="2.1.6" />
   <Package Id="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   <Package Id="Microsoft.Extensions.Options" Version="2.1.1" />
-  <Package Id="Microsoft.Extensions.Primitives" Version="2.1.1" />
+  <Package Id="Microsoft.Extensions.Primitives" Version="2.1.6" />
 </Baseline>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.3-rtm-15839
-commithash:ee0ad5bd4ede948c6954704b621acc0c83445e5d
+version:2.1.3-rtm-15844
+commithash:8d031079e81ea30446712d48f7e8e9539fb92907

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>6</PatchVersion>
+    <PatchVersion>7</PatchVersion>
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PreReleaseBrandingLabel></PreReleaseBrandingLabel>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
@@ -36,6 +36,9 @@
     <ExperimentalVersionSuffix>$(VersionSuffix)</ExperimentalVersionSuffix>
 
     <InformationalVersion>$(VersionPrefix)-$(VersionSuffix)</InformationalVersion>
+
+    <!-- This is used for error checking to ensure generated code and baselines are up to date when we increment the patch. -->
+    <PreviousExtensionsReleaseVersion Condition=" '$(PatchVersion)' != '0' ">$(MajorVersion).$(MinorVersion).$([MSBuild]::Subtract($(PatchVersion), 1))</PreviousExtensionsReleaseVersion>
   </PropertyGroup>
 
   <!-- Run 'dotnet msbuild version.props' to test changes to this file. -->


### PR DESCRIPTION
Changes:
* Update targets to correctly import Baseline.props after setting PackageId
* Add error checking to ensure the baseline is up to date
* Bump version to 2.1.7
* Update BuildTools to include signcheck
* Update tests to use the 2.1.6 runtime