### PR TITLE
Use shortdate in package versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,13 +8,14 @@ trigger:
     include:
     - 'master'
     - 'release/*'
+    - 'internal/release/*'
 # Run PR validation on all branches
 pr:
   branches:
     include:
     - '*'
 
-name: $(Date:yyMMdd)-$(Rev:rr)
+name: $(Date:yyyyMMdd).$(Rev:rr)
 
 jobs:
 - template: eng/templates/default-build.yml

--- a/version.props
+++ b/version.props
@@ -5,11 +5,33 @@
     <PatchVersion>7</PatchVersion>
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PreReleaseBrandingLabel></PreReleaseBrandingLabel>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
+    <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OfficialBuildId)' != '' ">
+    <!-- This implements core versioning. Spec: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md -->
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+
+    <!-- _BuildNumber from CI is assumed to have format "yyyyMMdd.r". -->
+    <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+    <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+    <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+    <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+    <!-- yy * 1000 + mm * 50 + dd -->
+    <_BuildNumberShortDate>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_BuildNumberYY), 1000)), $([MSBuild]::Multiply($(_BuildNumberMM), 50)))), $(_BuildNumberDD)))</_BuildNumberShortDate>
+
+    <VersionSuffixBuildOfTheDay>$([System.Convert]::ToInt32($(_BuildNumberR)))</VersionSuffixBuildOfTheDay>
+    <VersionSuffixBuildOfTheDayPadded>$(VersionSuffixBuildOfTheDay.PadLeft($([System.Convert]::ToInt32(2)), '0'))</VersionSuffixBuildOfTheDayPadded>
+
+    <_BuildNumberSuffix>$(_BuildNumberShortDate)-$(VersionSuffixBuildOfTheDayPadded)</_BuildNumberSuffix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_BuildNumberSuffix Condition=" '$(_BuildNumberSuffix)' == '' ">t000</_BuildNumberSuffix>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix>$(PreReleaseLabel)-$(BuildNumber)</VersionSuffix>
-    <BrandingVersionSuffix>$(PreReleaseBrandingLabel) Build $(BuildNumber)</BrandingVersionSuffix>
+    <VersionSuffix>$(PreReleaseLabel)-$(_BuildNumberSuffix)</VersionSuffix>
+    <BrandingVersionSuffix>$(PreReleaseBrandingLabel) Build $(_BuildNumberSuffix)</BrandingVersionSuffix>
 
     <ExperimentalVersionPrefix>0.1.$(PatchVersion)</ExperimentalVersionPrefix>
 


### PR DESCRIPTION
See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md for details on the versioning spec.

This shortens the package ID for pre-release builds to the "SHORTDATE".

For example, today's build would be `2.1.7-servicing-18565-01`