### PR TITLE
Don't fail ProdCon publishing for servicing builds that produce no packages

### DIFF
--- a/eng/ProdConPublish.csproj
+++ b/eng/ProdConPublish.csproj
@@ -11,10 +11,13 @@
     <!-- Detect branch and commit from the build environment -->
     <RepositoryBranch Condition=" '$(RepositoryBranch)' == '' ">$(BUILD_SOURCEBRANCH)</RepositoryBranch>
     <RepositoryCommit Condition=" '$(RepositoryCommit)' == '' ">$(BUILD_SOURCEVERSION)</RepositoryCommit>
+    
+    <!-- Servicing builds might not produce packages -->
+    <PushToBlobFeed_AllowEmptyItems>$(IsServicingBuild)</PushToBlobFeed_AllowEmptyItems>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-preview1-03124-01" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="3.0.0-preview1-03415-01" />
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkPackageVersion)" />
   </ItemGroup>
 

--- a/eng/ProdConPublish.csproj
+++ b/eng/ProdConPublish.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="3.0.0-preview1-03415-01" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-preview1-03415-02" />
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This repo is not currently building packages in 2.1.7. We'd like to keep it building in ProdCon because it gives us test coverage. This fixes the prodcon publish error when there are no packages to publish.

cref https://github.com/dotnet/buildtools/pull/2202

cc @mmitche 