### PR TITLE
Refactor out GetChildrenImplementation into extension method on IConf…

### DIFF
--- a/src/Configuration/Config/src/ConfigurationRoot.cs
+++ b/src/Configuration/Config/src/ConfigurationRoot.cs
@@ -81,16 +81,7 @@ namespace Microsoft.Extensions.Configuration
         /// Gets the immediate children sub-sections.
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<IConfigurationSection> GetChildren() => GetChildrenImplementation(null);
-
-        internal IEnumerable<IConfigurationSection> GetChildrenImplementation(string path)
-        {
-            return _providers
-                .Aggregate(Enumerable.Empty<string>(),
-                    (seed, source) => source.GetChildKeys(seed, path))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Select(key => GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
-        }
+        public IEnumerable<IConfigurationSection> GetChildren() => this.GetChildrenImplementation(null);
 
         /// <summary>
         /// Returns a <see cref="IChangeToken"/> that can be used to observe when this configuration is reloaded.

--- a/src/Configuration/Config/src/ConfigurationRootExtension.cs
+++ b/src/Configuration/Config/src/ConfigurationRootExtension.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Extensions method for <see cref="IConfigurationRoot"/>
+    /// </summary>
+    internal static class ConfigurationRootExtension
+    {
+        /// <summary>
+        /// Gets the immediate children sub-sections of configuration root based on key.
+        /// </summary>
+        /// <param name="root">Configuration from which to retrieve sub-sections.</param>
+        /// <param name="path">Key of a section of which children to retrieve.</param>
+        /// <returns>Immediate children sub-sections of section specified by key.</returns>
+        internal static IEnumerable<IConfigurationSection> GetChildrenImplementation(this IConfigurationRoot root, string path)
+        {
+            return root.Providers
+                .Aggregate(Enumerable.Empty<string>(),
+                    (seed, source) => source.GetChildKeys(seed, path))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(key => root.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
+        }
+    }
+}

--- a/src/Configuration/Config/src/ConfigurationSection.cs
+++ b/src/Configuration/Config/src/ConfigurationSection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public class ConfigurationSection : IConfigurationSection
     {
-        private readonly ConfigurationRoot _root;
+        private readonly IConfigurationRoot _root;
         private readonly string _path;
         private string _key;
 
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Configuration
         /// </summary>
         /// <param name="root">The configuration root.</param>
         /// <param name="path">The path to this section.</param>
-        public ConfigurationSection(ConfigurationRoot root, string path)
+        public ConfigurationSection(IConfigurationRoot root, string path)
         {
             if (root == null)
             {


### PR DESCRIPTION
Moving my PR from previous repo ( https://github.com/aspnet/Configuration/pull/899 )

When creating a decorator around `IConfigurationRoot`, I found out that I'm unable to use `ConfigurationSection` as it requires specific implementation of `ConfigurationRoot` instead of abstraction `IConfigurationRoot`.
To make this change possible, it was necessary to change internal method `ConfigurationRoot.GetChildrenImplementation` into static method on `IConfigurationRoot` instead of instance method. I also went ahead and turned it into extension method.

This change doesn't require any new tests, as it is refactoring of internal structure.

I will leave it to maintainers to decide if this is breaking change or not.
I don't see this a breaking change, as it goes from specific class to it's interface. But there might be some weirdness, that I might not know off.