### PR TITLE
Add event for expression tree generation and chunk call sites

### DIFF
--- a/src/DependencyInjection/DI/src/DependencyInjectionEventSource.cs
+++ b/src/DependencyInjection/DI/src/DependencyInjectionEventSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
@@ -13,7 +14,9 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static readonly DependencyInjectionEventSource Log = new DependencyInjectionEventSource();
 
-        private DependencyInjectionEventSource()
+        private int MaxChunkSize = 10 * 1024;
+
+        private DependencyInjectionEventSource():base(EventSourceSettings.EtwSelfDescribingEventFormat)
         {
         }
 
@@ -26,15 +29,21 @@ namespace Microsoft.Extensions.DependencyInjection
         // - Avoid renaming methods or parameters marked with EventAttribute. EventSource uses these to form the event object.
 
         [Event(1, Level = EventLevel.Verbose)]
-        private void CallSiteBuilt(string serviceType, string callSite)
+        private void CallSiteBuilt(string serviceType, string callSite, int chunkIndex, int chunkCount)
         {
-            WriteEvent(1, serviceType, callSite);
+            WriteEvent(1, serviceType, callSite, chunkIndex, chunkCount);
         }
 
         [Event(2, Level = EventLevel.Verbose)]
         public void ServiceResolved(string serviceType)
         {
             WriteEvent(2, serviceType);
+        }
+
+        [Event(3, Level = EventLevel.Verbose)]
+        public void ExpressionTreeGenerated(string serviceType, int nodeCount)
+        {
+            WriteEvent(3, serviceType, nodeCount);
         }
 
         [NonEvent]
@@ -51,7 +60,38 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
             {
-                CallSiteBuilt(serviceType.ToString(), CallSiteJsonFormatter.Instance.Format(callSite));
+                var format = CallSiteJsonFormatter.Instance.Format(callSite);
+                var chunkCount = format.Length / MaxChunkSize + (format.Length % MaxChunkSize > 0 ? 1 : 0);
+
+                for (int i = 0; i < chunkCount; i++)
+                {
+                    CallSiteBuilt(
+                        serviceType.ToString(),
+                        format.Substring(i * MaxChunkSize, Math.Min(MaxChunkSize, format.Length - i * MaxChunkSize)), i, chunkCount);
+                }
+            }
+        }
+
+        [NonEvent]
+        public void ExpressionTreeGenerated(Type serviceType, Expression expression)
+        {
+            if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
+            {
+                var visitor = new NodeCountingVisitor();
+                visitor.Visit(expression);
+                ExpressionTreeGenerated(serviceType.ToString(), visitor.NodeCount);
+            }
+        }
+
+        private class NodeCountingVisitor : ExpressionVisitor
+        {
+            public int NodeCount { get; private set; }
+
+            public override Expression Visit(Expression e)
+            {
+                base.Visit(e);
+                NodeCount++;
+                return e;
             }
         }
     }

--- a/src/DependencyInjection/DI/src/DependencyInjectionEventSource.cs
+++ b/src/DependencyInjection/DI/src/DependencyInjectionEventSource.cs
@@ -14,9 +14,10 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static readonly DependencyInjectionEventSource Log = new DependencyInjectionEventSource();
 
+        // Event source doesn't support large payloads so we chunk formatted call site tree
         private int MaxChunkSize = 10 * 1024;
 
-        private DependencyInjectionEventSource():base(EventSourceSettings.EtwSelfDescribingEventFormat)
+        private DependencyInjectionEventSource()
         {
         }
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -67,7 +67,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 return scope => _runtimeResolver.Resolve(callSite, scope);
             }
 
-            return BuildExpression(callSite).Compile();
+            var expression = BuildExpression(callSite);
+            DependencyInjectionEventSource.Log.ExpressionTreeGenerated(callSite.ServiceType, expression);
+            return expression.Compile();
         }
 
         private bool TryResolveSingletonValue(ServiceCallSite singletonCallSite, out object value)

--- a/src/DependencyInjection/DI/test/DependencyInjectionEventSourceTests.cs
+++ b/src/DependencyInjection/DI/test/DependencyInjectionEventSourceTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -56,109 +57,96 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var callsiteBuiltEvent = _listener.EventData.Single(e => e.EventName == "CallSiteBuilt");
 
-            Assert.Equal(string.Join(Environment.NewLine, "{",
-                "    \"serviceType\": \"System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService]\",",
-                "    \"kind\": \"IEnumerable\",",
-                "    \"cache\": \"None\",",
-                "    \"itemType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService\",",
-                "    \"size\": \"1\",",
-                "    \"items\":",
-                "    [",
-                "        {",
-                "            \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService\",",
-                "            \"kind\": \"Constructor\",",
-                "            \"cache\": \"Dispose\",",
-                "            \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackOuterService\",",
-                "            \"arguments\":",
-                "            [",
-                "                {",
-                "                    \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService\",",
-                "                    \"kind\": \"Constructor\",",
-                "                    \"cache\": \"Root\",",
-                "                    \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
-                "                    \"arguments\":",
-                "                    [",
-                "                        {",
-                "                            \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\",",
-                "                            \"kind\": \"Constant\",",
-                "                            \"cache\": \"None\",",
-                "                            \"value\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
-                "                        }",
-                "                    ]",
-                "                },",
-                "                {",
-                "                    \"serviceType\": \"System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService]\",",
-                "                    \"kind\": \"IEnumerable\",",
-                "                    \"cache\": \"None\",",
-                "                    \"itemType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
-                "                    \"size\": \"4\",",
-                "                    \"items\":",
-                "                    [",
-                "                        {",
-                "                            \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
-                "                            \"kind\": \"Constructor\",",
-                "                            \"cache\": \"Root\",",
-                "                            \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
-                "                            \"arguments\":",
-                "                            [",
-                "                                {",
-                "                                    \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\",",
-                "                                    \"kind\": \"Constant\",",
-                "                                    \"cache\": \"None\",",
-                "                                    \"value\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
-                "                                }",
-                "                            ]",
-                "                        },",
-                "                        {",
-                "                            \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
-                "                            \"kind\": \"Factory\",",
-                "                            \"cache\": \"Root\",",
-                "                            \"method\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService <EmitsCallSiteBuiltEvent>b__0(System.IServiceProvider)\"",
-                "                        },",
-                "                        {",
-                "                            \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
-                "                            \"kind\": \"Constructor\",",
-                "                            \"cache\": \"Scope\",",
-                "                            \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
-                "                            \"arguments\":",
-                "                            [",
-                "                                {",
-                "                                    \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\",",
-                "                                    \"kind\": \"Constant\",",
-                "                                    \"cache\": \"None\",",
-                "                                    \"value\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
-                "                                }",
-                "                            ]",
-                "                        },",
-                "                        {",
-                "                            \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
-                "                            \"kind\": \"Constructor\",",
-                "                            \"cache\": \"Dispose\",",
-                "                            \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
-                "                            \"arguments\":",
-                "                            [",
-                "                                {",
-                "                                    \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\",",
-                "                                    \"kind\": \"Constant\",",
-                "                                    \"cache\": \"None\",",
-                "                                    \"value\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
-                "                                }",
-                "                            ]",
-                "                        }",
-                "                    ]",
-                "                },",
-                "                {",
-                "                    \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\",",
-                "                    \"kind\": \"Constant\",",
-                "                    \"cache\": \"None\",",
-                "                    \"value\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
-                "                }",
-                "            ]",
-                "        }",
-                "    ]",
-                "}"), GetProperty(callsiteBuiltEvent, "callSite"));
 
-            Assert.Equal("System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService]", GetProperty(callsiteBuiltEvent, "serviceType"));
+            Assert.Equal(
+                string.Join(Environment.NewLine,
+                "{",
+                "  \"serviceType\": \"System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService]\",",
+                "  \"kind\": \"IEnumerable\",",
+                "  \"cache\": \"None\",",
+                "  \"itemType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService\",",
+                "  \"size\": \"1\",",
+                "  \"items\": [",
+                "    {",
+                "      \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService\",",
+                "      \"kind\": \"Constructor\",",
+                "      \"cache\": \"Dispose\",",
+                "      \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackOuterService\",",
+                "      \"arguments\": [",
+                "        {",
+                "          \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService\",",
+                "          \"kind\": \"Constructor\",",
+                "          \"cache\": \"Root\",",
+                "          \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
+                "          \"arguments\": [",
+                "            {",
+                "              \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\",",
+                "              \"kind\": \"Constant\",",
+                "              \"cache\": \"None\",",
+                "              \"value\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
+                "            }",
+                "          ]",
+                "        },",
+                "        {",
+                "          \"serviceType\": \"System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService]\",",
+                "          \"kind\": \"IEnumerable\",",
+                "          \"cache\": \"None\",",
+                "          \"itemType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
+                "          \"size\": \"4\",",
+                "          \"items\": [",
+                "            {",
+                "              \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
+                "              \"kind\": \"Constructor\",",
+                "              \"cache\": \"Root\",",
+                "              \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
+                "              \"arguments\": [",
+                "                {",
+                "                  \"ref\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
+                "                }",
+                "              ]",
+                "            },",
+                "            {",
+                "              \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
+                "              \"kind\": \"Factory\",",
+                "              \"cache\": \"Root\",",
+                "              \"method\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService <EmitsCallSiteBuiltEvent>b__0(System.IServiceProvider)\"",
+                "            },",
+                "            {",
+                "              \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
+                "              \"kind\": \"Constructor\",",
+                "              \"cache\": \"Scope\",",
+                "              \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
+                "              \"arguments\": [",
+                "                {",
+                "                  \"ref\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
+                "                }",
+                "              ]",
+                "            },",
+                "            {",
+                "              \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeMultipleService\",",
+                "              \"kind\": \"Constructor\",",
+                "              \"cache\": \"Dispose\",",
+                "              \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\",",
+                "              \"arguments\": [",
+                "                {",
+                "                  \"ref\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
+                "                }",
+                "              ]",
+                "            }",
+                "          ]",
+                "        },",
+                "        {",
+                "          \"ref\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposeCallback\"",
+                "        }",
+                "      ]",
+                "    }",
+                "  ]",
+                "}"),
+                JObject.Parse(GetProperty<string>(callsiteBuiltEvent, "callSite")).ToString());
+
+            Assert.Equal("System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOuterService]", GetProperty<string>(callsiteBuiltEvent, "serviceType"));
+            Assert.Equal(0, GetProperty<int>(callsiteBuiltEvent, "chunkIndex"));
+            Assert.Equal(1, GetProperty<int>(callsiteBuiltEvent, "chunkCount"));
             Assert.Equal(1, callsiteBuiltEvent.EventId);
         }
 
@@ -180,13 +168,31 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.Equal(3, serviceResolvedEvents.Length);
             foreach (var serviceResolvedEvent in serviceResolvedEvents)
             {
-                Assert.Equal("Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService", GetProperty(serviceResolvedEvent, "serviceType"));
+                Assert.Equal("Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService", GetProperty<string>(serviceResolvedEvent, "serviceType"));
                 Assert.Equal(2, serviceResolvedEvent.EventId);
             }
         }
 
-        private string GetProperty(EventWrittenEventArgs data, string propName)
-            => data.Payload[data.PayloadNames.IndexOf(propName)] as string;
+        [Fact]
+        public void EmitsExpressionTreeBuiltEvent()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IFakeService, FakeService>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Expressions });
+
+            serviceProvider.GetService<IFakeService>();
+
+            var expressionTreeGeneratedEvent = _listener.EventData.Single(e => e.EventName == "ExpressionTreeGenerated");
+
+            Assert.Equal("Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService", GetProperty<string>(expressionTreeGeneratedEvent, "serviceType"));
+            Assert.Equal(9, GetProperty<int>(expressionTreeGeneratedEvent, "nodeCount"));
+            Assert.Equal(3, expressionTreeGeneratedEvent.EventId);
+        }
+
+        private T GetProperty<T>(EventWrittenEventArgs data, string propName)
+            => (T)data.Payload[data.PayloadNames.IndexOf(propName)];
 
         private class TestEventListener : EventListener
         {

--- a/src/DependencyInjection/DI/test/Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/DependencyInjection/DI/test/Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json" />
+
     <ProjectReference Include="..\src\Microsoft.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
1. Add event that logs size of expression trees that are generated
2. Modify call site built event to avoid printing duplicated nodes - it would output  `{ "ref": "TypeName" }` instead
3. Modify call site built event to chunk output in 10k chunks.