### PR TITLE
Allow caching of IEnumerable services

### DIFF
--- a/src/DependencyInjection/DI/perf/GetServiceBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/GetServiceBenchmark.cs
@@ -1,14 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 
 namespace Microsoft.Extensions.DependencyInjection.Performance
 {
-    public class GetServiceBenchmark
+    public class GetServiceBenchmark: ServiceProviderEngineBenchmark
     {
         private const int OperationsPerInvoke = 50000;
 
@@ -18,14 +17,6 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
         private IServiceProvider _serviceScopeFactoryProvider;
         private IServiceProvider _serviceScope;
         private IServiceProvider _emptyEnumerable;
-        private ServiceProviderMode _mode;
-
-        [Params("Expressions", "Dynamic", "Runtime", "ILEmit")]
-        public string Mode {
-            set {
-                _mode = (ServiceProviderMode)Enum.Parse(typeof(ServiceProviderMode), value);
-            }
-        }
 
         [Benchmark(Baseline = true, OperationsPerInvoke = OperationsPerInvoke)]
         public void NoDI()
@@ -46,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             services.AddTransient<C>();
             _transientSp = services.BuildServiceProvider(new ServiceProviderOptions()
             {
-                Mode = _mode
+                Mode = ServiceProviderMode
             });
         }
 
@@ -69,7 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             services.AddScoped<C>();
             _scopedSp = services.BuildServiceProvider(new ServiceProviderOptions()
             {
-                Mode = _mode
+                Mode = ServiceProviderMode
             }).CreateScope();
         }
 
@@ -92,7 +83,7 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             services.AddSingleton<C>();
             _singletonSp = services.BuildServiceProvider(new ServiceProviderOptions()
             {
-                Mode = _mode
+                Mode = ServiceProviderMode
             });
         }
 
@@ -111,7 +102,7 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
         {
             _serviceScope = new ServiceCollection().BuildServiceProvider(new ServiceProviderOptions()
             {
-                Mode = _mode
+                Mode = ServiceProviderMode
             });
         }
 
@@ -129,7 +120,7 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
         {
             _serviceScopeFactoryProvider = new ServiceCollection().BuildServiceProvider(new ServiceProviderOptions()
             {
-                Mode = _mode
+                Mode = ServiceProviderMode
             });
         }
 
@@ -147,7 +138,7 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
         {
             _emptyEnumerable = new ServiceCollection().BuildServiceProvider(new ServiceProviderOptions()
             {
-                Mode = _mode
+                Mode = ServiceProviderMode
             });
         }
 
@@ -158,33 +149,6 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             {
                 _emptyEnumerable.GetService<IEnumerable<A>>();
             }
-        }
-
-        private class A
-        {
-            public A(B b)
-            {
-
-            }
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void Foo()
-            {
-
-            }
-        }
-
-        private class B
-        {
-            public B(C c)
-            {
-
-            }
-        }
-
-        private class C
-        {
-
         }
     }
 }

--- a/src/DependencyInjection/DI/perf/IEnumerableGetServiceBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/IEnumerableGetServiceBenchmark.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.DependencyInjection.Performance
+{
+    public class IEnumerableGetServiceBenchmark: ServiceProviderEngineBenchmark
+    {
+        private const int OperationsPerInvoke = 50000;
+
+        private IServiceProvider _serviceProvider;
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void Transient()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                _serviceProvider.GetService<IEnumerable<A>>();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void Scoped()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                _serviceProvider.GetService<IEnumerable<A>>();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void Singleton()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                _serviceProvider.GetService<IEnumerable<A>>();
+            }
+        }
+
+        [GlobalSetup(Target = nameof(Transient))]
+        public void SetupTransient() => Setup(ServiceLifetime.Transient);
+
+        [GlobalSetup(Target = nameof(Scoped))]
+        public void SetupScoped() => Setup(ServiceLifetime.Scoped);
+
+        [GlobalSetup(Target = nameof(Singleton))]
+        public void SetupSingleton() => Setup(ServiceLifetime.Singleton);
+
+        private void Setup(ServiceLifetime lifetime)
+        {
+            IServiceCollection services = new ServiceCollection();
+            for (int i = 0; i < 10; i++)
+            {
+                services.Add(ServiceDescriptor.Describe(typeof(A), typeof(A), lifetime));
+            }
+
+            services.Add(ServiceDescriptor.Describe(typeof(B), typeof(B), lifetime));
+            services.Add(ServiceDescriptor.Describe(typeof(C), typeof(C), lifetime));
+
+            _serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions()
+            {
+                Mode = ServiceProviderMode
+            }).CreateScope().ServiceProvider;
+        }
+    }
+}

--- a/src/DependencyInjection/DI/perf/ServiceProviderEngineBenchmark.cs
+++ b/src/DependencyInjection/DI/perf/ServiceProviderEngineBenchmark.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.DependencyInjection.Performance
+{
+    public class ServiceProviderEngineBenchmark
+    {
+        internal ServiceProviderMode ServiceProviderMode { get; private set; }
+
+        [Params("Expressions", "Dynamic", "Runtime", "ILEmit")]
+        public string Mode {
+            set {
+                ServiceProviderMode = (ServiceProviderMode)Enum.Parse(typeof(ServiceProviderMode), value);
+            }
+        }
+
+        internal class A
+        {
+            public A(B b)
+            {
+
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void Foo()
+            {
+
+            }
+        }
+
+        internal class B
+        {
+            public B(C c)
+            {
+
+            }
+        }
+
+        internal class C
+        {
+
+        }
+
+    }
+}

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
                 {
                     var itemType = serviceType.GenericTypeArguments.Single();
+                    var cacheLocation = CallSiteResultCacheLocation.Root;
 
                     var callSites = new List<ServiceCallSite>();
 
@@ -155,6 +156,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                             var callSite = TryCreateExact(descriptor, itemType, callSiteChain, slot);
                             Debug.Assert(callSite != null);
 
+                            cacheLocation = GetCommonCacheLocation(cacheLocation, callSite.Cache.Location);
                             callSites.Add(callSite);
                         }
                     }
@@ -170,6 +172,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                             slot++;
                             if (callSite != null)
                             {
+                                cacheLocation = GetCommonCacheLocation(cacheLocation, callSite.Cache.Location);
                                 callSites.Add(callSite);
                             }
                         }
@@ -177,7 +180,14 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         callSites.Reverse();
                     }
 
-                    return new IEnumerableCallSite(itemType, callSites.ToArray());
+                    // We know implementation type won't be disposable so don't try to capture it
+                    if (cacheLocation == CallSiteResultCacheLocation.Dispose)
+                    {
+                        cacheLocation = CallSiteResultCacheLocation.None;
+                    }
+
+                    var resultCache = new ResultCache(cacheLocation, new ServiceCacheKey(serviceType, DefaultSlot));
+                    return new IEnumerableCallSite(resultCache, itemType, callSites.ToArray());
                 }
 
                 return null;
@@ -186,6 +196,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 callSiteChain.Remove(serviceType);
             }
+        }
+
+        private CallSiteResultCacheLocation GetCommonCacheLocation(CallSiteResultCacheLocation locationA, CallSiteResultCacheLocation locationB)
+        {
+            return (CallSiteResultCacheLocation)Math.Max((int)locationA, (int)locationB);
         }
 
         private ServiceCallSite TryCreateExact(ServiceDescriptor descriptor, Type serviceType, CallSiteChain callSiteChain, int slot)

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
@@ -180,13 +180,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         callSites.Reverse();
                     }
 
-                    // We know implementation type won't be disposable so don't try to capture it
-                    if (cacheLocation == CallSiteResultCacheLocation.Dispose)
+
+                    var resultCache = ResultCache.None;
+                    if (cacheLocation == CallSiteResultCacheLocation.Scope || cacheLocation == CallSiteResultCacheLocation.Root)
                     {
-                        cacheLocation = CallSiteResultCacheLocation.None;
+                        resultCache = new ResultCache(cacheLocation, new ServiceCacheKey(serviceType, DefaultSlot));
                     }
 
-                    var resultCache = new ResultCache(cacheLocation, new ServiceCacheKey(serviceType, DefaultSlot));
                     return new IEnumerableCallSite(resultCache, itemType, callSites.ToArray());
                 }
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/IEnumerableCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/IEnumerableCallSite.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         internal Type ItemType { get; }
         internal ServiceCallSite[] ServiceCallSites { get; }
 
-        public IEnumerableCallSite(Type itemType, ServiceCallSite[] serviceCallSites) : base(ResultCache.None)
+        public IEnumerableCallSite(ResultCache cache, Type itemType, ServiceCallSite[] serviceCallSites) : base(cache)
         {
             ItemType = itemType;
             ServiceCallSites = serviceCallSites;

--- a/src/DependencyInjection/DI/test/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/CallSiteFactoryTest.cs
@@ -438,9 +438,18 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var factory = GetCallSiteFactory(descriptors);
             var callSite = factory(typeof(IEnumerable<FakeService>));
 
-            Assert.Equal((CallSiteResultCacheLocation)expectedCacheLocation, callSite.Cache.Location);
-            Assert.Equal(0, callSite.Cache.Key.Slot);
-            Assert.Equal(typeof(IEnumerable<FakeService>), callSite.Cache.Key.Type);
+            var expectedLocation = (CallSiteResultCacheLocation)expectedCacheLocation;
+            Assert.Equal(expectedLocation, callSite.Cache.Location);
+
+            if (expectedLocation != CallSiteResultCacheLocation.None)
+            {
+                Assert.Equal(0, callSite.Cache.Key.Slot);
+                Assert.Equal(typeof(IEnumerable<FakeService>), callSite.Cache.Key.Type);
+            }
+            else
+            {
+                Assert.Equal(ResultCache.None, callSite.Cache);
+            }
         }
 
         private static Func<Type, ServiceCallSite> GetCallSiteFactory(params ServiceDescriptor[] descriptors)


### PR DESCRIPTION
Before this change only items inside IEnumerable services were cached but not the arrays themselves.

Before:
```
    Method |        Mode |        Mean |      Error |     StdDev |         Op/s |    Gen 0 | Allocated |
---------- |------------ |------------:|-----------:|-----------:|-------------:|---------:|----------:|
 Transient |     Dynamic |   130.08 ns |  1.9756 ns |  1.8480 ns |  7,687,870.4 |  78.1250 |   16.4 MB |
    Scoped |     Dynamic |   368.52 ns |  3.8814 ns |  3.2412 ns |  2,713,550.4 |        - |   4.96 MB |
 Singleton |     Dynamic |    91.74 ns |  0.4798 ns |  0.4488 ns | 10,900,236.7 |  23.4375 |   4.96 MB |
 Transient | Expressions |   126.98 ns |  0.5482 ns |  0.4280 ns |  7,875,461.9 |  78.1250 |   16.4 MB |
    Scoped | Expressions |   370.26 ns |  4.7635 ns |  3.9777 ns |  2,700,821.2 |        - |   4.96 MB |
 Singleton | Expressions |   771.69 ns |  6.7945 ns |  6.0231 ns |  1,295,860.0 |        - |   4.96 MB |
 Transient |      ILEmit |   128.30 ns |  3.3772 ns |  3.1590 ns |  7,793,932.7 |  78.1250 |   16.4 MB |
    Scoped |      ILEmit |   360.98 ns |  6.1067 ns |  5.7122 ns |  2,770,274.2 |        - |   4.96 MB |
 Singleton |      ILEmit |   742.02 ns |  6.9257 ns |  6.4783 ns |  1,347,672.1 |        - |   4.96 MB |
 Transient |     Runtime | 6,602.27 ns | 97.5553 ns | 81.4631 ns |    151,463.1 | 500.0000 | 100.33 MB |
    Scoped |     Runtime | 1,076.62 ns |  7.2792 ns |  5.2633 ns |    928,830.7 |        - |   4.96 MB |
 Singleton |     Runtime | 1,039.67 ns |  4.8091 ns |  4.2631 ns |    961,840.9 |        - |   4.96 MB |
```

After:

```
    Method |        Mode |        Mean |      Error |     StdDev |         Op/s |    Gen 0 |   Allocated |
---------- |------------ |------------:|-----------:|-----------:|-------------:|---------:|------------:|
 Transient |     Dynamic |   127.30 ns |  2.5201 ns |  2.4751 ns |  7,855,466.6 |  78.1250 |  17200000 B |
    Scoped |     Dynamic |    93.48 ns |  1.0289 ns |  0.9624 ns | 10,697,556.7 |        - |         0 B |
 Singleton |     Dynamic |    47.40 ns |  0.3928 ns |  0.3482 ns | 21,098,399.1 |        - |         0 B |
 Transient | Expressions |   131.14 ns |  0.8885 ns |  0.7876 ns |  7,625,504.5 |  78.1250 |  17200000 B |
    Scoped | Expressions |    95.35 ns |  0.9309 ns |  0.8708 ns | 10,487,389.7 |        - |         0 B |
 Singleton | Expressions |   121.26 ns |  0.4251 ns |  0.3550 ns |  8,246,987.5 |        - |         0 B |
 Transient |      ILEmit |   130.85 ns |  2.4997 ns |  2.4551 ns |  7,642,496.9 |  78.1250 |  17200000 B |
    Scoped |      ILEmit |   111.34 ns |  2.0843 ns |  1.8477 ns |  8,981,606.0 |        - |         0 B |
 Singleton |      ILEmit |   119.04 ns |  1.6809 ns |  1.5723 ns |  8,400,255.4 |        - |         0 B |
 Transient |     Runtime | 6,600.38 ns | 94.7213 ns | 83.9680 ns |    151,506.4 | 437.5000 | 105200000 B |
    Scoped |     Runtime |   121.81 ns |  2.3620 ns |  2.2094 ns |  8,209,234.8 |        - |         0 B |
 Singleton |     Runtime |   116.17 ns |  1.8472 ns |  1.7278 ns |  8,608,186.3 |        - |         0 B |
```