### PR TITLE
Reenable IL Emit DI backend

### DIFF
--- a/src/DependencyInjection/DI/src/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -8,11 +8,19 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal abstract class CompiledServiceProviderEngine : ServiceProviderEngine
     {
+#if IL_EMIT
+        public ILEmitResolverBuilder ExpressionResolverBuilder { get; }
+#else
         public ExpressionResolverBuilder ExpressionResolverBuilder { get; }
+#endif
 
         public CompiledServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
         {
+#if IL_EMIT
+            ExpressionResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
+#else
             ExpressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
+#endif
         }
 
         protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)

--- a/src/DependencyInjection/DI/src/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -9,23 +9,23 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal abstract class CompiledServiceProviderEngine : ServiceProviderEngine
     {
 #if IL_EMIT
-        public ILEmitResolverBuilder ExpressionResolverBuilder { get; }
+        public ILEmitResolverBuilder ResolverBuilder { get; }
 #else
-        public ExpressionResolverBuilder ExpressionResolverBuilder { get; }
+        public ExpressionResolverBuilder ResolverBuilder { get; }
 #endif
 
         public CompiledServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
         {
 #if IL_EMIT
-            ExpressionResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
+            ResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
 #else
-            ExpressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
+            ResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
 #endif
         }
 
         protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
-            var realizedService = ExpressionResolverBuilder.Build(callSite);
+            var realizedService = ResolverBuilder.Build(callSite);
             RealizedServices[callSite.ServiceType] = realizedService;
             return realizedService;
         }


### PR DESCRIPTION
https://github.com/aspnet/Extensions/pull/570 is fixing the bug we had with code generation.

It has the same runtime performance but is faster and uses less memory to generate methods.

Runtime flag is not available yet.