### PR TITLE
Update BuildTools to 2.2.1-build-20181130.1

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -6,7 +6,7 @@
   <!-- These package versions may be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Auto">
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview2-20181105.3</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.2.1-build-20181130.1</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.2.0</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>4.5.0</MicrosoftWin32RegistryPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview2-20181105.3
-commithash:2f561e9983bce0f39e64fdb262635da897b32d8c
+version:2.2.1-build-20181130.1
+commithash:e7f77e1fda60bc39e8239ea51d94a9b4cdb889bc


### PR DESCRIPTION
Updates KoreBuild to use 2.2.100 instead of a pre-release version of the .NET Core SDK.