### PR TITLE
Remove merge artifact, fix CTS leak

### DIFF
--- a/Extensions.sln
+++ b/Extensions.sln
@@ -1602,7 +1602,6 @@ Global
 		{97AE13C4-B72C-4E30-8835-FF1603A9E224}.Release|x64.Build.0 = Release|Any CPU
 		{97AE13C4-B72C-4E30-8835-FF1603A9E224}.Release|x86.ActiveCfg = Release|Any CPU
 		{97AE13C4-B72C-4E30-8835-FF1603A9E224}.Release|x86.Build.0 = Release|Any CPU
-<<<<<<< HEAD
 		{1A203DA9-D706-4094-B549-2611C6DA38F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1A203DA9-D706-4094-B549-2611C6DA38F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A203DA9-D706-4094-B549-2611C6DA38F4}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -1615,7 +1614,6 @@ Global
 		{1A203DA9-D706-4094-B549-2611C6DA38F4}.Release|x64.Build.0 = Release|Any CPU
 		{1A203DA9-D706-4094-B549-2611C6DA38F4}.Release|x86.ActiveCfg = Release|Any CPU
 		{1A203DA9-D706-4094-B549-2611C6DA38F4}.Release|x86.Build.0 = Release|Any CPU
-=======
 		{AC33A64E-1261-47E7-8676-69C48E4B0266}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AC33A64E-1261-47E7-8676-69C48E4B0266}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC33A64E-1261-47E7-8676-69C48E4B0266}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -1652,7 +1650,6 @@ Global
 		{9FE05F36-5626-416D-956D-5C4C6D7E3E1B}.Release|x64.Build.0 = Release|Any CPU
 		{9FE05F36-5626-416D-956D-5C4C6D7E3E1B}.Release|x86.ActiveCfg = Release|Any CPU
 		{9FE05F36-5626-416D-956D-5C4C6D7E3E1B}.Release|x86.Build.0 = Release|Any CPU
->>>>>>> release/2.1
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Configuration/Config/src/ConfigurationReloadToken.cs
+++ b/src/Configuration/Config/src/ConfigurationReloadToken.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Configuration
     /// <summary>
     /// Implements <see cref="IChangeToken"/>
     /// </summary>
-    public class ConfigurationReloadToken : IChangeToken
+    public class ConfigurationReloadToken : IChangeToken, IDisposable
     {
         private CancellationTokenSource _cts = new CancellationTokenSource();
 
@@ -37,5 +37,10 @@ namespace Microsoft.Extensions.Configuration
         /// Used to trigger the change token when a reload occurs.
         /// </summary>
         public void OnReload() => _cts.Cancel();
+
+        /// <summary>
+        /// Disposes the underlying CancellationTokenSource.
+        /// </summary>
+        public void Dispose() => _cts.Dispose();
     }
 }

--- a/src/Configuration/Config/src/ConfigurationRoot.cs
+++ b/src/Configuration/Config/src/ConfigurationRoot.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Extensions.Configuration
         {
             var previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
             previousToken.OnReload();
+            previousToken.Dispose();
         }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
- Fix some merge artifacts in master's .sln
- Dispose of revolving ConfigurationReloadToken's underlying CancellationTokenSource

Addresses #587
