### PR TITLE
Fix errors in VS about ProjectSystemFault: Replace all usages of `<Reference>` with `<Dependency>`

### DIFF
--- a/Extensions.sln
+++ b/Extensions.sln
@@ -245,8 +245,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{1E66
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenericHostSample", "src\Hosting\samples\GenericHostSample\GenericHostSample.csproj", "{97AE13C4-B72C-4E30-8835-FF1603A9E224}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{11FC1750-8A8A-4006-A9F1-F5D9082AC7FA}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Localization", "Localization", "{2FAC6FF0-1FB6-41C6-9A36-FFC2E1727783}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Localization", "src\Localization\Localization\src\Microsoft.Extensions.Localization.csproj", "{AC33A64E-1261-47E7-8676-69C48E4B0266}"

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -75,11 +75,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <Reference Include="Microsoft.AspNetCore.Testing" />
-    <Reference Include="Microsoft.NET.Test.Sdk" />
-    <Reference Include="Moq" />
-    <Reference Include="xunit" />
-    <Reference Include="xunit.analyzers" />
-    <Reference Include="xunit.runner.visualstudio" />
+    <Dependency Include="Microsoft.AspNetCore.Testing" />
+    <Dependency Include="Microsoft.NET.Test.Sdk" />
+    <Dependency Include="Moq" />
+    <Dependency Include="xunit" />
+    <Dependency Include="xunit.analyzers" />
+    <Dependency Include="xunit.runner.visualstudio" />
   </ItemGroup>
 </Project>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -36,7 +36,7 @@
     <_ExplicitPackageReference Include="@(PackageReference)" Exclude="@(_ImplicitPackageReference)" />
     <_ExplicitPackageReference Remove="Internal.AspNetCore.Sdk" />
 
-    <UnusedProjectReferenceProvider Include="@(ProjectReferenceProvider)" Exclude="@(Reference)" />
+    <UnusedProjectReferenceProvider Include="@(ProjectReferenceProvider)" Exclude="@(Dependency)" />
 
     <!-- Order matters. Projects should be used when possible instead of packages. -->
     <_ProjectReferenceByAssemblyName Condition="'$(UseProjectReferences)' == 'true'"
@@ -45,7 +45,7 @@
 
     <ProjectReference Include="@(_ProjectReferenceByAssemblyName->'%(ProjectPath)')" />
 
-    <Reference Remove="@(_ProjectReferenceByAssemblyName)" />
+    <Dependency Remove="@(_ProjectReferenceByAssemblyName)" />
   </ItemGroup>
 
   <!-- Ensure package output paths are available. -->
@@ -55,23 +55,23 @@
 
   <Target Name="ResolveCustomReferences" BeforeTargets="CollectPackageReferences;ResolveAssemblyReferencesDesignTime;ResolveAssemblyReferences" Condition=" '$(TargetFramework)' != '' ">
     <ItemGroup>
-      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Reference);@(_ProjectReferenceByAssemblyName)" />
+      <UnusedBaselinePackageReference Include="@(BaselinePackageReference)" Exclude="@(Dependency);@(_ProjectReferenceByAssemblyName)" />
 
       <!--
         MSBuild does not provide a way to join on matching identities in a Condition,
         but you can do a cartesian product of two item groups and filter out mismatched id's in a second pass.
       -->
-      <_LatestPackageReferenceWithVersion Include="@(Reference)" Condition=" '$(UseLatestPackageReferences)' == 'true' ">
+      <_LatestPackageReferenceWithVersion Include="@(Dependency)" Condition=" '$(UseLatestPackageReferences)' == 'true' ">
         <Id>%(LatestPackageReference.Identity)</Id>
         <Version>%(LatestPackageReference.Version)</Version>
       </_LatestPackageReferenceWithVersion>
       <_LatestPackageReferenceWithVersion Remove="@(_LatestPackageReferenceWithVersion)" Condition="'%(Id)' != '%(Identity)' " />
 
       <!-- Remove reference items that have been resolved to a LatestPackageReference item. -->
-      <Reference Remove="@(_LatestPackageReferenceWithVersion)" />
+      <Dependency Remove="@(_LatestPackageReferenceWithVersion)" />
       <PackageReference Include="@(_LatestPackageReferenceWithVersion)" IsImplicitlyDefined="true" />
 
-      <_BaselinePackageReferenceWithVersion Include="@(Reference)" Condition=" '$(IsServicingBuild)' == 'true' OR '$(UseLatestPackageReferences)' != 'true' ">
+      <_BaselinePackageReferenceWithVersion Include="@(Dependency)" Condition=" '$(IsServicingBuild)' == 'true' OR '$(UseLatestPackageReferences)' != 'true' ">
         <Id>%(BaselinePackageReference.Identity)</Id>
         <Version>%(BaselinePackageReference.Version)</Version>
       </_BaselinePackageReferenceWithVersion>
@@ -80,7 +80,7 @@
 
       <!-- Remove reference items that have been resolved to a BaselinePackageReference item. -->
       <PackageReference Include="@(_BaselinePackageReferenceWithVersion)" IsImplicitlyDefined="true" />
-      <Reference Remove="@(_BaselinePackageReferenceWithVersion)" />
+      <Dependency Remove="@(_BaselinePackageReferenceWithVersion)" />
 
       <!-- Free up memory for unnecessary items -->
       <_BaselinePackageReferenceWithVersion Remove="@(_BaselinePackageReferenceWithVersion)" />
@@ -89,7 +89,7 @@
     </ItemGroup>
 
     <Error Condition="@(_ExplicitPackageReference->Count()) != 0"
-           Text="PackageReference items are not allowed. Use &lt;Reference&gt; instead. " />
+           Text="PackageReference items are not allowed. Use &lt;Dependency&gt; instead. " />
 
     <ItemGroup>
       <_ExplicitPackageReference Remove="@(_ExplicitPackageReference)" />
@@ -98,9 +98,13 @@
     <Warning Condition="@(UnusedBaselinePackageReference->Count()) != 0"
              Text="Package references changed since the last release. This could be a breaking change. References removed:%0A - @(UnusedBaselinePackageReference, '%0A -')" />
 
-    <Error Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND '%(Reference.Identity)' != '' AND ! Exists('%(Reference.Identity)')"
+    <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+      <Reference Include="@(Dependency)" />
+    </ItemGroup>
+
+    <Error Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework' AND '%(Dependency.Identity)' != '' AND ! Exists('%(Dependency.Identity)')"
            Code="MSB3245"
-           Text="Could not resolve this reference. Could not locate the package or project for &quot;%(Reference.Identity)&quot;" />
+           Text="Could not resolve this reference. Could not locate the package or project for &quot;%(Dependency.Identity)&quot;" />
   </Target>
 
   <Target Name="GetReferencesProvided" Returns="@(ProvidesReference)">

--- a/src/Caching/Abstractions/src/Microsoft.Extensions.Caching.Abstractions.csproj
+++ b/src/Caching/Abstractions/src/Microsoft.Extensions.Caching.Abstractions.csproj
@@ -12,7 +12,7 @@ Microsoft.Extensions.Caching.Memory.IMemoryCache</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Primitives" />
+    <Dependency Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/Memory/src/Microsoft.Extensions.Caching.Memory.csproj
+++ b/src/Caching/Memory/src/Microsoft.Extensions.Caching.Memory.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.Caching.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/Memory/test/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/src/Caching/Memory/test/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Memory" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Caching.Memory" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/Redis/src/Microsoft.Extensions.Caching.Redis.csproj
+++ b/src/Caching/Redis/src/Microsoft.Extensions.Caching.Redis.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="StackExchange.Redis.StrongName" />
+    <Dependency Include="Microsoft.Extensions.Caching.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
+    <Dependency Include="StackExchange.Redis.StrongName" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/Redis/test/Microsoft.Extensions.Caching.Redis.Tests.csproj
+++ b/src/Caching/Redis/test/Microsoft.Extensions.Caching.Redis.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Redis" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Caching.Redis" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="System.Data.SqlClient" />
+    <Dependency Include="Microsoft.Extensions.Caching.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
+    <Dependency Include="System.Data.SqlClient" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/SqlServer/test/Microsoft.Extensions.Caching.SqlServer.Tests.csproj
+++ b/src/Caching/SqlServer/test/Microsoft.Extensions.Caching.SqlServer.Tests.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.SqlServer" />
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Caching.SqlServer" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/MemoryCacheConcurencySample/MemoryCacheConcurencySample.csproj
+++ b/src/Caching/samples/MemoryCacheConcurencySample/MemoryCacheConcurencySample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Memory" />
+    <Dependency Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/MemoryCacheFileWatchSample/MemoryCacheFileWatchSample.csproj
+++ b/src/Caching/samples/MemoryCacheFileWatchSample/MemoryCacheFileWatchSample.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Memory" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.Caching.Memory" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/MemoryCacheSample/MemoryCacheSample.csproj
+++ b/src/Caching/samples/MemoryCacheSample/MemoryCacheSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Memory" />
+    <Dependency Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/ProfilingSample/ProfilingSample.csproj
+++ b/src/Caching/samples/ProfilingSample/ProfilingSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Memory" />
+    <Dependency Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/RedisCacheSample/RedisCacheSample.csproj
+++ b/src/Caching/samples/RedisCacheSample/RedisCacheSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Redis" />
+    <Dependency Include="Microsoft.Extensions.Caching.Redis" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/SqlServerCacheConcurencySample/SqlServerCacheConcurencySample.csproj
+++ b/src/Caching/samples/SqlServerCacheConcurencySample/SqlServerCacheConcurencySample.csproj
@@ -10,10 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.SqlServer" />
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.Caching.SqlServer" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/samples/SqlServerCacheSample/SqlServerCacheSample.csproj
+++ b/src/Caching/samples/SqlServerCacheSample/SqlServerCacheSample.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.SqlServer" />
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Caching.SqlServer" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Abstractions/src/Microsoft.Extensions.Configuration.Abstractions.csproj
+++ b/src/Configuration/Config.Abstractions/src/Microsoft.Extensions.Configuration.Abstractions.csproj
@@ -12,7 +12,7 @@ Microsoft.Extensions.Configuration.IConfigurationSection</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Primitives" />
+    <Dependency Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.AzureKeyVault/samples/KeyVaultSample.csproj
+++ b/src/Configuration/Config.AzureKeyVault/samples/KeyVaultSample.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.AzureKeyVault" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Configuration.AzureKeyVault" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.AzureKeyVault/src/Microsoft.Extensions.Configuration.AzureKeyVault.csproj
+++ b/src/Configuration/Config.AzureKeyVault/src/Microsoft.Extensions.Configuration.AzureKeyVault.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.KeyVault" />
-    <Reference Include="Microsoft.Azure.Services.AppAuthentication" />
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="Microsoft.Azure.KeyVault" />
+    <Dependency Include="Microsoft.Azure.Services.AppAuthentication" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.AzureKeyVault/test/Microsoft.Extensions.Configuration.AzureKeyVault.Tests.csproj
+++ b/src/Configuration/Config.AzureKeyVault/test/Microsoft.Extensions.Configuration.AzureKeyVault.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.AzureKeyVault" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.AzureKeyVault" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Binder/src/Microsoft.Extensions.Configuration.Binder.csproj
+++ b/src/Configuration/Config.Binder/src/Microsoft.Extensions.Configuration.Binder.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Binder/test/Microsoft.Extensions.Configuration.Binder.Tests.csproj
+++ b/src/Configuration/Config.Binder/test/Microsoft.Extensions.Configuration.Binder.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Binder" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.CommandLine/src/Microsoft.Extensions.Configuration.CommandLine.csproj
+++ b/src/Configuration/Config.CommandLine/src/Microsoft.Extensions.Configuration.CommandLine.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.CommandLine/test/Microsoft.Extensions.Configuration.CommandLine.Tests.csproj
+++ b/src/Configuration/Config.CommandLine/test/Microsoft.Extensions.Configuration.CommandLine.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/Configuration/Config.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.EnvironmentVariables/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Tests.csproj
+++ b/src/Configuration/Config.EnvironmentVariables/test/Microsoft.Extensions.Configuration.EnvironmentVariables.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.FileExtensions/src/Microsoft.Extensions.Configuration.FileExtensions.csproj
+++ b/src/Configuration/Config.FileExtensions/src/Microsoft.Extensions.Configuration.FileExtensions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.FileExtensions/test/Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj
+++ b/src/Configuration/Config.FileExtensions/test/Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Ini/src/Microsoft.Extensions.Configuration.Ini.csproj
+++ b/src/Configuration/Config.Ini/src/Microsoft.Extensions.Configuration.Ini.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Ini/test/Microsoft.Extensions.Configuration.Ini.Tests.csproj
+++ b/src/Configuration/Config.Ini/test/Microsoft.Extensions.Configuration.Ini.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Ini" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Ini" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Json/src/Microsoft.Extensions.Configuration.Json.csproj
+++ b/src/Configuration/Config.Json/src/Microsoft.Extensions.Configuration.Json.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <Reference Include="Newtonsoft.Json" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Json/test/Microsoft.Extensions.Configuration.Json.Tests.csproj
+++ b/src/Configuration/Config.Json/test/Microsoft.Extensions.Configuration.Json.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.KeyPerFile/src/Microsoft.Extensions.Configuration.KeyPerFile.csproj
+++ b/src/Configuration/Config.KeyPerFile/src/Microsoft.Extensions.Configuration.KeyPerFile.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.KeyPerFile/test/Microsoft.Extensions.Configuration.KeyPerFile.Tests.csproj
+++ b/src/Configuration/Config.KeyPerFile/test/Microsoft.Extensions.Configuration.KeyPerFile.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.KeyPerFile" />
+    <Dependency Include="Microsoft.Extensions.Configuration.KeyPerFile" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.UserSecrets/src/Microsoft.Extensions.Configuration.UserSecrets.csproj
+++ b/src/Configuration/Config.UserSecrets/src/Microsoft.Extensions.Configuration.UserSecrets.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.UserSecrets/test/Microsoft.Extensions.Configuration.UserSecrets.Tests.csproj
+++ b/src/Configuration/Config.UserSecrets/test/Microsoft.Extensions.Configuration.UserSecrets.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <Dependency Include="Microsoft.Extensions.Configuration.UserSecrets" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Xml/src/Microsoft.Extensions.Configuration.Xml.csproj
+++ b/src/Configuration/Config.Xml/src/Microsoft.Extensions.Configuration.Xml.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Xml/test/Microsoft.Extensions.Configuration.Xml.Tests.csproj
+++ b/src/Configuration/Config.Xml/test/Microsoft.Extensions.Configuration.Xml.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
-    <Reference Include="Microsoft.Extensions.Configuration.Xml" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Xml" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Security" />
+    <Dependency Include="System.Security" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config/src/Microsoft.Extensions.Configuration.csproj
+++ b/src/Configuration/Config/src/Microsoft.Extensions.Configuration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config/test/Microsoft.Extensions.Configuration.Tests.csproj
+++ b/src/Configuration/Config/test/Microsoft.Extensions.Configuration.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/test/Config.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
+++ b/src/Configuration/test/Config.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Ini" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.Configuration.Xml" />
-    <Reference Include="Microsoft.Extensions.Configuration.Test.Common" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Ini" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Xml" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Test.Common" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/test/Config.Test.Common/Microsoft.Extensions.Configuration.Test.Common.csproj
+++ b/src/Configuration/test/Config.Test.Common/Microsoft.Extensions.Configuration.Test.Common.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
 </Project>

--- a/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -15,12 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="xunit.assert" />
-    <Reference Include="xunit.extensibility.core" />
+    <Dependency Include="xunit.assert" />
+    <Dependency Include="xunit.extensibility.core" />
   </ItemGroup>
 
 </Project>

--- a/src/DependencyInjection/DI/perf/Microsoft.Extensions.DependencyInjection.Performance.csproj
+++ b/src/DependencyInjection/DI/perf/Microsoft.Extensions.DependencyInjection.Performance.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="BenchmarkDotNet" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="BenchmarkDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DependencyInjection/DI/src/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/DependencyInjection/DI/src/Microsoft.Extensions.DependencyInjection.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DiagnosticAdapter/src/Microsoft.Extensions.DiagnosticAdapter.csproj
+++ b/src/DiagnosticAdapter/src/Microsoft.Extensions.DiagnosticAdapter.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.Diagnostics.DiagnosticSource" />
+    <Dependency Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Abstractions/src/Microsoft.Extensions.FileProviders.Abstractions.csproj
+++ b/src/FileProviders/Abstractions/src/Microsoft.Extensions.FileProviders.Abstractions.csproj
@@ -15,7 +15,7 @@ Microsoft.Extensions.FileProviders.IFileProvider</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Primitives" />
+    <Dependency Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Composite/src/Microsoft.Extensions.FileProviders.Composite.csproj
+++ b/src/FileProviders/Composite/src/Microsoft.Extensions.FileProviders.Composite.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Composite/test/Microsoft.Extensions.FileProviders.Composite.Tests.csproj
+++ b/src/FileProviders/Composite/test/Microsoft.Extensions.FileProviders.Composite.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileProviders.Composite" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Composite" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <ProjectReference Include="..\..\Manifest.MSBuildTask\src\Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.csproj" PrivateAssets="All" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/FileProviders/Embedded/test/Microsoft.Extensions.FileProviders.Embedded.Tests.csproj
+++ b/src/FileProviders/Embedded/test/Microsoft.Extensions.FileProviders.Embedded.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Embedded" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Manifest.MSBuildTask/src/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.csproj
+++ b/src/FileProviders/Manifest.MSBuildTask/src/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.csproj
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Build" PrivateAssets="All" />
-    <Reference Include="Microsoft.Build.Framework" PrivateAssets="All" />
+    <Dependency Include="Microsoft.Build" PrivateAssets="All" />
+    <Dependency Include="Microsoft.Build.Framework" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <Reference Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
+    <Dependency Include="Microsoft.Build.Utilities.Core" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="Microsoft.Build.Utilities.v4.0" PrivateAssets="All" />
+    <Dependency Include="Microsoft.Build.Utilities.v4.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Manifest.MSBuildTask/test/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.Test.csproj
+++ b/src/FileProviders/Manifest.MSBuildTask/test/Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.Test.csproj
@@ -9,16 +9,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
+    <Dependency Include="Microsoft.Build" />
+    <Dependency Include="Microsoft.Build.Framework" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <Reference Include="Microsoft.Build.Utilities.Core" />
+    <Dependency Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Dependency Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Physical/src/Microsoft.Extensions.FileProviders.Physical.csproj
+++ b/src/FileProviders/Physical/src/Microsoft.Extensions.FileProviders.Physical.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
-    <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
 
 </Project>

--- a/src/FileProviders/Physical/test/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
+++ b/src/FileProviders/Physical/test/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
 </Project>

--- a/src/FileSystemGlobbing/test/Microsoft.Extensions.FileSystemGlobbing.Tests.csproj
+++ b/src/FileSystemGlobbing/test/Microsoft.Extensions.FileSystemGlobbing.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <Dependency Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/Abstractions/src/Microsoft.Extensions.Hosting.Abstractions.csproj
+++ b/src/Hosting/Abstractions/src/Microsoft.Extensions.Hosting.Abstractions.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
   
 </Project>

--- a/src/Hosting/Hosting/src/Microsoft.Extensions.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.Extensions.Hosting.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Configuration" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
-    <Reference Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Configuration" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/Hosting/test/Microsoft.Extensions.Hosting.Tests.csproj
+++ b/src/Hosting/Hosting/test/Microsoft.Extensions.Hosting.Tests.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Hosting" />
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Logging.Testing" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.Hosting" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Logging.Testing" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/samples/GenericHostSample/GenericHostSample.csproj
+++ b/src/Hosting/samples/GenericHostSample/GenericHostSample.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Hosting" />
+    <Dependency Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.ServiceProcess" />
+    <Dependency Include="System.ServiceProcess" />
   </ItemGroup>
   
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/Http/perf/Microsoft.Extensions.Http.Performance.csproj
+++ b/src/HttpClientFactory/Http/perf/Microsoft.Extensions.Http.Performance.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Http" />
-    <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Http" />
+    <Dependency Include="BenchmarkDotNet" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/Http/src/Microsoft.Extensions.Http.csproj
+++ b/src/HttpClientFactory/Http/src/Microsoft.Extensions.Http.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/Http/test/Microsoft.Extensions.Http.Tests.csproj
+++ b/src/HttpClientFactory/Http/test/Microsoft.Extensions.Http.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Http" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Http" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/Polly/src/Microsoft.Extensions.Http.Polly.csproj
+++ b/src/HttpClientFactory/Polly/src/Microsoft.Extensions.Http.Polly.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Http" />
-    <Reference Include="Polly.Extensions.Http" />
-    <Reference Include="Polly" />
+    <Dependency Include="Microsoft.Extensions.Http" />
+    <Dependency Include="Polly.Extensions.Http" />
+    <Dependency Include="Polly" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/Polly/test/Microsoft.Extensions.Http.Polly.Tests.csproj
+++ b/src/HttpClientFactory/Polly/test/Microsoft.Extensions.Http.Polly.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Http.Polly" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Http.Polly" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/samples/HttpClientFactorySample/HttpClientFactorySample.csproj
+++ b/src/HttpClientFactory/samples/HttpClientFactorySample/HttpClientFactorySample.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.AspNet.WebApi.Client" />
-    <Reference Include="Microsoft.Extensions.Http" />
-    <Reference Include="Microsoft.Extensions.Http.Polly" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Logging.Console" />
+    <Dependency Include="Microsoft.AspNet.WebApi.Client" />
+    <Dependency Include="Microsoft.Extensions.Http" />
+    <Dependency Include="Microsoft.Extensions.Http.Polly" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
 </Project>

--- a/src/Localization/Localization/src/Microsoft.Extensions.Localization.csproj
+++ b/src/Localization/Localization/src/Microsoft.Extensions.Localization.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="Microsoft.Extensions.Localization.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.Localization.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests.csproj
+++ b/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Localization" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Logging.Testing" />
+    <Dependency Include="Microsoft.Extensions.Localization" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Logging.Testing" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="All" />
+    <Dependency Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="All" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Logging/Logging.Analyzers/test/Microsoft.Extensions.Logging.Analyzer.Tests.csproj
+++ b/src/Logging/Logging.Analyzers/test/Microsoft.Extensions.Logging.Analyzer.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <Reference Include="Microsoft.Extensions.DependencyModel" />
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Analyzers" />
-    <Reference Include="System.Reflection.Metadata" />
+    <Dependency Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <Dependency Include="Microsoft.Extensions.DependencyModel" />
+    <Dependency Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Analyzers" />
+    <Dependency Include="System.Reflection.Metadata" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/Logging.AzureAppServices/src/Microsoft.Extensions.Logging.AzureAppServices.csproj
+++ b/src/Logging/Logging.AzureAppServices/src/Microsoft.Extensions.Logging.AzureAppServices.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Configuration" />
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="System.ValueTuple" />
+    <Dependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.AzureAppServices/test/Microsoft.Extensions.Logging.AzureAppServices.Tests.csproj
+++ b/src/Logging/Logging.AzureAppServices/test/Microsoft.Extensions.Logging.AzureAppServices.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Logging.AzureAppServices" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Logging.AzureAppServices" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.Configuration/src/Microsoft.Extensions.Logging.Configuration.csproj
+++ b/src/Logging/Logging.Configuration/src/Microsoft.Extensions.Logging.Configuration.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/Logging/Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Configuration" />
-    <Reference Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.Debug/src/Microsoft.Extensions.Logging.Debug.csproj
+++ b/src/Logging/Logging.Debug/src/Microsoft.Extensions.Logging.Debug.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/Logging/Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="System.Diagnostics.EventLog" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="System.Diagnostics.EventLog" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Newtonsoft.Json" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.EventSource/test/Microsoft.Extensions.Logging.EventSource.Tests.csproj
+++ b/src/Logging/Logging.EventSource/test/Microsoft.Extensions.Logging.EventSource.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.Extensions.Logging.EventSource" />
-    <Reference Include="Microsoft.Extensions.Logging.Tests" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Logging.EventSource" />
+    <Dependency Include="Microsoft.Extensions.Logging.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.Testing/src/Microsoft.Extensions.Logging.Testing.csproj
+++ b/src/Logging/Logging.Testing/src/Microsoft.Extensions.Logging.Testing.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore.Testing" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Logging.Console" />
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Serilog.Extensions.Logging" />
-    <Reference Include="Serilog.Sinks.File" />
-    <Reference Include="xunit.abstractions" />
-    <Reference Include="xunit.assert" />
-    <Reference Include="xunit.extensibility.execution" />
+    <Dependency Include="Microsoft.AspNetCore.Testing" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Logging.Console" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Serilog.Extensions.Logging" />
+    <Dependency Include="Serilog.Sinks.File" />
+    <Dependency Include="xunit.abstractions" />
+    <Dependency Include="xunit.assert" />
+    <Dependency Include="xunit.extensibility.execution" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/Logging.Testing/test/Microsoft.Extensions.Logging.Testing.Tests.csproj
+++ b/src/Logging/Logging.Testing/test/Microsoft.Extensions.Logging.Testing.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging.Testing" />
-    <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.Extensions.Logging.Tests" />
+    <Dependency Include="Microsoft.Extensions.Logging.Testing" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Logging.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Logging/Logging.TraceSource/src/Microsoft.Extensions.Logging.TraceSource.csproj
+++ b/src/Logging/Logging.TraceSource/src/Microsoft.Extensions.Logging.TraceSource.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging/src/Microsoft.Extensions.Logging.csproj
+++ b/src/Logging/Logging/src/Microsoft.Extensions.Logging.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Binder" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/samples/SampleApp/SampleApp.csproj
+++ b/src/Logging/samples/SampleApp/SampleApp.csproj
@@ -10,17 +10,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
-    <Reference Include="Microsoft.Extensions.Logging.AzureAppServices" />
-    <Reference Include="Microsoft.Extensions.Logging.Configuration" />
-    <Reference Include="Microsoft.Extensions.Logging.Console" />
+    <Dependency Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Dependency Include="Microsoft.Extensions.Logging.AzureAppServices" />
+    <Dependency Include="Microsoft.Extensions.Logging.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="Microsoft.Extensions.Logging.EventLog" />
+    <Dependency Include="Microsoft.Extensions.Logging.EventLog" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/test/Microsoft.Extensions.Logging.Tests.csproj
+++ b/src/Logging/test/Microsoft.Extensions.Logging.Tests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Json" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Logging.Configuration" />
-    <Reference Include="Microsoft.Extensions.Logging.Console" />
-    <Reference Include="Microsoft.Extensions.Logging.Debug" />
-    <Reference Include="Microsoft.Extensions.Logging.EventLog" />
-    <Reference Include="Microsoft.Extensions.Logging.Testing" />
-    <Reference Include="Microsoft.Extensions.Logging.TraceSource" />
-    <Reference Include="Microsoft.Extensions.Logging" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Json" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Logging.Configuration" />
+    <Dependency Include="Microsoft.Extensions.Logging.Console" />
+    <Dependency Include="Microsoft.Extensions.Logging.Debug" />
+    <Dependency Include="Microsoft.Extensions.Logging.EventLog" />
+    <Dependency Include="Microsoft.Extensions.Logging.Testing" />
+    <Dependency Include="Microsoft.Extensions.Logging.TraceSource" />
+    <Dependency Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/src/ObjectPool/perf/Microsoft.Extensions.ObjectPool.Performance.csproj
+++ b/src/ObjectPool/perf/Microsoft.Extensions.ObjectPool.Performance.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Newtonsoft.Json" />
+    <Dependency Include="BenchmarkDotNet" />
+    <Dependency Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Options/ConfigurationExtensions/src/Microsoft.Extensions.Options.ConfigurationExtensions.csproj
+++ b/src/Options/ConfigurationExtensions/src/Microsoft.Extensions.Options.ConfigurationExtensions.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Configuration.Binder" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/Options/Options/src/Microsoft.Extensions.Options.csproj
+++ b/src/Options/Options/src/Microsoft.Extensions.Options.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Primitives" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Options/test/Microsoft.Extensions.Options.Tests.csproj
+++ b/src/Options/test/Microsoft.Extensions.Options.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <Reference Include="Microsoft.Extensions.Options" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/Primitives/perf/Microsoft.Extensions.Primitives.Performance.csproj
+++ b/src/Primitives/perf/Microsoft.Extensions.Primitives.Performance.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="BenchmarkDotNet" />
-    <Reference Include="Newtonsoft.Json" />
+    <Dependency Include="BenchmarkDotNet" />
+    <Dependency Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Primitives/src/Microsoft.Extensions.Primitives.csproj
+++ b/src/Primitives/src/Microsoft.Extensions.Primitives.csproj
@@ -17,8 +17,8 @@ Microsoft.Extensions.Primitives.StringSegment</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Memory" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+    <Dependency Include="System.Memory" />
+    <Dependency Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/src/Shared/test/Microsoft.Extensions.Sources.Tests.csproj
+++ b/src/Shared/test/Microsoft.Extensions.Sources.Tests.csproj
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="FSharp.Core" />
-    <Reference Include="System.Reflection.Metadata" />
-    <Reference Include="System.Threading.Tasks.Extensions" />
-    <Reference Include="System.Security.Cryptography.Cng" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
-    <Reference Include="System.IO.Pipelines" />
+    <Dependency Include="FSharp.Core" />
+    <Dependency Include="System.Reflection.Metadata" />
+    <Dependency Include="System.Threading.Tasks.Extensions" />
+    <Dependency Include="System.Security.Cryptography.Cng" />
+    <Dependency Include="System.Runtime.CompilerServices.Unsafe" />
+    <Dependency Include="System.IO.Pipelines" />
   </ItemGroup>
 
 </Project>

--- a/src/WebEncoders/src/Microsoft.Extensions.WebEncoders.csproj
+++ b/src/WebEncoders/src/Microsoft.Extensions.WebEncoders.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="System.Text.Encodings.Web" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Dependency Include="Microsoft.Extensions.Options" />
+    <Dependency Include="System.Text.Encodings.Web" />
   </ItemGroup>
 
 </Project>

--- a/src/WebEncoders/test/Microsoft.Extensions.WebEncoders.Tests.csproj
+++ b/src/WebEncoders/test/Microsoft.Extensions.WebEncoders.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.WebEncoders" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Dependency Include="Microsoft.Extensions.WebEncoders" />
+    <Dependency Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Still haven't figured out what leads to https://developercommunity.visualstudio.com/content/problem/377676/argumentexception-thrown-by-referenceshostbridge-a.html (cref https://github.com/dotnet/project-system/issues/4237), but it seems the root cause is that we are attempting to use the `<Reference>` item group name.

This PR replaces all usages of `<Reference>` with `<Dependency>` to workaround this.