### PR TITLE
Use Task.Run instead of Task.Factory.StartNew

### DIFF
--- a/src/Logging/Logging.AzureAppServices/src/BatchingLoggerProvider.cs
+++ b/src/Logging/Logging.AzureAppServices/src/BatchingLoggerProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
 
         internal abstract Task WriteMessagesAsync(IEnumerable<LogMessage> messages, CancellationToken token);
 
-        private async Task ProcessLogQueue(object state)
+        private async Task ProcessLogQueue()
         {
             while (!_cancellationTokenSource.IsCancellationRequested)
             {
@@ -143,10 +143,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
                 new BlockingCollection<LogMessage>(new ConcurrentQueue<LogMessage>(), _queueSize.Value);
 
             _cancellationTokenSource = new CancellationTokenSource();
-            _outputTask = Task.Factory.StartNew<Task>(
-                ProcessLogQueue,
-                null,
-                TaskCreationOptions.LongRunning);
+            _outputTask = Task.Run(ProcessLogQueue);
         }
 
         private void Stop()


### PR DESCRIPTION
Using `TaskCreationOptions.LongRunning` creates a dedicated thread, but it's released on the first await. Using `Task.Run` uses the thread pool instead.

Addresses #571
