### PR TITLE
Add spec tests for external container implementations

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -80,6 +80,8 @@
     <LatestPackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
     <LatestPackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <LatestPackageReference Include="xunit" Version="2.4.0" />
+    <LatestPackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
+    <LatestPackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -80,8 +80,16 @@
     <LatestPackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
     <LatestPackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <LatestPackageReference Include="xunit" Version="2.4.0" />
+
+    <!-- External DI container references -->
     <LatestPackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
     <LatestPackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="2.1.0" />
+    <LatestPackageReference Include="Grace.DependencyInjection.Extensions" Version="6.4.0" />
+    <LatestPackageReference Include="Lamar.Microsoft.DependencyInjection" Version="2.0.1" />
+    <LatestPackageReference Include="LightInject.Microsoft.DependencyInjection" Version="2.2.0" />
+    <LatestPackageReference Include="Stashbox.Extensions.Dependencyinjection" Version="2.6.3" />
+    <LatestPackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="1.4.0" />
+    <LatestPackageReference Include="Unity.Microsoft.DependencyInjection" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/src/DependencyInjection/DI.External.Tests/test/Autofac.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Autofac.cs
@@ -1,0 +1,19 @@
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+
+    namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public class AutofacDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    {
+        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        {
+            var builder = new ContainerBuilder();
+            builder.Populate(serviceCollection);
+            return new AutofacServiceProvider(builder.Build());
+        }
+    }
+}

--- a/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
@@ -1,0 +1,23 @@
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using DryIoc;
+using DryIoc.Microsoft.DependencyInjection;
+
+    namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public class DryIocDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    {
+        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        {
+            return new Container()
+                // setup DI adapter
+                .WithDependencyInjectionAdapter(serviceCollection)
+                // add registrations from CompositionRoot classs
+                .BuildServiceProvider();
+        }
+    }
+}

--- a/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Autofac;
-using Autofac.Extensions.DependencyInjection;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 
@@ -14,9 +12,7 @@ using DryIoc.Microsoft.DependencyInjection;
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
             return new Container()
-                // setup DI adapter
                 .WithDependencyInjectionAdapter(serviceCollection)
-                // add registrations from CompositionRoot classs
                 .BuildServiceProvider();
         }
     }

--- a/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/DryIoc.cs
@@ -5,7 +5,7 @@ using System;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 
-    namespace Microsoft.Extensions.DependencyInjection.Specification
+namespace Microsoft.Extensions.DependencyInjection.Specification
 {
     public class DryIocDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
     {

--- a/src/DependencyInjection/DI.External.Tests/test/Grace.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Grace.cs
@@ -1,0 +1,23 @@
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Grace.DependencyInjection;
+using Grace.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public class GraceDependencyInjectionSpecificationTests: SkipableDependencyInjectionSpecificationTests
+    {
+        public override string[] SkippedTests => new[]
+        {
+            "ResolvesMixedOpenClosedGenericsAsEnumerable",
+            "TypeActivatorWorksWithCtorWithOptionalArgs_WithStructDefaults"
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
+        {
+            return new DependencyInjectionContainer().Populate(serviceCollection);
+        }
+    }
+}

--- a/src/DependencyInjection/DI.External.Tests/test/Grace.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Grace.cs
@@ -7,7 +7,7 @@ using Grace.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class GraceDependencyInjectionSpecificationTests: SkipableDependencyInjectionSpecificationTests
+    public class GraceDependencyInjectionSpecificationTests: SkippableDependencyInjectionSpecificationTests
     {
         public override string[] SkippedTests => new[]
         {

--- a/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
@@ -1,0 +1,21 @@
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public class LamarDependencyInjectionSpecificationTests : SkipableDependencyInjectionSpecificationTests
+    {
+        public override string[] SkippedTests => new[]
+        {
+            "DisposesInReverseOrderOfCreation",
+            "ResolvesMixedOpenClosedGenericsAsEnumerable"
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
+        {
+            return Lamar.Container.BuildAsync(serviceCollection).Result;
+        }
+    }
+}

--- a/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Lamar.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class LamarDependencyInjectionSpecificationTests : SkipableDependencyInjectionSpecificationTests
+    public class LamarDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
         public override string[] SkippedTests => new[]
         {

--- a/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
@@ -4,16 +4,17 @@
 using System;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
+using LightInject.Microsoft.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection.Specification
+    namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class AutofacDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    public class LightInjectDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
             var builder = new ContainerBuilder();
             builder.Populate(serviceCollection);
-            return new AutofacServiceProvider(builder.Build());
+            return serviceCollection.CreateLightInjectServiceProvider();
         }
     }
 }

--- a/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/LightInject.cs
@@ -6,7 +6,7 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using LightInject.Microsoft.DependencyInjection;
 
-    namespace Microsoft.Extensions.DependencyInjection.Specification
+namespace Microsoft.Extensions.DependencyInjection.Specification
 {
     public class LightInjectDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
     {

--- a/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -10,7 +10,7 @@
     <Reference Include="Newtonsoft.Json" />
 
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <ProjectReference Include="..\..\DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" />
 
     <Reference Include="Autofac.Extensions.DependencyInjection" />
     <Reference Include="DryIoc.Microsoft.DependencyInjection" />

--- a/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -9,11 +9,17 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json" />
 
+    <ProjectReference Include="..\..\DI\src\Microsoft.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
 
     <Reference Include="Autofac.Extensions.DependencyInjection" />
     <Reference Include="DryIoc.Microsoft.DependencyInjection" />
-
+    <Reference Include="Lamar.Microsoft.DependencyInjection" />
+    <Reference Include="LightInject.Microsoft.DependencyInjection" />
+    <Reference Include="StructureMap.Microsoft.DependencyInjection" />
+    <Reference Include="Grace.DependencyInjection.Extensions" />
+    <Reference Include="Stashbox.Extensions.Dependencyinjection" />
+    <Reference Include="Unity.Microsoft.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <RootNamespace>Microsoft.Extensions.DependencyInjection</RootNamespace>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,7 @@
     <ProjectReference Include="..\..\DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
 
     <Reference Include="Autofac.Extensions.DependencyInjection" />
+    <Reference Include="DryIoc.Microsoft.DependencyInjection" />
 
   </ItemGroup>
 

--- a/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
+    <RootNamespace>Microsoft.Extensions.DependencyInjection</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json" />
+
+    <ProjectReference Include="..\..\DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
+
+    <Reference Include="Autofac.Extensions.DependencyInjection" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/DependencyInjection/DI.External.Tests/test/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json" />
 
-    <ProjectReference Include="..\..\DI\src\Microsoft.Extensions.DependencyInjection.csproj" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <ProjectReference Include="..\..\DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj" />
 
     <Reference Include="Autofac.Extensions.DependencyInjection" />

--- a/src/DependencyInjection/DI.External.Tests/test/SkipableDependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/SkipableDependencyInjectionSpecificationTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public abstract class SkipableDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    {
+        public abstract string[] SkippedTests { get; }
+
+
+        protected sealed override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        {
+            foreach (var stackFrame in new StackTrace(1).GetFrames().Take(2))
+            {
+                if (SkippedTests.Contains(stackFrame.GetMethod().Name))
+                {
+                    return serviceCollection.BuildServiceProvider();
+                }
+            }
+
+            return CreateServiceProviderImpl(serviceCollection);
+        }
+
+        protected abstract IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection);
+    }
+}

--- a/src/DependencyInjection/DI.External.Tests/test/SkipableDependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/SkipableDependencyInjectionSpecificationTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             {
                 if (SkippedTests.Contains(stackFrame.GetMethod().Name))
                 {
+                    // We skip tests by returning MEDI service provider that we know passes the test
                     return serviceCollection.BuildServiceProvider();
                 }
             }

--- a/src/DependencyInjection/DI.External.Tests/test/SkippableDependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/SkippableDependencyInjectionSpecificationTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public abstract class SkipableDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    public abstract class SkippableDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
     {
         public abstract string[] SkippedTests { get; }
 

--- a/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
@@ -2,18 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Autofac;
-using Autofac.Extensions.DependencyInjection;
+using System.Linq;
+using StructureMap;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class AutofacDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    public class StashBoxDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
-            var builder = new ContainerBuilder();
-            builder.Populate(serviceCollection);
-            return new AutofacServiceProvider(builder.Build());
+            return serviceCollection.UseStashbox();
         }
     }
 }

--- a/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StashBox.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using StructureMap;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {

--- a/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
@@ -6,7 +6,7 @@ using StructureMap;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class StructureMapDependencyInjectionSpecificationTests: SkipableDependencyInjectionSpecificationTests
+    public class StructureMapDependencyInjectionSpecificationTests: SkippableDependencyInjectionSpecificationTests
     {
         public override string[] SkippedTests => new[]
         {

--- a/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
@@ -1,0 +1,29 @@
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using StructureMap;
+
+namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public class StructureMapDependencyInjectionSpecificationTests: SkipableDependencyInjectionSpecificationTests
+    {
+        public override string[] SkippedTests => new[]
+        {
+            "DisposesInReverseOrderOfCreation",
+            "ResolvesMixedOpenClosedGenericsAsEnumerable"
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
+        {
+            var container = new Container();
+            container.Configure(config =>
+            {
+                config.Populate(serviceCollection);
+            });
+
+            return container.GetInstance<IServiceProvider>();
+        }
+    }
+}

--- a/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/StructureMap.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using StructureMap;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification

--- a/src/DependencyInjection/DI.External.Tests/test/Unity.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Unity.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class UnityDependencyInjectionSpecificationTests: SkipableDependencyInjectionSpecificationTests
+    public class UnityDependencyInjectionSpecificationTests: SkippableDependencyInjectionSpecificationTests
     {
         public override string[] SkippedTests => new String[0]
         {

--- a/src/DependencyInjection/DI.External.Tests/test/Unity.cs
+++ b/src/DependencyInjection/DI.External.Tests/test/Unity.cs
@@ -1,0 +1,19 @@
+    // Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection.Specification
+{
+    public class UnityDependencyInjectionSpecificationTests: SkipableDependencyInjectionSpecificationTests
+    {
+        public override string[] SkippedTests => new String[0]
+        {
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
+        {
+            return Unity.Microsoft.DependencyInjection.ServiceProviderExtensions.BuildServiceProvider(serviceCollection);
+        }
+    }
+}

--- a/src/DependencyInjection/DependencyInjection.sln
+++ b/src/DependencyInjection/DependencyInjection.sln
@@ -1,0 +1,120 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DI", "DI", "{B4373F1E-3E9F-49DA-B1BD-CA440932CF52}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection.Performance", "DI\perf\Microsoft.Extensions.DependencyInjection.Performance.csproj", "{27C11410-9269-452B-ACF6-BC2E46695DC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection", "DI\src\Microsoft.Extensions.DependencyInjection.csproj", "{B694E607-F2DA-42D8-A924-945C69AB52EE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection.Tests", "DI\test\Microsoft.Extensions.DependencyInjection.Tests.csproj", "{EB4BAB4A-49F2-4597-936F-D444C332F6DF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DI.Abstractions", "DI.Abstractions", "{A53A122C-0656-4EF9-B3C4-38AB80DFC9A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection.Abstractions", "DI.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj", "{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DI.External.Tests", "DI.External.Tests", "{2AB3CFC2-9E7D-4928-ADC3-07DC42778DC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests", "DI.External.Tests\test\Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj", "{61A474DD-2FA9-47CE-BA61-D5D441C6924B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DI.Specification.Tests", "DI.Specification.Tests", "{DCE2FA14-0ADC-4774-AAFB-604FE4AB423A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection.Specification.Tests", "DI.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj", "{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Debug|x64.Build.0 = Debug|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Debug|x86.Build.0 = Debug|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Release|x64.ActiveCfg = Release|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Release|x64.Build.0 = Release|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Release|x86.ActiveCfg = Release|Any CPU
+		{27C11410-9269-452B-ACF6-BC2E46695DC3}.Release|x86.Build.0 = Release|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Debug|x64.Build.0 = Debug|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Debug|x86.Build.0 = Debug|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Release|x64.ActiveCfg = Release|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Release|x64.Build.0 = Release|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Release|x86.ActiveCfg = Release|Any CPU
+		{B694E607-F2DA-42D8-A924-945C69AB52EE}.Release|x86.Build.0 = Release|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Release|x64.Build.0 = Release|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF}.Release|x86.Build.0 = Release|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Debug|x64.Build.0 = Debug|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Debug|x86.Build.0 = Debug|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Release|x64.ActiveCfg = Release|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Release|x64.Build.0 = Release|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Release|x86.ActiveCfg = Release|Any CPU
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D}.Release|x86.Build.0 = Release|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Debug|x64.Build.0 = Debug|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Debug|x86.Build.0 = Debug|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Release|x64.ActiveCfg = Release|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Release|x64.Build.0 = Release|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Release|x86.ActiveCfg = Release|Any CPU
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B}.Release|x86.Build.0 = Release|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Release|x64.Build.0 = Release|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{27C11410-9269-452B-ACF6-BC2E46695DC3} = {B4373F1E-3E9F-49DA-B1BD-CA440932CF52}
+		{B694E607-F2DA-42D8-A924-945C69AB52EE} = {B4373F1E-3E9F-49DA-B1BD-CA440932CF52}
+		{EB4BAB4A-49F2-4597-936F-D444C332F6DF} = {B4373F1E-3E9F-49DA-B1BD-CA440932CF52}
+		{BD0501CE-C2CB-46A7-9BF4-ACEF9D5F256D} = {A53A122C-0656-4EF9-B3C4-38AB80DFC9A3}
+		{61A474DD-2FA9-47CE-BA61-D5D441C6924B} = {2AB3CFC2-9E7D-4928-ADC3-07DC42778DC8}
+		{F1F351F3-B92F-49DE-93E1-DD7FFC137C0F} = {DCE2FA14-0ADC-4774-AAFB-604FE4AB423A}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
So when there is a request to add a new feature to spec tests we can easily verify against external container implementations.

This list is a combination between README.md from this project and @jbogard's MediatR samples (https://github.com/jbogard/MediatR/tree/master/samples)

Some implementations do not pass all the tests so I've added a way to skip test methods per container. It's not ideal, but works.

I'll try to update versions every time new spec test is added but feel free to send PRs if you have a new release.