### PR TITLE
Fix running published analyzer tests

### DIFF
--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
@@ -80,18 +80,17 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
                     if (File.Exists(dll))
                     {
                         assemblies.Add(dll);
-                        return true;
+                        continue;
                     }
 
                     dll = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(assembly));
                     if (File.Exists(dll))
                     {
                         assemblies.Add(dll);
-                        return true;
                     }
                 }
 
-                return false;
+                return assemblies.Count > 0;
             }
         }
     }


### PR DESCRIPTION
We were resolving only first assembly from compilation libraries instead of all of them.
Fixes: https://github.com/aspnet/Extensions/issues/625