### PR TITLE
Add LoggerFactory.Create method

### DIFF
--- a/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
+++ b/src/Logging/Logging.EventSource/test/EventSourceLoggerTest.cs
@@ -15,20 +15,16 @@ namespace Microsoft.Extensions.Logging.Test
 {
     public class EventSourceLoggerTest: IDisposable
     {
-        private ServiceProvider _serviceProvider;
+        private ILoggerFactory _loggerFactory;
 
         protected ILoggerFactory CreateLoggerFactory()
         {
-            _serviceProvider = new ServiceCollection()
-                .AddLogging(builder => builder.AddEventSourceLogger())
-                .BuildServiceProvider();
-
-            return _serviceProvider.GetRequiredService<ILoggerFactory>();
+            return _loggerFactory = LoggerFactory.Create(builder => builder.AddEventSourceLogger());
         }
 
         public void Dispose()
         {
-            _serviceProvider?.Dispose();
+            _loggerFactory?.Dispose();
         }
 
         [Fact]

--- a/src/Logging/Logging/src/LoggerFactory.cs
+++ b/src/Logging/Logging/src/LoggerFactory.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         public static ILoggerFactory Create(Action<ILoggingBuilder> configure)
         {
-            IServiceCollection serviceCollection = new ServiceCollection();
+            var serviceCollection = new ServiceCollection();
             serviceCollection.AddLogging(configure);
             var serviceProvider = serviceCollection.BuildServiceProvider();
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
@@ -222,7 +222,7 @@ namespace Microsoft.Extensions.Logging
 
         private class DisposingLoggerFactory: ILoggerFactory
         {
-            private ILoggerFactory _loggerFactory;
+            private readonly ILoggerFactory _loggerFactory;
 
             private readonly ServiceProvider _serviceProvider;
 
@@ -234,7 +234,6 @@ namespace Microsoft.Extensions.Logging
 
             public void Dispose()
             {
-                _loggerFactory.Dispose();
                 _serviceProvider.Dispose();
             }
 

--- a/src/Logging/Logging/src/LoggerFactory.cs
+++ b/src/Logging/Logging/src/LoggerFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Logging
@@ -41,6 +42,18 @@ namespace Microsoft.Extensions.Logging
 
             _changeTokenRegistration = filterOption.OnChange(RefreshFilters);
             RefreshFilters(filterOption.CurrentValue);
+        }
+
+        /// <summary>
+        /// Creates new instance of <see cref="ILoggerFactory"/> configured using provided <paramref name="configure"/> delegate.
+        /// </summary>
+        public static ILoggerFactory Create(Action<ILoggingBuilder> configure)
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(configure);
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+            return new DisposingLoggerFactory(loggerFactory, serviceProvider);
         }
 
         private void RefreshFilters(LoggerFilterOptions filterOptions)
@@ -205,6 +218,35 @@ namespace Microsoft.Extensions.Logging
         {
             public ILoggerProvider Provider;
             public bool ShouldDispose;
+        }
+
+        private class DisposingLoggerFactory: ILoggerFactory
+        {
+            private ILoggerFactory _loggerFactory;
+
+            private readonly ServiceProvider _serviceProvider;
+
+            public DisposingLoggerFactory(ILoggerFactory loggerFactory, ServiceProvider serviceProvider)
+            {
+                _loggerFactory = loggerFactory;
+                _serviceProvider = serviceProvider;
+            }
+
+            public void Dispose()
+            {
+                _loggerFactory.Dispose();
+                _serviceProvider.Dispose();
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return _loggerFactory.CreateLogger(categoryName);
+            }
+
+            public void AddProvider(ILoggerProvider provider)
+            {
+                _loggerFactory.AddProvider(provider);
+            }
         }
     }
 }

--- a/src/Logging/Logging/src/Microsoft.Extensions.Logging.csproj
+++ b/src/Logging/Logging/src/Microsoft.Extensions.Logging.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../../shared/*.cs" />
 
     <Reference Include="Microsoft.Extensions.Configuration.Binder" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/Logging/samples/SampleApp/Program.cs
+++ b/src/Logging/samples/SampleApp/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,9 +12,7 @@ namespace SampleApp
 {
     public class Program
     {
-        private readonly ILogger _logger;
-
-        public Program()
+        public static void Main(string[] args)
         {
             var loggingConfiguration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
@@ -23,82 +21,67 @@ namespace SampleApp
 
             // A Web App based program would configure logging via the WebHostBuilder.
             // Create a logger factory with filters that can be applied across all logger providers.
-            var serviceCollection = new ServiceCollection()
-                .AddLogging(builder =>
-                {
-                    builder
-                        .AddConfiguration(loggingConfiguration.GetSection("Logging"))
-                        .AddFilter("Microsoft", LogLevel.Warning)
-                        .AddFilter("System", LogLevel.Warning)
-                        .AddFilter("SampleApp.Program", LogLevel.Debug)
-                        .AddConsole();
-#if NET461
-                    builder.AddEventLog();
-#elif NETCOREAPP3_0
-#else
-#error Target framework needs to be updated
-#endif
-                });
-
-            // providers may be added to a LoggerFactory before any loggers are created
-
-
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-            // getting the logger using the class's name is conventional
-            _logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-        }
-
-        public static void Main(string[] args)
-        {
-            new Program().Execute(args);
-        }
-
-        public void Execute(string[] args)
-        {
-            _logger.LogInformation("Starting");
-
-            var startTime = DateTimeOffset.Now;
-            _logger.LogInformation(1, "Started at '{StartTime}' and 0x{Hello:X} is hex of 42", startTime, 42);
-            // or
-            _logger.ProgramStarting(startTime, 42);
-
-            using (_logger.PurchaseOrderScope("00655321"))
+            var loggerFactory = LoggerFactory.Create(builder =>
             {
-                try
-                {
-                    throw new Exception("Boom");
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogCritical(1, ex, "Unexpected critical error starting application");
-                    _logger.LogError(1, ex, "Unexpected error");
-                    _logger.LogWarning(1, ex, "Unexpected warning");
-                }
+                builder
+                    .AddConfiguration(loggingConfiguration.GetSection("Logging"))
+                    .AddFilter("Microsoft", LogLevel.Warning)
+                    .AddFilter("System", LogLevel.Warning)
+                    .AddFilter("SampleApp.Program", LogLevel.Debug)
+                    .AddConsole()
+                    .AddEventLog();
+            });
 
-                using (_logger.BeginScope("Main"))
+            // Make sure to dispose ILoggerFactory
+            using (loggerFactory)
+            {
+                var logger = loggerFactory.CreateLogger<Program>();
+
+                logger.LogInformation("Starting");
+
+                var startTime = DateTimeOffset.Now;
+                logger.LogInformation(1, "Started at '{StartTime}' and 0x{Hello:X} is hex of 42", startTime, 42);
+                // or
+                logger.ProgramStarting(startTime, 42);
+
+                using (logger.PurchaseOrderScope("00655321"))
                 {
-
-                    _logger.LogInformation("Waiting for user input");
-
-                    string input;
-                    do
+                    try
                     {
-                        Console.WriteLine("Enter some test to log more, or 'quit' to exit.");
-                        input = Console.ReadLine();
-
-                        _logger.LogInformation("User typed '{input}' on the command line", input);
-                        _logger.LogWarning("The time is now {Time}, it's getting late!", DateTimeOffset.Now);
+                        throw new Exception("Boom");
                     }
-                    while (input != "quit");
+                    catch (Exception ex)
+                    {
+                        logger.LogCritical(1, ex, "Unexpected critical error starting application");
+                        logger.LogError(1, ex, "Unexpected error");
+                        logger.LogWarning(1, ex, "Unexpected warning");
+                    }
+
+                    using (logger.BeginScope("Main"))
+                    {
+
+                        logger.LogInformation("Waiting for user input");
+
+                        string input;
+                        do
+                        {
+                            Console.WriteLine("Enter some test to log more, or 'quit' to exit.");
+                            input = Console.ReadLine();
+
+                            logger.LogInformation("User typed '{input}' on the command line", input);
+                            logger.LogWarning("The time is now {Time}, it's getting late!", DateTimeOffset.Now);
+                        }
+                        while (input != "quit");
+                    }
                 }
+
+                var endTime = DateTimeOffset.Now;
+                logger.LogInformation(2, "Stopping at '{StopTime}'", endTime);
+                // or
+                logger.ProgramStopping(endTime);
+
+                logger.LogInformation("Stopping");
             }
-
-            var endTime = DateTimeOffset.Now;
-            _logger.LogInformation(2, "Stopping at '{StopTime}'", endTime);
-            // or
-            _logger.ProgramStopping(endTime);
-
-            _logger.LogInformation("Stopping");
         }
     }
 }

--- a/src/Logging/samples/SampleApp/SampleApp.csproj
+++ b/src/Logging/samples/SampleApp/SampleApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
@@ -19,9 +19,6 @@
     <Reference Include="Microsoft.Extensions.Logging.AzureAppServices" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.Extensions.Logging.EventLog" />
   </ItemGroup>
 

--- a/src/Logging/test/LoggerFactoryTest.cs
+++ b/src/Logging/test/LoggerFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -176,6 +177,19 @@ namespace Microsoft.Extensions.Logging.Test
                     "Scope2",
                     "Message2",
                 });
+        }
+
+        [Fact]
+        public void CreateDisposeDisposesInnerServiceProvider()
+        {
+            var disposed = false;
+            var provider = new Mock<ILoggerProvider>();
+            provider.Setup(p => p.Dispose()).Callback(() => disposed = true);
+
+            var factory = LoggerFactory.Create(builder => builder.Services.AddSingleton(_=> provider.Object));
+            factory.Dispose();
+
+            Assert.True(disposed);
         }
 
         private class InternalScopeLoggerProvider : ILoggerProvider, ILogger


### PR DESCRIPTION
Adds the `LoggerFactory.Create` that simplifies LoggerFactory creation in cases where dependency injection is not used in the application.

So the pattern becomes:

```C#
var loggerFactory = LoggerFactory.Create(builder => 
    builder.AddEventSourceLogger()
           .AddConsole()
           .AddFilter(...));
```

Fixes: https://github.com/aspnet/Extensions/issues/615
