### PR TITLE
Fix path to embedded manifest task file

### DIFF
--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.nuspec
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.nuspec
@@ -27,7 +27,5 @@
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting\" />
     <file src="$TaskAssemblyNetStandard$" target="tasks\netstandard2.0\$AssemblyName$.Manifest.Task.dll" />
     <file src="$TaskSymbolNetStandard$" target="tasks\netstandard2.0\$AssemblyName$.Manifest.Task.pdb" />
-    <file src="$TaskAssemblyNet461$" target="tasks\net461\$AssemblyName$.Manifest.Task.dll" />
-    <file src="$TaskSymbolNet461$" target="tasks\net461\$AssemblyName$.Manifest.Task.pdb" />
   </files>
 </package>

--- a/src/FileProviders/Embedded/src/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.props
+++ b/src/FileProviders/Embedded/src/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.props
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_FileProviderTaskFolder Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_FileProviderTaskFolder>
-    <_FileProviderTaskFolder Condition="'$(MSBuildRuntimeType)' != 'Core'">net461</_FileProviderTaskFolder>
-    <_FileProviderTaskAssembly>$(MSBuildThisFileDirectory)..\..\tasks\$(_FileProviderTaskFolder)\Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.dll</_FileProviderTaskAssembly>
+    <_FileProviderTaskAssembly>$(MSBuildThisFileDirectory)..\..\tasks\netstandard2.0\Microsoft.Extensions.FileProviders.Embedded.Manifest.Task.dll</_FileProviderTaskAssembly>
   </PropertyGroup>
 
   <UsingTask


### PR DESCRIPTION
Fixes #815. The targets file is pointing to a task assembly which does not exist.