### PR TITLE
Clean up event handlers and other subscriptions

### DIFF
--- a/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             _shutdownBlock.Set();
 
-            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
-            Console.CancelKeyPress += OnCancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+            Console.CancelKeyPress -= OnCancelKeyPress;
 
             _applicationStartedRegistration.Dispose();
         }

--- a/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Hosting.Internal
     public class ConsoleLifetime : IHostLifetime, IDisposable
     {
         private readonly ManualResetEvent _shutdownBlock = new ManualResetEvent(false);
+        private CancellationTokenRegistration _applicationStartedRegistration;
 
         public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostingEnvironment environment, IApplicationLifetime applicationLifetime)
             : this(options, environment, applicationLifetime, NullLoggerFactory.Instance) { }
@@ -40,27 +41,37 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             if (!Options.SuppressStatusMessages)
             {
-                ApplicationLifetime.ApplicationStarted.Register(() =>
+                _applicationStartedRegistration = ApplicationLifetime.ApplicationStarted.Register(state =>
                 {
-                    Logger.LogInformation("Application started. Press Ctrl+C to shut down.");
-                    Logger.LogInformation("Hosting environment: {envName}", Environment.EnvironmentName);
-                    Logger.LogInformation("Content root path: {contentRoot}", Environment.ContentRootPath);
-                });
+                    ((ConsoleLifetime)state).OnApplicationStarted();
+                },
+                this);
             }
 
-            AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) =>
-            {
-                ApplicationLifetime.StopApplication();
-                _shutdownBlock.WaitOne();
-            };
-            Console.CancelKeyPress += (sender, e) =>
-            {
-                e.Cancel = true;
-                ApplicationLifetime.StopApplication();
-            };
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            Console.CancelKeyPress += OnCancelKeyPress;
 
             // Console applications start immediately.
             return Task.CompletedTask;
+        }
+
+        private void OnApplicationStarted()
+        {
+            Logger.LogInformation("Application started. Press Ctrl+C to shut down.");
+            Logger.LogInformation("Hosting environment: {envName}", Environment.EnvironmentName);
+            Logger.LogInformation("Content root path: {contentRoot}", Environment.ContentRootPath);
+        }
+
+        private void OnProcessExit(object sender, EventArgs e)
+        {
+            ApplicationLifetime.StopApplication();
+            _shutdownBlock.WaitOne();
+        }
+
+        private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            e.Cancel = true;
+            ApplicationLifetime.StopApplication();
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
@@ -72,6 +83,11 @@ namespace Microsoft.Extensions.Hosting.Internal
         public void Dispose()
         {
             _shutdownBlock.Set();
+
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            Console.CancelKeyPress += OnCancelKeyPress;
+
+            _applicationStartedRegistration.Dispose();
         }
     }
 }


### PR DESCRIPTION
- Also removed the closure when logging
- Captured _applicationStartedRegistration though it shouldn't strictly be necessary since the CTS *should* be disposed when the host is disposed

This change was inspired by looking at memory dumps and seeing this:

![image](https://user-images.githubusercontent.com/95136/50344809-79418300-04e1-11e9-8059-f6ebcfccda18.png)

Maybe worth doing in the WebHost as well (but we're moving away from that)