### PR TITLE
Fix aspnet/Extensions#639

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DependencyInjection/HealthCheckServiceCollectionExtensions.cs
+++ b/src/HealthChecks/HealthChecks/src/DependencyInjection/HealthCheckServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IHealthChecksBuilder AddHealthChecks(this IServiceCollection services)
         {
             services.TryAddSingleton<HealthCheckService, DefaultHealthCheckService>();
-            services.TryAddSingleton<IHostedService, HealthCheckPublisherHostedService>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, HealthCheckPublisherHostedService>());
             return new HealthChecksBuilder(services);
         }
     }

--- a/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DependencyInjection/ServiceCollectionExtensionsTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -38,6 +40,57 @@ namespace Microsoft.Extensions.DependencyInjection
                     Assert.Null(actual.ImplementationInstance);
                     Assert.Null(actual.ImplementationFactory);
                 });
+        }
+
+        [Fact] // see: https://github.com/aspnet/Extensions/issues/639
+        public void AddHealthChecks_RegistersPublisherService_WhenOtherHostedServicesRegistered()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddSingleton<IHostedService, DummyHostedService>();
+            services.AddHealthChecks();
+
+            // Assert
+            Assert.Collection(services.OrderBy(s => s.ServiceType.FullName).ThenBy(s => s.ImplementationType.FullName),
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(HealthCheckService), actual.ServiceType);
+                    Assert.Equal(typeof(DefaultHealthCheckService), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IHostedService), actual.ServiceType);
+                    Assert.Equal(typeof(DummyHostedService), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                },
+                actual =>
+                {
+                    Assert.Equal(ServiceLifetime.Singleton, actual.Lifetime);
+                    Assert.Equal(typeof(IHostedService), actual.ServiceType);
+                    Assert.Equal(typeof(HealthCheckPublisherHostedService), actual.ImplementationType);
+                    Assert.Null(actual.ImplementationInstance);
+                    Assert.Null(actual.ImplementationFactory);
+                });
+        }
+
+        private class DummyHostedService : IHostedService
+        {
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
The issue is that the hosted service would not be registered if other
hosted services are present. The fix is to use TryAddEnumble so that we
allow multipled `IHostedService`s but not multiple instances of
the same type.