### PR TITLE
Made changes to ChangeToken.OnChange

### DIFF
--- a/src/Primitives/src/ChangeToken.cs
+++ b/src/Primitives/src/ChangeToken.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.Threading;
 
 namespace Microsoft.Extensions.Primitives
 {
@@ -27,26 +29,7 @@ namespace Microsoft.Extensions.Primitives
                 throw new ArgumentNullException(nameof(changeTokenConsumer));
             }
 
-            Action<object> callback = null;
-            callback = (s) =>
-            {
-                // The order here is important. We need to take the token and then apply our changes BEFORE
-                // registering. This prevents us from possible having two change updates to process concurrently.
-                //
-                // If the token changes after we take the token, then we'll process the update immediately upon
-                // registering the callback.
-                var t = changeTokenProducer();
-                try
-                {
-                    changeTokenConsumer();
-                }
-                finally // We always want to ensure the callback is registered
-                {
-                    t.RegisterChangeCallback(callback, null);
-                }
-            };
-
-            return changeTokenProducer().RegisterChangeCallback(callback, null);
+            return new ChangeTokenRegistration<object>(changeTokenProducer, state => ((Action)state)(), changeTokenConsumer);
         }
 
         /// <summary>
@@ -67,26 +50,91 @@ namespace Microsoft.Extensions.Primitives
                 throw new ArgumentNullException(nameof(changeTokenConsumer));
             }
 
-            Action<object> callback = null;
-            callback = (s) =>
+            return new ChangeTokenRegistration<TState>(changeTokenProducer, changeTokenConsumer, state);
+        }
+
+        private class ChangeTokenRegistration<TState> : IDisposable
+        {
+            private readonly Func<IChangeToken> _changeTokenProducer;
+            private readonly Action<TState> _changeTokenConsumer;
+            private readonly TState _state;
+            private object _disposable;
+
+            private static readonly object _disposedSentinel = new object();
+
+            public ChangeTokenRegistration(Func<IChangeToken> changeTokenProducer, Action<TState> changeTokenConsumer, TState state)
+            {
+                _changeTokenProducer = changeTokenProducer;
+                _changeTokenConsumer = changeTokenConsumer;
+                _state = state;
+
+                var token = changeTokenProducer();
+
+                RegisterChangeTokenCallback(token);
+            }
+
+            private void OnChangeTokenFired()
             {
                 // The order here is important. We need to take the token and then apply our changes BEFORE
                 // registering. This prevents us from possible having two change updates to process concurrently.
                 //
                 // If the token changes after we take the token, then we'll process the update immediately upon
                 // registering the callback.
-                var t = changeTokenProducer();
+                var token = _changeTokenProducer();
+
                 try
                 {
-                    changeTokenConsumer((TState)s);
+                    _changeTokenConsumer(_state);
                 }
-                finally // We always want to ensure the callback is registered
+                finally
                 {
-                    t.RegisterChangeCallback(callback, s);
+                    // We always want to ensure the callback is registered
+                    RegisterChangeTokenCallback(token);
                 }
-            };
+            }
 
-            return changeTokenProducer().RegisterChangeCallback(callback, state);
+            private void RegisterChangeTokenCallback(IChangeToken token)
+            {
+                var registraton = token.RegisterChangeCallback(s => ((ChangeTokenRegistration<TState>)s).OnChangeTokenFired(), this);
+
+                SetDisposable(registraton);
+            }
+
+            private void SetDisposable(IDisposable disposable)
+            {
+                // We don't want to transition from _disposedSentinel => anything since it's terminal
+                // but we want to allow going from previously assigned disposable, to another
+                // disposable. The assumption here is that we don't have to dispose the registration if an IChangeToken
+                // fires.
+                var current = Volatile.Read(ref _disposable);
+
+                var previous = Interlocked.CompareExchange(ref _disposable, disposable, current);
+
+                if (previous == _disposedSentinel)
+                {
+                    // The subscription was disposed so we dispose immediately and return
+                    disposable.Dispose();
+                }
+                else if (previous == current)
+                {
+                    // We successfuly assigned the _disposable field to disposable
+                }
+                else
+                {
+                    // Sets can never overlap with other sets so we should never get into this situation
+                    Debug.Fail("Somebody else set the _disposable");
+                }
+            }
+
+            public void Dispose()
+            {
+                // If the previous value is disposable then dispose it, otherwise,
+                // now we've set the disposed sentinel
+                if (Interlocked.Exchange(ref _disposable, _disposedSentinel) is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Introduced ChangeTokenRegistration to reduce allocations and managed the the registration to the underlying change token.
- Support dispose working if the token fires more than once

cc @stephentoub to check if my lock free code is BS 😄 

Fixes #558
