### PR TITLE
Reduce event source logger allocations

### DIFF
--- a/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
@@ -191,14 +191,11 @@ namespace Microsoft.Extensions.Logging.EventSource
         {
             if (state is IReadOnlyList<KeyValuePair<string, object>> keyValuePairs)
             {
-                var arguments = new List<KeyValuePair<string, string>>();
-                for (int i = 0; i < keyValuePairs.Count; i++)
+                var arguments = new KeyValuePair<string, string>[keyValuePairs.Count];
+                for (var i = 0; i < keyValuePairs.Count; i++)
                 {
-                    var keyValue = keyValuePairs[i];
-                    if (keyValue.Key != null)
-                    {
-                        arguments.Add(new KeyValuePair<string, string>(keyValue.Key, keyValue.Value?.ToString()));
-                    }
+                    var keyValuePair = keyValuePairs[i];
+                    arguments[i] = new KeyValuePair<string, string>(keyValuePair.Key, keyValuePair.Value?.ToString());
                 }
                 return arguments;
             }

--- a/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
@@ -128,7 +128,8 @@ namespace Microsoft.Extensions.Logging.EventSource
                 return new ActivityScope(_eventSource, CategoryName, id, _factoryID, true);
             }
 
-            if (_eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.Message))
+            if (_eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.Message) ||
+                _eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.FormattedMessage))
             {
                 IEnumerable<KeyValuePair<string, string>> arguments = GetProperties(state);
                 _eventSource.ActivityStart(id, _factoryID, CategoryName, arguments);

--- a/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
@@ -70,8 +70,8 @@ namespace Microsoft.Extensions.Logging.EventSource
             // See if they want the message as its component parts.
             if (_eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.Message))
             {
-                ExceptionInfo exceptionInfo = GetExceptionInfo(exception);
-                IEnumerable<KeyValuePair<string, string>> arguments = GetProperties(state);
+                var exceptionInfo = GetExceptionInfo(exception);
+                var arguments = GetProperties(state);
 
                 _eventSource.Message(
                     logLevel,
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging.EventSource
                 if (exception != null)
                 {
                     var exceptionInfo = GetExceptionInfo(exception);
-                    var exceptionInfoData = new KeyValuePair<string, string>[]
+                    var exceptionInfoData = new []
                     {
                         new KeyValuePair<string, string>("TypeName", exceptionInfo.TypeName),
                         new KeyValuePair<string, string>("Message", exceptionInfo.Message),
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Logging.EventSource
                     };
                     exceptionJson = ToJson(exceptionInfoData);
                 }
-                IEnumerable<KeyValuePair<string, string>> arguments = GetProperties(state);
+                var arguments = GetProperties(state);
                 _eventSource.MessageJson(
                     logLevel,
                     _factoryID,
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Logging.EventSource
             // If JsonMessage is on, use JSON format
             if (_eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.JsonMessage))
             {
-                IEnumerable<KeyValuePair<string, string>> arguments = GetProperties(state);
+                var arguments = GetProperties(state);
                 _eventSource.ActivityJsonStart(id, _factoryID, CategoryName, ToJson(arguments));
                 return new ActivityScope(_eventSource, CategoryName, id, _factoryID, true);
             }
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Logging.EventSource
             if (_eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.Message) ||
                 _eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.FormattedMessage))
             {
-                IEnumerable<KeyValuePair<string, string>> arguments = GetProperties(state);
+                var arguments = GetProperties(state);
                 _eventSource.ActivityStart(id, _factoryID, CategoryName, arguments);
                 return new ActivityScope(_eventSource, CategoryName, id, _factoryID, false);
             }
@@ -181,27 +181,20 @@ namespace Microsoft.Extensions.Logging.EventSource
         /// <remarks>ETW does not support a concept of a null value. So we use an un-initialized object if there is no exception in the event data.</remarks>
         private ExceptionInfo GetExceptionInfo(Exception exception)
         {
-            var exceptionInfo = new ExceptionInfo();
-            if (exception != null)
-            {
-                exceptionInfo.TypeName = exception.GetType().FullName;
-                exceptionInfo.Message = exception.Message;
-                exceptionInfo.HResult = exception.HResult;
-                exceptionInfo.VerboseMessage = exception.ToString();
-            }
-            return exceptionInfo;
+            return exception != null ? new ExceptionInfo(exception) : ExceptionInfo.Empty;
         }
 
         /// <summary>
         /// Converts an ILogger state object into a set of key-value pairs (That can be send to a EventSource)
         /// </summary>
-        private IEnumerable<KeyValuePair<string, string>> GetProperties(object state)
+        private IReadOnlyList<KeyValuePair<string, string>> GetProperties(object state)
         {
-            if (state is IEnumerable<KeyValuePair<string, object>> keyValuePairs)
+            if (state is IReadOnlyList<KeyValuePair<string, object>> keyValuePairs)
             {
                 var arguments = new List<KeyValuePair<string, string>>();
-                foreach (var keyValue in keyValuePairs)
+                for (int i = 0; i < keyValuePairs.Count; i++)
                 {
+                    var keyValue = keyValuePairs[i];
                     if (keyValue.Key != null)
                     {
                         arguments.Add(new KeyValuePair<string, string>(keyValue.Key, keyValue.Value?.ToString()));
@@ -213,15 +206,16 @@ namespace Microsoft.Extensions.Logging.EventSource
             return Array.Empty<KeyValuePair<string, string>>();
         }
 
-        private string ToJson(IEnumerable<KeyValuePair<string, string>> keyValues)
+        private string ToJson(IReadOnlyList<KeyValuePair<string, string>> keyValues)
         {
             var sw = new StringWriter();
             var writer = new JsonTextWriter(sw);
             writer.DateFormatString = "O"; // ISO 8601
 
             writer.WriteStartObject();
-            foreach (var keyValue in keyValues)
+            for (int i = 0; i < keyValues.Count; i++)
             {
+                var keyValue = keyValues[i];
                 writer.WritePropertyName(keyValue.Key, true);
                 writer.WriteValue(keyValue.Value);
             }

--- a/src/Logging/Logging.EventSource/src/ExceptionInfo.cs
+++ b/src/Logging/Logging.EventSource/src/ExceptionInfo.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.Extensions.Logging.EventSource
 {
@@ -9,9 +11,23 @@ namespace Microsoft.Extensions.Logging.EventSource
     [System.Diagnostics.Tracing.EventData(Name ="ExceptionInfo")]
     internal class ExceptionInfo
     {
-        public string TypeName { get; set; }
-        public string Message { get; set; }
-        public int HResult { get; set; }
-        public string VerboseMessage { get; set; } // This is the ToString() of the Exception
+        public static ExceptionInfo Empty { get; } = new ExceptionInfo();
+
+        private ExceptionInfo()
+        {
+        }
+
+        public ExceptionInfo(Exception exception)
+        {
+            TypeName = exception.GetType().FullName;
+            Message = exception.Message;
+            HResult = exception.HResult;
+            VerboseMessage = exception.ToString();
+        }
+
+        public string TypeName { get; }
+        public string Message { get; }
+        public int HResult { get; }
+        public string VerboseMessage { get; } // This is the ToString() of the Exception
     }
 }

--- a/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
@@ -457,7 +457,8 @@ namespace Microsoft.Extensions.Logging.EventSource
                 }
 #endif
 
-                if (pinnedString != null) {
+                if (pinnedString != null)
+                {
                     eventData.DataPointer = (IntPtr)pinnedString;
                     eventData.Size = checked((str.Length + 1) * sizeof(char)); // size is specified in bytes, including null wide char
                 }

--- a/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/Logging/Logging.EventSource/src/LoggingEventSource.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
 
@@ -119,9 +121,27 @@ namespace Microsoft.Extensions.Logging.EventSource
         /// This only gives you the human reasable formatted message.
         /// </summary>
         [Event(1, Keywords = Keywords.FormattedMessage, Level = EventLevel.LogAlways)]
-        internal void FormattedMessage(LogLevel Level, int FactoryID, string LoggerName, string EventId, string FormattedMessage)
+        internal unsafe void FormattedMessage(LogLevel Level, int FactoryID, string LoggerName, int EventId, string EventName, string FormattedMessage)
         {
-            WriteEvent(1, Level, FactoryID, LoggerName, EventId, FormattedMessage);
+            if (IsEnabled())
+            {
+                fixed (char* loggerName = LoggerName)
+                fixed (char* eventName = EventName)
+                fixed (char* formattedMessage = FormattedMessage)
+                {
+                    const int eventDataCount = 6;
+                    var eventData = stackalloc EventData[eventDataCount];
+
+                    SetEventData(ref eventData[0], ref Level);
+                    SetEventData(ref eventData[1], ref FactoryID);
+                    SetEventData(ref eventData[2], ref LoggerName, loggerName);
+                    SetEventData(ref eventData[3], ref EventId);
+                    SetEventData(ref eventData[4], ref EventName, eventName);
+                    SetEventData(ref eventData[5], ref FormattedMessage, formattedMessage);
+
+                    WriteEventCore(1, eventDataCount, eventData);
+                }
+            }
         }
 
         /// <summary>
@@ -129,9 +149,12 @@ namespace Microsoft.Extensions.Logging.EventSource
         /// This gives you the logged information in a programatic format (arguments are key-value pairs)
         /// </summary>
         [Event(2, Keywords = Keywords.Message, Level = EventLevel.LogAlways)]
-        internal void Message(LogLevel Level, int FactoryID, string LoggerName, string EventId, ExceptionInfo Exception, IEnumerable<KeyValuePair<string, string>> Arguments)
+        internal void Message(LogLevel Level, int FactoryID, string LoggerName, int EventId, string EventName, ExceptionInfo Exception, IEnumerable<KeyValuePair<string, string>> Arguments)
         {
-            WriteEvent(2, Level, FactoryID, LoggerName, EventId, Exception, Arguments);
+            if (IsEnabled())
+            {
+                WriteEvent(2, Level, FactoryID, LoggerName, EventId, EventName, Exception, Arguments);
+            }
         }
 
         /// <summary>
@@ -140,31 +163,95 @@ namespace Microsoft.Extensions.Logging.EventSource
         [Event(3, Keywords = Keywords.Message | Keywords.FormattedMessage, Level = EventLevel.LogAlways, ActivityOptions = EventActivityOptions.Recursive)]
         internal void ActivityStart(int ID, int FactoryID, string LoggerName, IEnumerable<KeyValuePair<string, string>> Arguments)
         {
-            WriteEvent(3, ID, FactoryID, LoggerName, Arguments);
+            if (IsEnabled())
+            {
+                WriteEvent(3, ID, FactoryID, LoggerName, Arguments);
+            }
         }
 
         [Event(4, Keywords = Keywords.Message | Keywords.FormattedMessage, Level = EventLevel.LogAlways)]
-        internal void ActivityStop(int ID, int FactoryID, string LoggerName)
+        internal unsafe void ActivityStop(int ID, int FactoryID, string LoggerName)
         {
-            WriteEvent(4, ID, FactoryID, LoggerName);
+            if (IsEnabled())
+            {
+                fixed (char* loggerName = LoggerName)
+                {
+                    const int eventDataCount = 3;
+                    var eventData = stackalloc EventData[eventDataCount];
+
+                    SetEventData(ref eventData[0], ref ID);
+                    SetEventData(ref eventData[1], ref FactoryID);
+                    SetEventData(ref eventData[2], ref LoggerName, loggerName);
+
+                    WriteEventCore(4, eventDataCount, eventData);
+                }
+            }
         }
 
         [Event(5, Keywords = Keywords.JsonMessage, Level = EventLevel.LogAlways)]
-        internal void MessageJson(LogLevel Level, int FactoryID, string LoggerName, string EventId, string ExceptionJson, string ArgumentsJson)
+        internal unsafe void MessageJson(LogLevel Level, int FactoryID, string LoggerName, int EventId, string EventName, string ExceptionJson, string ArgumentsJson)
         {
-            WriteEvent(5, Level, FactoryID, LoggerName, EventId, ExceptionJson, ArgumentsJson);
+            if (IsEnabled())
+            {
+                fixed (char* loggerName = LoggerName)
+                fixed (char* eventName = EventName)
+                fixed (char* exceptionJson = ExceptionJson)
+                fixed (char* argumentsJson = ArgumentsJson)
+                {
+                    const int eventDataCount = 7;
+                    var eventData = stackalloc EventData[eventDataCount];
+
+                    SetEventData(ref eventData[0], ref Level);
+                    SetEventData(ref eventData[1], ref FactoryID);
+                    SetEventData(ref eventData[2], ref LoggerName, loggerName);
+                    SetEventData(ref eventData[3], ref EventId);
+                    SetEventData(ref eventData[4], ref EventName, eventName);
+                    SetEventData(ref eventData[5], ref ExceptionJson, exceptionJson);
+                    SetEventData(ref eventData[6], ref ArgumentsJson, argumentsJson);
+
+                    WriteEventCore(5, eventDataCount, eventData);
+                }
+            }
         }
 
         [Event(6, Keywords = Keywords.JsonMessage | Keywords.FormattedMessage, Level = EventLevel.LogAlways, ActivityOptions = EventActivityOptions.Recursive)]
-        internal void ActivityJsonStart(int ID, int FactoryID, string LoggerName, string ArgumentsJson)
+        internal unsafe void ActivityJsonStart(int ID, int FactoryID, string LoggerName, string ArgumentsJson)
         {
-            WriteEvent(6, ID, FactoryID, LoggerName, ArgumentsJson);
+            if (IsEnabled())
+            {
+                fixed (char* loggerName = LoggerName)
+                fixed (char* argumentsJson = ArgumentsJson)
+                {
+                    const int eventDataCount = 4;
+                    var eventData = stackalloc EventData[eventDataCount];
+
+                    SetEventData(ref eventData[0], ref ID);
+                    SetEventData(ref eventData[1], ref FactoryID);
+                    SetEventData(ref eventData[2], ref LoggerName, loggerName);
+                    SetEventData(ref eventData[3], ref ArgumentsJson, argumentsJson);
+
+                    WriteEventCore(6, eventDataCount, eventData);
+                }
+            }
         }
 
         [Event(7, Keywords = Keywords.JsonMessage | Keywords.FormattedMessage, Level = EventLevel.LogAlways)]
-        internal void ActivityJsonStop(int ID, int FactoryID, string LoggerName)
+        internal unsafe void ActivityJsonStop(int ID, int FactoryID, string LoggerName)
         {
-            WriteEvent(7, ID, FactoryID, LoggerName);
+            if (IsEnabled())
+            {
+                fixed (char* loggerName = LoggerName)
+                {
+                    const int eventDataCount = 3;
+                    var eventData = stackalloc EventData[eventDataCount];
+
+                    SetEventData(ref eventData[0], ref ID);
+                    SetEventData(ref eventData[1], ref FactoryID);
+                    SetEventData(ref eventData[2], ref LoggerName, loggerName);
+
+                    WriteEventCore(7, eventDataCount, eventData);
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -354,6 +441,37 @@ namespace Microsoft.Extensions.Logging.EventSource
         internal LoggerFilterRule[] GetFilterRules()
         {
             return _filterSpec;
+        }
+
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void SetEventData<T>(ref EventData eventData, ref T value, void* pinnedString = null)
+        {
+            if (typeof(T) == typeof(string))
+            {
+                var str = value as string;
+#if DEBUG
+                fixed (char* rePinnedString = str)
+                {
+                    Debug.Assert(pinnedString == rePinnedString);
+                }
+#endif
+
+                if (pinnedString != null) {
+                    eventData.DataPointer = (IntPtr)pinnedString;
+                    eventData.Size = checked((str.Length + 1) * sizeof(char)); // size is specified in bytes, including null wide char
+                }
+                else
+                {
+                    eventData.DataPointer = IntPtr.Zero;
+                    eventData.Size = 0;
+                }
+            }
+            else
+            {
+                eventData.DataPointer = (IntPtr)Unsafe.AsPointer(ref value);
+                eventData.Size = Unsafe.SizeOf<T>();
+            }
         }
     }
 }

--- a/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
@@ -4,6 +4,7 @@
     <Description>EventSource/EventListener logger provider implementation for Microsoft.Extensions.Logging.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>$(PackageTags);EventSource;ETW</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Logging/Logging/perf/EventSourceBenchmark.cs
+++ b/src/Logging/Logging/perf/EventSourceBenchmark.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.EventSource;
+
+namespace Microsoft.Extensions.Logging.Performance
+{
+    [AspNetCoreBenchmark]
+    public class EventSourceBenchmark: LoggingBenchmarkBase
+    {
+        private ILogger _logger;
+
+        private TestEventListener _listener;
+
+        [Params(true, false)]
+        public bool HasSubscribers { get; set; } = false;
+
+        [Params(true, false)]
+        public bool Json { get; set; } = false;
+
+        [Benchmark]
+        public void FilteredByLevel_InsideScope()
+        {
+            using (_logger.BeginScope("String scope"))
+            {
+                using (_logger.BeginScope(new SampleScope()))
+                {
+                    TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+                    TwoArgumentTraceMessage(_logger, 2, "string", Exception);
+                }
+            }
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(builder => builder.AddEventSourceLogger());
+
+            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
+
+            if (HasSubscribers)
+            {
+                _listener = new TestEventListener(Json ? LoggingEventSource.Keywords.JsonMessage : LoggingEventSource.Keywords.FormattedMessage);
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _listener?.Dispose();
+        }
+
+        private class TestEventListener : EventListener
+        {
+            private readonly EventKeywords _keywords;
+
+            public TestEventListener(EventKeywords keywords)
+            {
+                _keywords = keywords;
+            }
+
+            protected override void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource)
+            {
+                if (eventSource.Name == "Microsoft-Extensions-Logging")
+                {
+                    EnableEvents(eventSource, EventLevel.Verbose, _keywords);
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventWrittenArgs)
+            {
+            }
+        }
+    }
+}

--- a/src/Logging/Logging/perf/LoggingBenchmarkBase.cs
+++ b/src/Logging/Logging/perf/LoggingBenchmarkBase.cs
@@ -40,6 +40,23 @@ namespace Microsoft.Extensions.Logging.Performance
             }
         }
 
+        public class NoopLogger : ILogger
+        {
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+        }
+
         public class LoggerProvider<T>: ILoggerProvider
             where T: ILogger, new()
         {

--- a/src/Logging/Logging/perf/LoggingBenchmarkBase.cs
+++ b/src/Logging/Logging/perf/LoggingBenchmarkBase.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Logging.Performance
 {
@@ -23,6 +25,20 @@ namespace Microsoft.Extensions.Logging.Performance
                 return ex;
             }
         }))();
+
+        public class SampleScope : IEnumerable<KeyValuePair<string, object>>
+        {
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                yield return new KeyValuePair<string, object>("A", 1);
+                yield return new KeyValuePair<string, object>("B", "2");
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
 
         public class LoggerProvider<T>: ILoggerProvider
             where T: ILogger, new()

--- a/src/Logging/Logging/perf/LoggingOverheadBenchmark.cs
+++ b/src/Logging/Logging/perf/LoggingOverheadBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -68,23 +68,6 @@ namespace Microsoft.Extensions.Logging.Performance
             services.AddLogging();
             services.AddSingleton<ILoggerProvider, LoggerProvider<NoopLogger>>();
             _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
-        }
-    }
-
-    public class NoopLogger : ILogger
-    {
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-        {
-        }
-
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            return true;
-        }
-
-        public IDisposable BeginScope<TState>(TState state)
-        {
-            return null;
         }
     }
 }

--- a/src/Logging/Logging/perf/Microsoft.Extensions.Logging.Performance.csproj
+++ b/src/Logging/Logging/perf/Microsoft.Extensions.Logging.Performance.csproj
@@ -15,6 +15,7 @@
     <Reference Include="BenchmarkDotNet" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Logging.EventSource" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
https://github.com/aspnet/Extensions/issues/864

1. Use EventData
1. No-op more
1. Split event id and event name so we don't ToString it all the time