### PR TITLE
Validate that implemenation types are assignable to service types

### DIFF
--- a/src/DependencyInjection/DI/src/Properties/Resources.Designer.cs
+++ b/src/DependencyInjection/DI/src/Properties/Resources.Designer.cs
@@ -150,6 +150,34 @@ namespace Microsoft.Extensions.DependencyInjection
         internal static string FormatDirectScopedResolvedFromRootException(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("DirectScopedResolvedFromRootException"), p0, p1);
 
+        /// <summary>
+        /// Constant value of type '{0}' can't be converted to service type '{1}'
+        /// </summary>
+        internal static string ConstantCantBeConvertedToServiceType
+        {
+            get => GetString("ConstantCantBeConvertedToServiceType");
+        }
+
+        /// <summary>
+        /// Constant value of type '{0}' can't be converted to service type '{1}'
+        /// </summary>
+        internal static string FormatConstantCantBeConvertedToServiceType(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("ConstantCantBeConvertedToServiceType"), p0, p1);
+
+        /// <summary>
+        /// Implementation type '{0}' can't be converted to service type '{1}'
+        /// </summary>
+        internal static string ImplementationTypeCantBeConvertedToServiceType
+        {
+            get => GetString("ImplementationTypeCantBeConvertedToServiceType");
+        }
+
+        /// <summary>
+        /// Implementation type '{0}' can't be converted to service type '{1}'
+        /// </summary>
+        internal static string FormatImplementationTypeCantBeConvertedToServiceType(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("ImplementationTypeCantBeConvertedToServiceType"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/DependencyInjection/DI/src/Resources.resx
+++ b/src/DependencyInjection/DI/src/Resources.resx
@@ -150,4 +150,10 @@
   <data name="DirectScopedResolvedFromRootException" xml:space="preserve">
     <value>Cannot resolve {1} service '{0}' from root provider.</value>
   </data>
+  <data name="ConstantCantBeConvertedToServiceType" xml:space="preserve">
+    <value>Constant value of type '{0}' can't be converted to service type '{1}'</value>
+  </data>
+  <data name="ImplementationTypeCantBeConvertedToServiceType" xml:space="preserve">
+    <value>Implementation type '{0}' can't be converted to service type '{1}'</value>
+  </data>
 </root>

--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
@@ -357,11 +357,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var parameterCallSites = new ServiceCallSite[parameters.Length];
             for (var index = 0; index < parameters.Length; index++)
             {
-                var callSite = GetCallSite(parameters[index].ParameterType, callSiteChain);
+                var parameterType = parameters[index].ParameterType;
+                var callSite = GetCallSite(parameterType, callSiteChain);
 
                 if (callSite == null && ParameterDefaultValue.TryGetDefaultValue(parameters[index], out var defaultValue))
                 {
-                    callSite = new ConstantCallSite(serviceType, defaultValue);
+                    callSite = new ConstantCallSite(parameterType, defaultValue);
                 }
 
                 if (callSite == null)
@@ -369,7 +370,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     if (throwIfCallSiteNotFound)
                     {
                         throw new InvalidOperationException(Resources.FormatCannotResolveService(
-                            parameters[index].ParameterType,
+                            parameterType,
                             implementationType));
                     }
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ConstantCallSite.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public ConstantCallSite(Type serviceType, object defaultValue): base(ResultCache.None)
         {
+            if (defaultValue != null && !serviceType.IsInstanceOfType(defaultValue))
+            {
+                throw new ArgumentException(Resources.FormatConstantCantBeConvertedToServiceType(defaultValue.GetType(), serviceType));
+            }
+
             DefaultValue = defaultValue;
         }
 

--- a/src/DependencyInjection/DI/src/ServiceLookup/ConstructorCallSite.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ConstructorCallSite.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, ServiceCallSite[] parameterCallSites) : base(cache)
         {
+            if (!serviceType.IsAssignableFrom(constructorInfo.DeclaringType))
+            {
+                throw new ArgumentException(Resources.FormatImplementationTypeCantBeConvertedToServiceType(constructorInfo.DeclaringType, serviceType));
+            }
+
             ServiceType = serviceType;
             ConstructorInfo = constructorInfo;
             ParameterCallSites = parameterCallSites;

--- a/src/DependencyInjection/DI/test/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceLookup/CallSiteFactoryTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithSupersetConstructors),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithSupersetConstructors), typeof(TypeWithSupersetConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFakeService), typeof(FakeService))
+                        new ServiceDescriptor(typeof(IFakeService), new FakeService())
                     ),
                     new[] { typeof(IFakeService) }
                 },
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithSupersetConstructors),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithSupersetConstructors), typeof(TypeWithSupersetConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService))
+                        new ServiceDescriptor(typeof(IFactoryService), new TransientFactoryService())
                     ),
                     new[] { typeof(IFactoryService) }
                 },
@@ -134,8 +134,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithSupersetConstructors),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithSupersetConstructors), typeof(TypeWithSupersetConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFakeService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService))
+                        new ServiceDescriptor(typeof(IFakeService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFactoryService), new TransientFactoryService())
                     ),
                     new[] { typeof(IFakeService), typeof(IFactoryService) }
                 },
@@ -143,9 +143,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithSupersetConstructors),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithSupersetConstructors), typeof(TypeWithSupersetConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFakeMultipleService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFakeService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService))
+                        new ServiceDescriptor(typeof(IFakeMultipleService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFakeService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFactoryService), new TransientFactoryService())
                     ),
                     new[] { typeof(IFakeService), typeof(IFakeMultipleService), typeof(IFactoryService) }
                 },
@@ -153,10 +153,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithSupersetConstructors),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithSupersetConstructors), typeof(TypeWithSupersetConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFakeMultipleService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFakeService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService)),
-                        new ServiceDescriptor(typeof(IFakeScopedService), typeof(FakeService))
+                        new ServiceDescriptor(typeof(IFakeMultipleService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFakeService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFactoryService), new TransientFactoryService()),
+                        new ServiceDescriptor(typeof(IFakeScopedService), new FakeService())
                     ),
                     new[] { typeof(IFakeMultipleService), typeof(IFactoryService), typeof(IFakeService), typeof(IFakeScopedService) }
                 },
@@ -164,10 +164,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithSupersetConstructors),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithSupersetConstructors), typeof(TypeWithSupersetConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFakeMultipleService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFakeService), typeof(FakeService)),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService)),
-                        new ServiceDescriptor(typeof(IFakeScopedService), typeof(FakeService))
+                        new ServiceDescriptor(typeof(IFakeMultipleService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFakeService), new FakeService()),
+                        new ServiceDescriptor(typeof(IFactoryService), new TransientFactoryService()),
+                        new ServiceDescriptor(typeof(IFakeScopedService), new FakeService())
                     ),
                     new[] { typeof(IFakeMultipleService), typeof(IFactoryService), typeof(IFakeService), typeof(IFakeScopedService) }
                 },
@@ -186,7 +186,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         new ServiceDescriptor(typeof(TypeWithGenericServices), typeof(TypeWithGenericServices), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(FakeService), ServiceLifetime.Transient)
+                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService), ServiceLifetime.Transient)
                     ),
                     new[] { typeof(IFakeService), typeof(IFactoryService), typeof(IFakeOpenGenericService<IFakeService>) }
                 }
@@ -221,7 +221,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 {
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithDefaultConstructorParameters), typeof(TypeWithDefaultConstructorParameters), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(FakeService), ServiceLifetime.Transient)
+                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService), ServiceLifetime.Transient)
                     ),
                     new[] { typeof(IFactoryService), typeof(IFakeScopedService) }
                 },
@@ -229,7 +229,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                    GetCallSiteFactory(
                        new ServiceDescriptor(typeof(TypeWithDefaultConstructorParameters), typeof(TypeWithDefaultConstructorParameters), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeScopedService), typeof(FakeService), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(FakeService), ServiceLifetime.Transient)
+                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService), ServiceLifetime.Transient)
                     ),
                     new[] { typeof(IFactoryService), typeof(IFakeScopedService) }
                 }
@@ -296,7 +296,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     typeof(TypeWithDefaultConstructorParameters),
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithDefaultConstructorParameters), typeof(TypeWithDefaultConstructorParameters), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(FakeService), ServiceLifetime.Transient),
+                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeMultipleService), typeof(FakeService), ServiceLifetime.Transient)
                     ),
                     new[]
@@ -310,7 +310,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithMultipleParameterizedConstructors), typeof(TypeWithMultipleParameterizedConstructors), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(FakeService), ServiceLifetime.Transient)
+                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService), ServiceLifetime.Transient)
                     ),
                     new[]
                     {
@@ -324,7 +324,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         new ServiceDescriptor(typeof(TypeWithNonOverlappedConstructors), typeof(TypeWithNonOverlappedConstructors), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeScopedService), typeof(FakeService), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeMultipleService), typeof(FakeService), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFakeOuterService), typeof(FakeService), ServiceLifetime.Transient),
+                        new ServiceDescriptor(typeof(IFakeOuterService), typeof(FakeOuterService), ServiceLifetime.Transient),
                         new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), ServiceLifetime.Transient)
                     ),
                     new[]
@@ -349,7 +349,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                    typeof(TypeWithUnresolvableEnumerableConstructors),
                    GetCallSiteFactory(
                         new ServiceDescriptor(typeof(TypeWithUnresolvableEnumerableConstructors), typeof(TypeWithUnresolvableEnumerableConstructors), ServiceLifetime.Transient),
-                        new ServiceDescriptor(typeof(IFactoryService), typeof(FakeService), ServiceLifetime.Transient)
+                        new ServiceDescriptor(typeof(IFactoryService), typeof(TransientFactoryService), ServiceLifetime.Transient)
                     ),
                    new[]
                    {


### PR DESCRIPTION
We didn't have an explicit check like this so event with `ValidateOnBuild` nothing would get thrown and resolution fails with type cast exception.

Fixes: https://github.com/aspnet/Extensions/issues/696