### PR TITLE
Add shorthand for getting connection string "DefaultConnection"

### DIFF
--- a/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
+++ b/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Configuration
         /// <returns></returns>
         public static string GetDefaultConnectionString(this IConfiguration configuration)
         {
-            return configuration?.GetConnectionString("DefaultConnection");
+            return configuration.GetConnectionString("DefaultConnection");
         }
 
         /// <summary>

--- a/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
+++ b/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Configuration
         /// <returns></returns>
         public static string GetDefaultConnectionString(this IConfiguration configuration)
         {
-            return configuration.GetConnectionString("DefaultConnection");
+            return configuration?.GetConnectionString("DefaultConnection");
         }
 
         /// <summary>

--- a/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
+++ b/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs
@@ -37,6 +37,16 @@ namespace Microsoft.Extensions.Configuration
         }
 
         /// <summary>
+        /// Shorthand for GetSection("ConnectionStrings")["DefaultConnection"].
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <returns></returns>
+        public static string GetDefaultConnectionString(this IConfiguration configuration)
+        {
+            return configuration.GetConnectionString("DefaultConnection");
+        }
+
+        /// <summary>
         /// Get the enumeration of key value pairs within the <see cref="IConfiguration" />
         /// </summary>
         /// <param name="configuration">The <see cref="IConfiguration"/> to enumerate.</param>

--- a/src/Configuration/Config/test/ConfigurationTest.cs
+++ b/src/Configuration/Config/test/ConfigurationTest.cs
@@ -471,12 +471,15 @@ namespace Microsoft.Extensions.Configuration.Test
             configurationBuilder.Add(memConfigSrc1);
 
             var config = configurationBuilder.Build();
+            var nullConfig = default(IConfiguration);
 
             // Act
             var memVal1 = config.GetDefaultConnectionString();
+            var memVal2 = nullConfig.GetDefaultConnectionString();
 
             // Assert
             Assert.Equal("MemVal1", memVal1);
+            Assert.Equal(null, memVal2);
         }
 
         [Fact]

--- a/src/Configuration/Config/test/ConfigurationTest.cs
+++ b/src/Configuration/Config/test/ConfigurationTest.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
-        public void CanGetDefaultConnection()
+        public void CanGetDefaultConnectionString()
         {
             // Arrange
             const string defaultConnection = "DefaultConnection";

--- a/src/Configuration/Config/test/ConfigurationTest.cs
+++ b/src/Configuration/Config/test/ConfigurationTest.cs
@@ -456,6 +456,30 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
+        public void CanGetDefaultConnection()
+        {
+            // Arrange
+            const string defaultConnection = "DefaultConnection";
+
+            var dic1 = new Dictionary<string, string>()
+            {
+                {$"ConnectionStrings:{defaultConnection}", "MemVal1"},
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(memConfigSrc1);
+
+            var config = configurationBuilder.Build();
+
+            // Act
+            var memVal1 = config.GetDefaultConnectionString();
+
+            // Assert
+            Assert.Equal("MemVal1", memVal1);
+        }
+
+        [Fact]
         public void CanGetConfigurationChildren()
         {
             // Arrange

--- a/src/Configuration/Config/test/ConfigurationTest.cs
+++ b/src/Configuration/Config/test/ConfigurationTest.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Extensions.Configuration.Test
 
             // Assert
             Assert.Equal("MemVal1", memVal1);
-            Assert.Equal(null, memVal2);
+            Assert.Null(memVal2);
         }
 
         [Fact]


### PR DESCRIPTION
Since there is an extension method [`GetConnectionString`](https://github.com/aspnet/Extensions/blob/master/src/Configuration/Config.Abstractions/src/ConfigurationExtensions.cs#L34L37) that avoids having to use the `"ConnectionStrings"` hard-coded string, why not add another ex. method that would avoid using hard-coded `"DefaultConnection"` too?