### PR TITLE
Use runtime feature detection when selecting DI mode

### DIFF
--- a/src/DependencyInjection/DI/src/ServiceProvider.cs
+++ b/src/DependencyInjection/DI/src/ServiceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,6 +28,17 @@ namespace Microsoft.Extensions.DependencyInjection
 
             switch (options.Mode)
             {
+                case ServiceProviderMode.Default:
+                    if (RuntimeFeature.IsSupported("IsDynamicCodeCompiled"))
+                    {
+                        _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback);
+                    }
+                    else
+                    {
+                        // Don't try to compile Expressions/IL if they are going to get interpreted
+                        _engine = new RuntimeServiceProviderEngine(serviceDescriptors, callback);
+                    }
+                    break;
                 case ServiceProviderMode.Dynamic:
                     _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback);
                     break;

--- a/src/DependencyInjection/DI/src/ServiceProviderMode.cs
+++ b/src/DependencyInjection/DI/src/ServiceProviderMode.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     internal enum ServiceProviderMode
     {
+        Default,
         Dynamic,
         Runtime,
         Expressions,

--- a/src/DependencyInjection/DI/src/ServiceProviderOptions.cs
+++ b/src/DependencyInjection/DI/src/ServiceProviderOptions.cs
@@ -24,6 +24,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public bool ValidateOnBuild { get; set; }
 
-        internal ServiceProviderMode Mode { get; set; } = ServiceProviderMode.Dynamic;
+        internal ServiceProviderMode Mode { get; set; } = ServiceProviderMode.Default;
     }
 }

--- a/src/DependencyInjection/DI/test/ServiceProviderDefaultContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderDefaultContainerTests.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+    public class ServiceProviderDefaultContainerTests : ServiceProviderContainerTests
+    {
+        protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
+            collection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Default });
+    }
+}


### PR DESCRIPTION
I've added another value for `ServiceProviderMode` so we can test `Dynamic` mode explicitly no matter which runtime flags are set.

Fixes: https://github.com/aspnet/Extensions/issues/422