### PR TITLE
Dispose configuration providers

### DIFF
--- a/src/Configuration/Config.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/Configuration/Config.FileExtensions/src/FileConfigurationProvider.cs
@@ -13,8 +13,10 @@ namespace Microsoft.Extensions.Configuration
     /// <summary>
     /// Base class for file based <see cref="ConfigurationProvider"/>.
     /// </summary>
-    public abstract class FileConfigurationProvider : ConfigurationProvider
+    public abstract class FileConfigurationProvider : ConfigurationProvider, IDisposable
     {
+        private readonly IDisposable _changeTokenRegistration;
+
         /// <summary>
         /// Initializes a new instance with the specified source.
         /// </summary>
@@ -29,7 +31,7 @@ namespace Microsoft.Extensions.Configuration
 
             if (Source.ReloadOnChange && Source.FileProvider != null)
             {
-                ChangeToken.OnChange(
+                _changeTokenRegistration = ChangeToken.OnChange(
                     () => Source.FileProvider.Watch(Source.Path),
                     () => {
                         Thread.Sleep(Source.ReloadDelay);
@@ -125,6 +127,18 @@ namespace Microsoft.Extensions.Configuration
             {
                 throw e;
             }
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => Dispose(true);
+
+        /// <summary>
+        /// Dispose the provider.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> if invoked from <see cref="IDisposable.Dispose"/>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            _changeTokenRegistration?.Dispose();
         }
     }
 }

--- a/src/Configuration/Config.FileExtensions/test/FileConfigurationBuilderExtensionsTest.cs
+++ b/src/Configuration/Config.FileExtensions/test/FileConfigurationBuilderExtensionsTest.cs
@@ -6,7 +6,7 @@ using System.IO;
 using Microsoft.Extensions.FileProviders;
 using Xunit;
 
-namespace Microsoft.Extensions.Configuration.Json
+namespace Microsoft.Extensions.Configuration.FileExtensions.Test
 {
     public class FileConfigurationBuilderExtensionsTest
     {

--- a/src/Configuration/Config.FileExtensions/test/FileConfigurationProviderTest.cs
+++ b/src/Configuration/Config.FileExtensions/test/FileConfigurationProviderTest.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Configuration.Test;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Extensions.Configuration.FileExtensions.Test
+{
+    public class FileConfigurationProviderTest
+    {
+        [Fact]
+        public void ProviderDisposesChangeTokenRegistration()
+        {
+            var changeToken = new ConfigurationRootTest.ChangeToken();
+            var fileProviderMock = new Mock<IFileProvider>();
+            fileProviderMock.Setup(fp => fp.Watch(It.IsAny<string>())).Returns(changeToken);
+
+            var provider = new FileConfigurationProviderImpl(new FileConfigurationSourceImpl
+            {
+                FileProvider = fileProviderMock.Object,
+                ReloadOnChange = true,
+            });
+
+            Assert.NotEmpty(changeToken.Callbacks);
+
+            provider.Dispose();
+
+            Assert.Empty(changeToken.Callbacks);
+        }
+
+        public class FileConfigurationProviderImpl : FileConfigurationProvider
+        {
+            public FileConfigurationProviderImpl(FileConfigurationSource source)
+                : base(source)
+            { }
+
+            public override void Load(Stream stream)
+            { }
+        }
+
+        public class FileConfigurationSourceImpl : FileConfigurationSource
+        {
+            public override IConfigurationProvider Build(IConfigurationBuilder builder)
+            {
+                EnsureDefaults(builder);
+                return new FileConfigurationProviderImpl(this);
+            }
+        }
+    }
+}

--- a/src/Configuration/Config.FileExtensions/test/Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj
+++ b/src/Configuration/Config.FileExtensions/test/Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Config\test\Microsoft.Extensions.Configuration.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
   </ItemGroup>
 

--- a/src/Configuration/Config/src/ConfigurationRoot.cs
+++ b/src/Configuration/Config/src/ConfigurationRoot.cs
@@ -12,9 +12,10 @@ namespace Microsoft.Extensions.Configuration
     /// <summary>
     /// The root node for a configuration.
     /// </summary>
-    public class ConfigurationRoot : IConfigurationRoot
+    public class ConfigurationRoot : IConfigurationRoot, IDisposable
     {
         private readonly IList<IConfigurationProvider> _providers;
+        private readonly IList<IDisposable> _changeTokenRegistrations;
         private ConfigurationReloadToken _changeToken = new ConfigurationReloadToken();
 
         /// <summary>
@@ -29,10 +30,11 @@ namespace Microsoft.Extensions.Configuration
             }
 
             _providers = providers;
+            _changeTokenRegistrations = new List<IDisposable>(providers.Count);
             foreach (var p in providers)
             {
                 p.Load();
-                ChangeToken.OnChange(() => p.GetReloadToken(), () => RaiseChanged());
+                _changeTokenRegistrations.Add(ChangeToken.OnChange(() => p.GetReloadToken(), () => RaiseChanged()));
             }
         }
 
@@ -114,6 +116,22 @@ namespace Microsoft.Extensions.Configuration
         {
             var previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
             previousToken.OnReload();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // dispose change token registrations
+            foreach (var registration in _changeTokenRegistrations)
+            {
+                registration.Dispose();
+            }
+
+            // dispose providers
+            foreach (var provider in _providers)
+            {
+                (provider as IDisposable)?.Dispose();
+            }
         }
     }
 }

--- a/src/Configuration/Config/test/ConfigurationRootTest.cs
+++ b/src/Configuration/Config/test/ConfigurationRootTest.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Extensions.Configuration.Test
+{
+    public class ConfigurationRootTest
+    {
+        [Fact]
+        public void RootDisposesProviders()
+        {
+            var provider1 = new TestConfigurationProvider("foo", "foo-value");
+            var provider2 = new DisposableTestConfigurationProvider("bar", "bar-value");
+            var provider3 = new TestConfigurationProvider("baz", "baz-value");
+            var provider4 = new DisposableTestConfigurationProvider("qux", "qux-value");
+            var provider5 = new DisposableTestConfigurationProvider("quux", "quux-value");
+
+            var config = new ConfigurationRoot(new IConfigurationProvider[] {
+                provider1, provider2, provider3, provider4, provider5
+            });
+
+            Assert.Equal("foo-value", config["foo"]);
+            Assert.Equal("bar-value", config["bar"]);
+            Assert.Equal("baz-value", config["baz"]);
+            Assert.Equal("qux-value", config["qux"]);
+            Assert.Equal("quux-value", config["quux"]);
+
+            config.Dispose();
+
+            Assert.True(provider2.IsDisposed);
+            Assert.True(provider4.IsDisposed);
+            Assert.True(provider5.IsDisposed);
+        }
+
+        [Fact]
+        public void RootDisposesChangeTokenRegistrations()
+        {
+            var changeToken = new ChangeToken();
+            var providerMock = new Mock<IConfigurationProvider>();
+            providerMock.Setup(p => p.GetReloadToken()).Returns(changeToken);
+
+            var config = new ConfigurationRoot(new IConfigurationProvider[] {
+                providerMock.Object,
+            });
+
+            Assert.NotEmpty(changeToken.Callbacks);
+
+            config.Dispose();
+
+            Assert.Empty(changeToken.Callbacks);
+        }
+
+        private class TestConfigurationProvider : ConfigurationProvider
+        {
+            public TestConfigurationProvider(string key, string value)
+                => Data.Add(key, value);
+        }
+
+        private class DisposableTestConfigurationProvider : ConfigurationProvider, IDisposable
+        {
+            public bool IsDisposed { get; set; }
+
+            public DisposableTestConfigurationProvider(string key, string value)
+                => Data.Add(key, value);
+
+            public void Dispose()
+                => IsDisposed = true;
+        }
+
+        public class ChangeToken : IChangeToken
+        {
+            public List<(Action<object>, object)> Callbacks { get; } = new List<(Action<object>, object)>();
+
+            public bool HasChanged => false;
+
+            public bool ActiveChangeCallbacks => true;
+
+            public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+            {
+                var item = (callback, state);
+                Callbacks.Add(item);
+                return new DisposableAction(() => Callbacks.Remove(item));
+            }
+
+            private class DisposableAction : IDisposable
+            {
+                private Action _action;
+
+                public DisposableAction(Action action)
+                {
+                    _action = action;
+                }
+
+                public void Dispose()
+                {
+                    var a = _action;
+                    if (a != null)
+                    {
+                        _action = null;
+                        a();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to fix the Extensions.Configuration side of #861. The next step would be to actually dispose the configuration root inside the WebHost. I’ll attempt a PR for that later.

With this, I’ve also fixed the leak that @HaoK mentioned in https://github.com/aspnet/Extensions/pull/868#issuecomment-449690016.

cc @davidfowl 