### PR TITLE
Add TryGetService and IsRegistered

### DIFF
--- a/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -118,6 +118,28 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Determines whether a service of type <typeparamref name="T"/> has been registered with the <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of service to check.</typeparam>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to check.</param>
+        /// <returns><c>true</c> if the service has been registered, <c>false</c> otherwise.</returns>
+        public static bool IsRegistered<T>(this IServiceProvider provider)
+        {
+            return provider.IsRegistered(typeof(T));
+        }
+
+        /// <summary>
+        /// Determines whether a service of type <paramref name="serviceType"/> has been registered with the <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to check.</param>
+        /// <param name="serviceType">An object that specifies the type of service to check.</param>
+        /// <returns><c>true</c> if the service has been registered, <c>false</c> otherwise.</returns>
+        public static bool IsRegistered(this IServiceProvider provider, Type serviceType)
+        {
+            return provider.TryGetService(serviceType, out _);
+        }
+
+        /// <summary>
         /// Tries to get the service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.
         /// </summary>
         /// <typeparam name="T">The type of service object to get.</typeparam>

--- a/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -118,6 +118,48 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Tries to get the service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of service object to get.</typeparam>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+        /// <param name="service">The retrieved instance of the requested service.</param>
+        /// <returns><c>true</c> if the service was retrieved, <c>false</c> otherwise.</returns>
+        public static bool TryGetService<T>(this IServiceProvider provider, out T service)
+        {
+            if (provider.TryGetService(typeof(T), out var instance))
+            {
+                service = (T)instance;
+                return true;
+            }
+
+            service = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to get the service of type <paramref name="serviceType"/> from the <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+        /// <param name="serviceType">An object that specifies the type of service object to get.</param>
+        /// <param name="service">The retrieved instance of the requested service.</param>
+        /// <returns><c>true</c> if the service was retrieved, <c>false</c> otherwise.</returns>
+        public static bool TryGetService(this IServiceProvider provider, Type serviceType, out object service)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            service = provider.GetService(serviceType);
+            return service is object;
+        }
+
+        /// <summary>
         /// Creates a new <see cref="IServiceScope"/> that can be used to resolve scoped services.
         /// </summary>
         /// <param name="provider">The <see cref="IServiceProvider"/> to create the scope from.</param>

--- a/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/DependencyInjection/DI.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -47,19 +47,17 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(serviceType));
             }
 
-            var requiredServiceSupportingProvider = provider as ISupportRequiredService;
-            if (requiredServiceSupportingProvider != null)
+            if (provider is ISupportRequiredService required)
             {
-                return requiredServiceSupportingProvider.GetRequiredService(serviceType);
+                return required.GetRequiredService(serviceType);
             }
 
-            var service = provider.GetService(serviceType);
-            if (service == null)
+            if (provider.TryGetService(serviceType, out var service))
             {
-                throw new InvalidOperationException(Resources.FormatNoServiceRegistered(serviceType));
+                return service;
             }
 
-            return service;
+            throw new InvalidOperationException(Resources.FormatNoServiceRegistered(serviceType));
         }
 
         /// <summary>

--- a/src/DependencyInjection/DI/test/ServiceProviderServiceExtensionsTest.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderServiceExtensionsTest.cs
@@ -214,6 +214,60 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.IsType<List<IFoo>>(services);
         }
 
+        [Fact]
+        public void TryGetService_Returns_True_WhenServiceHasBeenRegistered()
+        {
+            // Arrange
+            var serviceProvider = CreateTestServiceProvider(1);
+
+            // Act
+            var success = serviceProvider.TryGetService<IFoo>(out var service);
+
+            // Assert
+            Assert.True(success);
+            Assert.IsType<Foo1>(service);
+        }
+
+        [Fact]
+        public void TryGetService_Returns_False_WhenServiceHasNotBeenRegistered()
+        {
+            // Arrange
+            var serviceProvider = CreateTestServiceProvider(0);
+
+            // Act
+            var success = serviceProvider.TryGetService<IBar>(out var service);
+
+            // Assert
+            Assert.False(success);
+            Assert.Null(service);
+        }
+
+        [Fact]
+        public void IsRegistered_Returns_True_WhenServiceHasBeenRegistered()
+        {
+            // Arrange
+            var serviceProvider = CreateTestServiceProvider(1);
+
+            // Act
+            var isRegistered = serviceProvider.IsRegistered<IFoo>();
+
+            // Assert
+            Assert.True(isRegistered);
+        }
+
+        [Fact]
+        public void IsRegistered_Returns_False_WhenServiceHasNotBeenRegistered()
+        {
+            // Arrange
+            var serviceProvider = CreateTestServiceProvider(0);
+
+            // Act
+            var isRegistered = serviceProvider.IsRegistered<IBar>();
+
+            // Assert
+            Assert.False(isRegistered);
+        }
+
         private static IServiceProvider CreateTestServiceProvider(int count)
         {
             var serviceCollection = new ServiceCollection();


### PR DESCRIPTION
Ref. https://github.com/aspnet/AspNetCore/pull/6915#discussion_r249700661.

I found traces of this method [way back to 2014](https://github.com/aspnet/DependencyInjection/issues/75), but couldn't see it anywhere.

Some places these methods could be useful:

### IsRegistered

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Mvc/src/Microsoft.AspNetCore.Mvc.Core/Builder/MvcApplicationBuilderExtensions.cs#L184-L192

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Http/Routing/src/Builder/RoutingBuilderExtensions.cs#L64-L70

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs#L88-L96

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Http/Routing/src/RouteBuilder.cs#L26-L32

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilder.cs#L45-L49

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/SignalR/server/SignalR/src/SignalRAppBuilderExtensions.cs#L23-L28

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/SignalR/server/Core/src/SignalRConnectionBuilderExtensions.cs#L24-L29

### TryGetService

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Middleware/NodeServices/src/Configuration/NodeServicesOptions.cs#L38-L49

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Middleware/NodeServices/src/Configuration/NodeServicesOptions.cs#L51-L55

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/src/Middleware/SpaServices.Extensions/src/StaticFiles/SpaStaticFilesExtensions.cs#L122-L132

These were just found based on a quick GitHub search...