### PR TITLE
ConfigurePrimaryHttpMessageHandler<T> uses builder name

### DIFF
--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </typeparam>
         /// <remarks>
         /// <para>
-        /// The <typeparamref name="THandler"/> will be resolved from a scoped service provider that shares 
+        /// The <typeparamref name="THandler"/> will be resolved from a scoped service provider that shares
         /// the lifetime of the handler being constructed.
         /// </para>
         /// </remarks>
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds a delegate that will be used to configure the primary <see cref="HttpMessageHandler"/> for a 
+        /// Adds a delegate that will be used to configure the primary <see cref="HttpMessageHandler"/> for a
         /// named <see cref="HttpClient"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
@@ -197,7 +197,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds a delegate that will be used to configure the primary <see cref="HttpMessageHandler"/> for a 
+        /// Adds a delegate that will be used to configure the primary <see cref="HttpMessageHandler"/> for a
         /// named <see cref="HttpClient"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
@@ -244,7 +244,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </typeparam>
         /// <remarks>
         /// <para>
-        /// The <typeparamref name="THandler"/> will be resolved from a scoped service provider that shares 
+        /// The <typeparamref name="THandler"/> will be resolved from a scoped service provider that shares
         /// the lifetime of the handler being constructed.
         /// </para>
         /// </remarks>
@@ -265,7 +265,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds a delegate that will be used to configure message handlers using <see cref="HttpMessageHandlerBuilder"/> 
+        /// Adds a delegate that will be used to configure message handlers using <see cref="HttpMessageHandlerBuilder"/>
         /// for a named <see cref="HttpClient"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
@@ -301,7 +301,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <para>
         /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
-        /// <typeparamref name="TClient"/> as the service type. 
+        /// <typeparamref name="TClient"/> as the service type.
         /// </para>
         /// <para>
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient}(IHttpClientBuilder)"/> will register a typed
@@ -335,7 +335,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Configures a binding between the <typeparamref name="TClient" /> type and the named <see cref="HttpClient"/>
-        /// associated with the <see cref="IHttpClientBuilder"/>. The created instances will be of type 
+        /// associated with the <see cref="IHttpClientBuilder"/>. The created instances will be of type
         /// <typeparamref name="TImplementation"/>.
         /// </summary>
         /// <typeparam name="TClient">
@@ -343,7 +343,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// a transient service. See <see cref="ITypedHttpClientFactory{TImplementation}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <typeparam name="TImplementation">
-        /// The implementation type of the typed client. The type specified by will be instantiated by the 
+        /// The implementation type of the typed client. The type specified by will be instantiated by the
         /// <see cref="ITypedHttpClientFactory{TImplementation}"/>.
         /// </typeparam>
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
@@ -351,11 +351,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <para>
         /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
-        /// <typeparamref name="TClient"/> as the service type. 
+        /// <typeparamref name="TClient"/> as the service type.
         /// </para>
         /// <para>
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient,TImplementation}(IHttpClientBuilder)"/>
-        /// will register a typed client binding that creates <typeparamref name="TImplementation"/> using the 
+        /// will register a typed client binding that creates <typeparamref name="TImplementation"/> using the
         /// <see cref="ITypedHttpClientFactory{TImplementation}" />.
         /// </para>
         /// <para>
@@ -399,7 +399,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <para>
         /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
-        /// <typeparamref name="TClient"/> as the service type. 
+        /// <typeparamref name="TClient"/> as the service type.
         /// </para>
         /// <para>
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient}(IHttpClientBuilder,Func{HttpClient,TClient})"/>
@@ -444,7 +444,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <para>
         /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
-        /// <typeparamref name="TClient"/> as the service type. 
+        /// <typeparamref name="TClient"/> as the service type.
         /// </para>
         /// <para>
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient}(IHttpClientBuilder,Func{HttpClient,IServiceProvider,TClient})"/>
@@ -476,7 +476,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Sets the length of time that a <see cref="HttpMessageHandler"/> instance can be reused. Each named 
+        /// Sets the length of time that a <see cref="HttpMessageHandler"/> instance can be reused. Each named
         /// client can have its own configured handler lifetime value. The default value is two minutes. Set the lifetime to
         /// <see cref="Timeout.InfiniteTimeSpan"/> to disable handler expiry.
         /// </summary>
@@ -493,7 +493,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// chosen with an understanding of the application's requirement to respond to changes in the network environment.
         /// </para>
         /// <para>
-        /// Expiry of a handler will not immediately dispose the handler. An expired handler is placed in a separate pool 
+        /// Expiry of a handler will not immediately dispose the handler. An expired handler is placed in a separate pool
         /// which is processed at intervals to dispose handlers only when they become unreachable. Using long-lived
         /// <see cref="HttpClient"/> instances will prevent the underlying <see cref="HttpMessageHandler"/> from being
         /// disposed until all references are garbage-collected.

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.Configure<HttpClientFactoryOptions>(options =>
+            builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
                 options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = b.Services.GetRequiredService<THandler>());
             });


### PR DESCRIPTION
`HttpClientBuilderExtensions.ConfigurePrimaryHttpMessageHandler<THandler>()` uses builder name, so handler is configured for correct `HttpClient`.

Addresses #851 
