### PR TITLE
Fix deadlocks in single-threaded SynchronizationContext

### DIFF
--- a/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Http.Logging
             // Not using a scope here because we always expect this to be at the end of the pipeline, thus there's
             // not really anything to surround.
             Log.RequestStart(_logger, request);
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             Log.RequestEnd(_logger, response, stopwatch.GetElapsedTime());
 
             return response;

--- a/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Http.Logging
             using (Log.BeginRequestPipelineScope(_logger, request))
             {
                 Log.RequestPipelineStart(_logger, request);
-                var response = await base.SendAsync(request, cancellationToken);
+                var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 Log.RequestPipelineEnd(_logger, response, stopwatch.GetElapsedTime());
 
                 return response;

--- a/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             public TransientService Service { get; }
         }
-        
+
         private class SingleThreadedSynchronizationContext : SynchronizationContext
         {
             private readonly Queue<(SendOrPostCallback Callback, object State)> _queue = new Queue<(SendOrPostCallback Callback, object State)>();
@@ -1030,20 +1030,15 @@ namespace Microsoft.Extensions.DependencyInjection
                 _queue.Enqueue((d, state));
             }
 
-            public override void Send(SendOrPostCallback d, object state)
-            {
-                base.Send(d, state);
-            }
-
             public static void Run(Action action)
             {
-                var previous = SynchronizationContext.Current;
+                var previous = Current;
                 var context = new SingleThreadedSynchronizationContext();
-                SynchronizationContext.SetSynchronizationContext(context);
+                SetSynchronizationContext(context);
                 try
                 {
                     action();
-                    while(context._queue.Count > 0)
+                    while (context._queue.Count > 0)
                     {
                         var item = context._queue.Dequeue();
                         item.Callback(item.State);
@@ -1051,7 +1046,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
                 finally
                 {
-                    SynchronizationContext.SetSynchronizationContext(previous);
+                    SetSynchronizationContext(previous);
                 }
             }
         }


### PR DESCRIPTION
Add `ConfigureAwait(false)` for Logging(Scope)HttpMessageHandler
to prevent deadlocks in single-threaded SynchronizationContext

Addresses #999
