### PR TITLE
Reduce build times

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,8 +39,6 @@
     <SharedSourceRoot>$(MSBuildThisFileDirectory)src\Shared\src\</SharedSourceRoot>
     <ArtifactsConfigurationDir>$(ArtifactsDir)$(Configuration)\</ArtifactsConfigurationDir>
     <BasePackageOutputPath>$(ArtifactsConfigurationDir)packages\</BasePackageOutputPath>
-    <ProductPackageOutputPath>$(BasePackageOutputPath)product\</ProductPackageOutputPath>
-    <InternalPackageOutputPath>$(BasePackageOutputPath)internal\</InternalPackageOutputPath>
     <DebugType>portable</DebugType>
 
     <RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepositoryRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,10 +43,4 @@
   <Import Project="eng\targets\Packaging.targets" Condition=" '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="eng\targets\ResolveReferences.targets" Condition=" '$(DisableReferenceRestrictions)' != 'true' AND '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-
-  <!-- Has to be set after Sdk.targets or it will be overrided -->
-  <PropertyGroup>
-    <PackageOutputPath Condition="'$(IsProductComponent)' == 'true' ">$(ProductPackageOutputPath)</PackageOutputPath>
-    <PackageOutputPath Condition="'$(IsProductComponent)' != 'true' ">$(InternalPackageOutputPath)</PackageOutputPath>
-  </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,6 @@
 variables:
   - name: _TeamName
     value: AspNetCore
-  - name: _GeneralBuildArg
-    value: /p:ArtifactsShippingPackagesDir=$(Build.SourcesDirectory)/artifacts/$(_BuildConfig)/packages/product/
-           /p:ArtifactsNonShippingPackagesDir=$(Build.SourcesDirectory)/artifacts/$(_BuildConfig)/packages/internal/
 
 # CI and PR triggers
 trigger:
@@ -56,7 +53,7 @@ jobs:
               _BuildConfig: Debug
               _SignType: test
               _DotNetPublishToBlobFeed: false
-              _BuildArgs: $(_GeneralBuildArg)
+              _BuildArgs:
 
           Release:
             _BuildConfig: Release
@@ -64,12 +61,11 @@ jobs:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               _SignType: test
               _DotNetPublishToBlobFeed: false
-              _BuildArgs: $(_GeneralBuildArg)
+              _BuildArgs:
             ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
               _SignType: real
               _DotNetPublishToBlobFeed: true
               _BuildArgs: $(_OfficialBuildArgs)
-                          $(_GeneralBuildArg)
       steps:
       - checkout: self
         clean: true
@@ -82,20 +78,11 @@ jobs:
       - powershell: eng\common\msbuild.ps1 eng/repo.targets '/p:IsFinalBuild=$(IsFinalBuild)' '/p:CI=true'
         displayName: Set CI Tags
         condition: eq(variables['_BuildConfig'], 'Release')
-      # Remove temporary files before publishing artifacts
-      - task: DeleteFiles@1
-        inputs:
-          sourceFolder: artifacts/
-          contents: bin
-      - task: DeleteFiles@1
-        inputs:
-          sourceFolder: artifacts/
-          contents: obj
       - task: PublishBuildArtifacts@1
         displayName: Upload package artifacts
         condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         inputs:
-          pathtoPublish: artifacts/
+          pathtoPublish: artifacts/packages/
           ${{ if eq(parameters.artifacts.name, '') }}:
             artifactName: artifacts
           ${{ if ne(parameters.artifacts.name, '') }}:
@@ -126,7 +113,6 @@ jobs:
           --warnAsError false
           --configuration $(_BuildConfig)
           --prepareMachine
-          $(_GeneralBuildArg)
         displayName: Build
 
     - job: OSX_10_13
@@ -152,5 +138,4 @@ jobs:
           --warnAsError false
           --configuration $(_BuildConfig)
           --prepareMachine
-          $(_GeneralBuildArg)
         displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,7 @@ jobs:
           contents: obj
       - task: PublishBuildArtifacts@1
         displayName: Upload package artifacts
+        condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         inputs:
           pathtoPublish: artifacts/
           ${{ if eq(parameters.artifacts.name, '') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,15 @@ jobs:
       - powershell: eng\common\msbuild.ps1 eng/repo.targets '/p:IsFinalBuild=$(IsFinalBuild)' '/p:CI=true'
         displayName: Set CI Tags
         condition: eq(variables['_BuildConfig'], 'Release')
+      # Remove temporary files before publishing artifacts
+      - task: DeleteFiles@1
+        inputs:
+          sourceFolder: artifacts/
+          contents: bin
+      - task: DeleteFiles@1
+        inputs:
+          sourceFolder: artifacts/
+          contents: obj
       - task: PublishBuildArtifacts@1
         displayName: Upload package artifacts
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,6 @@ jobs:
         condition: eq(variables['_BuildConfig'], 'Release')
       - task: PublishBuildArtifacts@1
         displayName: Upload package artifacts
-        condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         inputs:
           pathtoPublish: artifacts/
           ${{ if eq(parameters.artifacts.name, '') }}:

--- a/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
+++ b/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
@@ -14,6 +14,8 @@
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageTags>analyzers;async</PackageTags>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
@@ -5,6 +5,7 @@
     <Description>Abstractions and features for interop between .NET and JavaScript code.</Description>
     <PackageTags>javascript;interop</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -12,6 +12,8 @@
     <EnableApiCheck>false</EnableApiCheck>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/src/HostFactoryResolver/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
+++ b/src/Shared/src/HostFactoryResolver/Microsoft.Extensions.HostFactoryResolver.Sources.csproj
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="Compile" />
+  <Target Name="CopyFilesToOutputDirectory" />
+</Project>


### PR DESCRIPTION
Knocks ~14 minutes off non-PR builds by not uploading files we don't care about.