### PR TITLE
Workaround for dotnet/cli#10528 - fix NU1605 error when Maestro updates corefx dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -39,4 +39,5 @@
   <Import Project="eng\targets\Packaging.targets" Condition=" '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="eng\targets\ResolveReferences.targets" Condition=" '$(DisableReferenceRestrictions)' != 'true' AND '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="eng\Workarounds.AfterArcade.targets" />
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -63,5 +63,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview.19073.11">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0000</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,10 @@
     <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview.19073.11</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingsWebPackageVersion>4.6.0-preview.19073.11</SystemTextEncodingsWebPackageVersion>
   </PropertyGroup>
+  <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
+  <PropertyGroup>
+    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview.19073.11</MicrosoftNETCorePlatformsPackageVersion>
+  </PropertyGroup>
   <!-- Stable dependencies which are not expected to update via automation -->
   <PropertyGroup>
     <SystemMemoryPackageVersion>4.5.2</SystemMemoryPackageVersion>

--- a/eng/Workarounds.AfterArcade.targets
+++ b/eng/Workarounds.AfterArcade.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
+  <PropertyGroup>
+    <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Unblocks https://github.com/aspnet/Extensions/pull/1020

We are getting package downgrade errors due to this implicit package reference: https://github.com/dotnet/sdk/blob/2eb6c546931b5bcb92cd3128b93932a980553ea1/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L67-L73.
This works around the problem by updating the implicit version variable.

cc @nguerrera @dsplaisted