### PR TITLE
Increase VSTS timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
     enablePublishBuildAssets: true
     enableTelemetry: true
     helixRepo: aspnet/Extensions
+    timeoutInMinutes: 120 # increase timeout since BAR publishing might wait a long time
     jobs:
     - job: Windows
       pool:


### PR DESCRIPTION
This should reduce the number of failures we have due to BAR publishing waiting too long for a lock. Same thing we did in [aspnet/AspNetCore-Tooling](https://github.com/aspnet/AspNetCore-Tooling/blob/master/azure-pipelines.yml#L29).