### PR TITLE
Make Analyzers have normal package names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
               _BuildConfig: Debug
               _SignType: test
               _DotNetPublishToBlobFeed: false
+              _BuildArgs:
 
           Release:
             _BuildConfig: Release

--- a/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
+++ b/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <Description>Analyzer package for async best practices.</Description>
     <VersionPrefix>$(ExperimentalVersionPrefix)</VersionPrefix>
-    <VersionSuffix>$(ExperimentalVersionSuffix)</VersionSuffix>
-    <PackageVersion>$(ExperimentalPackageVersion)</PackageVersion>
-    <InformationalVersion>$(ExperimentalPackageVersion)</InformationalVersion>
     <VerifyVersion>false</VerifyVersion>
     <TargetFramework>netstandard1.3</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <Description>Analyzer package for Microsoft.Extensions.Logging.</Description>
     <VersionPrefix>$(ExperimentalVersionPrefix)</VersionPrefix>
-    <VersionSuffix>$(ExperimentalVersionSuffix)</VersionSuffix>
-    <PackageVersion>$(ExperimentalPackageVersion)</PackageVersion>
-    <InformationalVersion>$(ExperimentalPackageVersion)</InformationalVersion>
     <VerifyVersion>false</VerifyVersion>
     <TargetFramework>netstandard1.3</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
The current properties cause us to produce packages without version numbers such as [here](https://dnceng.visualstudio.com/internal/_build/results?buildId=83255&view=logs&jobId=37bec900-c686-5858-5c69-ce96aeb4a5fe&taskId=c1643131-9f71-5236-b3f8-6b62b8cc1e19&lineStart=4592&lineEnd=4593&colStart=1&colEnd=1) so that when you try to upload it the second time it complains that it already exists.