### PR TITLE
Remove implicit references for non-test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,6 @@
   <ItemGroup Condition=" '$(IsUnitTestProject)' == 'true' ">
     <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Moq" />
-    <Reference Include="xunit.analyzers" />
   </ItemGroup>
 
   <Import Project="eng\Dependencies.props" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -55,12 +55,9 @@
     <LatestPackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <LatestPackageReference Include="StackExchange.Redis" Version="2.0.513" />
     <LatestPackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <LatestPackageReference Include="xunit.analyzers" Version="0.10.0" />
     <LatestPackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
     <LatestPackageReference Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
     <LatestPackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
-    <LatestPackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
-    <LatestPackageReference Include="xunit" Version="$(XUnitVersion)" />
 
     <!-- External DI container references -->
     <LatestPackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />

--- a/eng/Workarounds.AfterArcade.targets
+++ b/eng/Workarounds.AfterArcade.targets
@@ -1,6 +1,18 @@
 <Project>
-  <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
   <PropertyGroup>
+    <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
     <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
+
+    <!-- Workaround for the evaluation order in which Arcade assigns test properties. -->
+    <TestRunnerName Condition="'$(IsUnitTestProject)' == 'false'"/>
   </PropertyGroup>
+
+  <!-- Workaround for implicit references added by Arcade based on project name. Non-test projects should not reference these projects. -->
+  <ItemGroup Condition="'$(IsUnitTestProject)' == 'false'">
+    <PackageReference Remove="Microsoft.NET.Test.Sdk" />
+    <PackageReference Remove="xunit" />
+    <PackageReference Remove="xunit.core" />
+    <PackageReference Remove="xunit.runner.visualstudio" />
+    <PackageReference Remove="xunit.runner.console" />
+  </ItemGroup>
 </Project>

--- a/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -7,8 +7,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>dependencyinjection;di</PackageTags>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- This is actually a library of test projects that we ship to consumer, not a test project. -->
     <IsUnitTestProject>false</IsUnitTestProject>
-    <TestRunnerName></TestRunnerName>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
+      XUnit recommends only using these packages which "extend" xunit. This allows consumers
+      to decide which type of xunit runner they want to use to run these tests.
+     -->
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.extensibility.core" />
   </ItemGroup>

--- a/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -19,8 +19,11 @@
   <ItemGroup>
     <!--
       This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
-      XUnit recommends only using these packages which "extend" xunit. This allows consumers
-      to decide which type of xunit runner they want to use to run these tests.
+      XUnit recommends only using xunit.extensibility.* an xunit.assert for packages which "extend" xunit.
+      This allows consumers to decide which type of xunit runner they want to use to run these tests,
+      and avoids problems with `dotnet pack`.
+
+      See https://xunit.github.io/docs/nuget-packages and the special note in https://xunit.github.io/releases/2.3.
      -->
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.extensibility.core" />

--- a/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>dependencyinjection;di</PackageTags>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <!-- This is actually a library of test projects that we ship to consumer, not a test project. -->
+    <!-- This is actually a library for test projects, not a test project. -->
     <IsUnitTestProject>false</IsUnitTestProject>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
@@ -19,12 +19,12 @@
   <ItemGroup>
     <!--
       This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
-      XUnit recommends only using xunit.extensibility.* an xunit.assert for packages which "extend" xunit.
+      XUnit recommends only using xunit.extensibility.*, xunit.assert, and xunit.abstractions for packages which "extend" xunit.
       This allows consumers to decide which type of xunit runner they want to use to run these tests,
       and avoids problems with `dotnet pack`.
 
       See https://xunit.github.io/docs/nuget-packages and the special note in https://xunit.github.io/releases/2.3.
-     -->
+    -->
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.extensibility.core" />
   </ItemGroup>

--- a/src/Logging/Logging.Testing/src/Microsoft.Extensions.Logging.Testing.csproj
+++ b/src/Logging/Logging.Testing/src/Microsoft.Extensions.Logging.Testing.csproj
@@ -5,6 +5,8 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>$(PackageTags);testing</PackageTags>
+    <!-- This is actually a library for test projects, not a test project. -->
+    <IsUnitTestProject>false</IsUnitTestProject>
     <!-- This is an internal package for testing purposes only. -->
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
@@ -21,6 +23,15 @@
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Serilog.Extensions.Logging" />
     <Reference Include="Serilog.Sinks.File" />
+
+    <!--
+      This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
+      XUnit recommends only using xunit.extensibility.*, xunit.assert, and xunit.abstractions for packages which "extend" xunit.
+      This allows consumers to decide which type of xunit runner they want to use to run these tests,
+      and avoids problems with `dotnet pack`.
+
+      See https://xunit.github.io/docs/nuget-packages and the special note in https://xunit.github.io/releases/2.3.
+    -->
     <Reference Include="xunit.abstractions" />
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.extensibility.execution" />

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj
@@ -4,6 +4,8 @@
     <Description>Helpers for writing tests for Roslyn analyzers.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>$(PackageTags);testing</PackageTags>
+    <!-- This is actually a library for test projects, not a test project. -->
+    <IsUnitTestProject>false</IsUnitTestProject>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
     <IsPackable>true</IsPackable>
@@ -14,6 +16,15 @@
     <Reference Include="System.Reflection.Metadata" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <Reference Include="Microsoft.Extensions.DependencyModel" />
+
+    <!--
+      This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
+      XUnit recommends only using xunit.extensibility.*, xunit.assert, and xunit.abstractions for packages which "extend" xunit.
+      This allows consumers to decide which type of xunit runner they want to use to run these tests,
+      and avoids problems with `dotnet pack`.
+
+      See https://xunit.github.io/docs/nuget-packages and the special note in https://xunit.github.io/releases/2.3.
+    -->
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.abstractions" />
   </ItemGroup>

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -20,6 +20,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Registry" />
     <Reference Include="System.ValueTuple" />
+
+    <!--
+      This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
+      XUnit recommends only using xunit.extensibility.* an xunit.assert for packages which "extend" xunit.
+      This allows consumers to decide which type of xunit runner they want to use to run these tests,
+      and avoids problems with `dotnet pack`.
+
+      See https://xunit.github.io/docs/nuget-packages and the special note in https://xunit.github.io/releases/2.3.
+    -->
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.extensibility.execution" />
   </ItemGroup>

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
+    <!-- This is actually a library for test projects, not a test project. -->
     <IsUnitTestProject>false</IsUnitTestProject>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
@@ -23,7 +24,7 @@
 
     <!--
       This intentionally does not reference 'xunit', 'xunit.core', or any runner packages.
-      XUnit recommends only using xunit.extensibility.* an xunit.assert for packages which "extend" xunit.
+      XUnit recommends only using xunit.extensibility.*, xunit.assert, and xunit.abstractions for packages which "extend" xunit.
       This allows consumers to decide which type of xunit runner they want to use to run these tests,
       and avoids problems with `dotnet pack`.
 

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
+    <IsUnitTestProject>false</IsUnitTestProject>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->


### PR DESCRIPTION
Fix #1036

Workaround for https://github.com/dotnet/arcade/issues/1910 which adds implicit references to Spec.Tests which should not be used.