### PR TITLE
Make VS2019 a prerequisite, and add scripts to set required env vars

### DIFF
--- a/Extensions.sln
+++ b/Extensions.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28508.60
-MinimumVisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DiagnosticAdapter", "DiagnosticAdapter", "{13B8928D-1FE1-4B9D-8B2C-E3248612052B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DiagnosticAdapter", "src\DiagnosticAdapter\src\Microsoft.Extensions.DiagnosticAdapter.csproj", "{EB6915B4-60EC-458F-B5E1-D896AB13363F}"

--- a/activate.ps1
+++ b/activate.ps1
@@ -49,6 +49,9 @@ if (-not $env:DISABLE_CUSTOM_PROMPT) {
 }
 
 Write-Host -f Magenta "Enabled the .NET Core environment. Execute 'deactivate' to exit."
-Write-Host ""
-Write-Host "  dotnet = ${env:DOTNET_ROOT}\dotnet.exe"
-Write-Host ""
+if (-not (Test-Path "${env:DOTNET_ROOT}\dotnet.exe")) {
+    Write-Host -f Yellow ".NET Core has not been installed yet. Run $PSScriptRoot\restore.cmd to install it."
+}
+else {
+    Write-Host "dotnet = ${env:DOTNET_ROOT}\dotnet.exe"
+}

--- a/activate.ps1
+++ b/activate.ps1
@@ -1,0 +1,54 @@
+#
+# This file must be used by invoking ". activate.ps1" from the command line.
+# You cannot run it directly.
+# To exit from the environment this creates, execute the 'deactivate' function.
+#
+
+function deactivate ([switch]$init) {
+
+    # reset old environment variables
+    if (Test-Path variable:_OLD_PATH) {
+        $env:PATH = $_OLD_PATH
+        Remove-Item variable:_OLD_PATH
+    }
+
+    if (test-path function:_old_prompt) {
+        Set-Item Function:prompt -Value $function:_old_prompt -ea ignore
+        remove-item function:_old_prompt
+    }
+
+    Remove-Item env:DOTNET_ROOT -ea ignore
+    Remove-Item env:DOTNET_MULTILEVEL_LOOKUP -ea ignore
+    if (-not $init) {
+        # Remove the deactivate function
+        Remove-Item function:deactivate
+    }
+}
+
+# Cleanup the environment
+deactivate -init
+
+$_OLD_PATH = $env:PATH
+# Tell dotnet where to find itself
+$env:DOTNET_ROOT = "$PSScriptRoot\.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+# Put dotnet first on PATH
+$env:PATH = "${env:DOTNET_ROOT};${env:PATH}"
+
+# Set the shell prompt
+if (-not $env:DISABLE_CUSTOM_PROMPT) {
+    $function:_old_prompt = $function:prompt
+    function dotnet_prompt {
+        # Add a prefix to the current prompt, but don't discard it.
+        write-host "($( split-path $PSScriptRoot -leaf )) " -nonewline
+        & $function:_old_prompt
+    }
+
+    Set-Item Function:prompt -Value $function:dotnet_prompt -ea ignore
+}
+
+Write-Host -f Magenta "Enabled the .NET Core environment. Execute 'deactivate' to exit."
+Write-Host ""
+Write-Host "  dotnet = ${env:DOTNET_ROOT}\dotnet.exe"
+Write-Host ""

--- a/activate.sh
+++ b/activate.sh
@@ -4,6 +4,7 @@
 # To exit from the environment this creates, execute the 'deactivate' function.
 
 _MAGENTA="\033[0;95m"
+_YELLOW="\033[0;33m"
 _RESET="\033[0m"
 
 deactivate () {
@@ -60,6 +61,9 @@ if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
 fi
 
 echo "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}"
-echo ""
-echo "  dotnet = $DOTNET_ROOT/dotnet"
-echo ""
+
+if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
+    echo "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}"
+else
+    echo "dotnet = $DOTNET_ROOT/dotnet"
+fi

--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,65 @@
+#
+# This file must be used by invoking "source activate.sh" from the command line.
+# You cannot run it directly.
+# To exit from the environment this creates, execute the 'deactivate' function.
+
+_MAGENTA="\033[0;95m"
+_RESET="\033[0m"
+
+deactivate () {
+
+    # reset old environment variables
+    if [ ! -z "${_OLD_PATH:-}" ] ; then
+        export PATH="$_OLD_PATH"
+        unset _OLD_PATH
+    fi
+
+    if [ ! -z "${_OLD_PS1:-}" ] ; then
+        export PS1="$_OLD_PS1"
+        unset _OLD_PS1
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    unset DOTNET_ROOT
+    unset DOTNET_MULTILEVEL_LOOKUP
+    if [ ! "${1:-}" = "init" ] ; then
+        # Remove the deactivate function
+        unset -f deactivate
+    fi
+}
+
+# Cleanup the environment
+deactivate init
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+_OLD_PATH="$PATH"
+# Tell dotnet where to find itself
+export DOTNET_ROOT="$DIR/.dotnet"
+# Tell dotnet not to look beyond the DOTNET_ROOT folder for more dotnet things
+export DOTNET_MULTILEVEL_LOOKUP=0
+# Put dotnet first on PATH
+export PATH="$DOTNET_ROOT:$PATH"
+
+# Set the shell prompt
+if [ -z "${DISABLE_CUSTOM_PROMPT:-}" ] ; then
+    _OLD_PS1="$PS1"
+    export PS1="(`basename \"$DIR\"`) $PS1"
+fi
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
+    hash -r 2>/dev/null
+fi
+
+echo "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}"
+echo ""
+echo "  dotnet = $DOTNET_ROOT/dotnet"
+echo ""

--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -4,20 +4,20 @@ Build .NET Extensions from Source
 Building .NET Extensions from source allows you tweak and customize the API, and
 to contribute your improvements back to the project.
 
-## Install pre-requistes
+## Install prerequistes
 
 ### Windows
 
-Building ASP.NET Core on Windows requires:
+Building Extensions on Windows requires:
 
 * Windows 7 or higher
 * At least 5 GB of disk space and a good internet connection (our build scripts download a lot of tools and dependencies)
-* Visual Studio 2017. <https://visualstudio.com>
+* Visual Studio 2019. <https://visualstudio.com>
 * Git. <https://git-scm.org>
 
 ### macOS/Linux
 
-Building ASP.NET Core on macOS or Linux requires:
+Building Extensions on macOS or Linux requires:
 
 * If using macOS, you need macOS Sierra or newer.
 * If using Linux, you need a machine with all .NET Core Linux prerequisites: <https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites>
@@ -47,6 +47,38 @@ On macOS/Linux:
 ./build.sh
 ```
 
+## Using `dotnet` on command line in this repo
+
+Because we are using pre-release versions of .NET Core, you have to set a handful of environment variables
+to make the .NET Core command line tool work well. You can set these environment variables like this
+
+On Windows (requires PowerShell):
+```
+. activate.ps1
+```
+
+On macOS/Linux:
+```
+source activate.sh
+```
+
+## Building with Visual Studio Code
+
+Using Visual Studio Code with this repo requires setting environment variables on command line first.
+Use these command to launch VS Code with the right settings.
+
+On Windows (requires PowerShell):
+```
+. activate.ps1
+code .
+```
+
+On macOS/Linux:
+```
+source activate.sh
+code .
+```
+
 ## Use the result of your build
 
 After building Extensions from source, you can use these in a project by pointing NuGet to the folder containing the .nupkg files.
@@ -58,7 +90,7 @@ After building Extensions from source, you can use these in a project by pointin
   <configuration>
       <packageSources>
           <clear />
-          <add key="MyBuildOfExtensions" value="C:\src\aspnet\Extensions\artifacts\packages\Debug\Shipping\" />
+          <add key="MyBuildOfExtensions" value="C:\src\Extensions\artifacts\packages\Debug\Shipping\" />
           <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
       </packageSources>
   </configuration>

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -14,7 +14,8 @@ SET PATH=%DOTNET_ROOT%;%PATH%
 SET sln=%1
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
-    restore.cmd
+    echo .NET Core has not yet been installed. Running restore.cmd to install it.
+    call restore.cmd
 )
 
 start %~dp0Extensions.sln


### PR DESCRIPTION
Changes:

* Update Extensions.sln to require VS 2019.
* Add two scripts (inspired by Python's virtualenv) which set required environment variables so you can use `dotnet` and launch VS Code on command line. I did this because Arcade puts dotnet core in "$repoRoot/.dotnet" by default now.