### PR TITLE
Fixed OptionsTest for different cultures

### DIFF
--- a/src/Options/test/OptionsTest.cs
+++ b/src/Options/test/OptionsTest.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Extensions.Options.Tests
                         {
                             { nameof(NullableOptions.MyNullableBool), "true" },
                             { nameof(NullableOptions.MyNullableInt), "1" },
-                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(2015, 1, 1).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern) }
+                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(2015, 1, 1).ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern) }
                         },
                         new Dictionary<string, object>
                         {
@@ -191,7 +191,7 @@ namespace Microsoft.Extensions.Options.Tests
                         {
                             { nameof(NullableOptions.MyNullableBool), "false" },
                             { nameof(NullableOptions.MyNullableInt), "-1" },
-                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(1995, 12, 31).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern) }
+                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(1995, 12, 31).ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern) }
                         },
                         new Dictionary<string, object>
                         {


### PR DESCRIPTION
The test was failing for en-GB, as on the parsing side the invariant culture is used