### PR TITLE
Update BaselineGenerator TargetFramework

### DIFF
--- a/eng/tools/BaselineGenerator/BaselineGenerator.csproj
+++ b/eng/tools/BaselineGenerator/BaselineGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <StartArguments>-o "$(MSBuildThisFileDirectory)../../Baseline.Designer.props" --v3 -s https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer</StartArguments>
     <StartWorkingDirectory>$(MSBuildThisFileDirectory)../../</StartWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
As there is a `global.json` in the root that force the prelease version of .NET Core 3.0