### PR TITLE
Avoid clearing ResolvedServices

### DIFF
--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -128,8 +128,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 _disposables = null;
 
                 // Not clearing ResolvedServices here because there might be a compilation running in background
-                // trying to get a cached singleton service instance and if it won't find it it will try to create a new one tripping the Debug.Assert in CaptureDisposable
-                // and leaking a Disposable object
+                // trying to get a cached singleton service instance and if it won't find 
+                // it it will try to create a new one tripping the Debug.Assert in CaptureDisposable
+                // and leaking a Disposable object in Release mode
             }
 
             return toDispose;

--- a/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -127,7 +127,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 toDispose = _disposables;
                 _disposables = null;
 
-                ResolvedServices.Clear();
+                // Not clearing ResolvedServices here because there might be a compilation running in background
+                // trying to get a cached singleton service instance and if it won't find it it will try to create a new one tripping the Debug.Assert in CaptureDisposable
+                // and leaking a Disposable object
             }
 
             return toDispose;

--- a/src/DependencyInjection/DI/test/ServiceProviderEngineScopeTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderEngineScopeTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    public class ServiceProviderEngineScopeTests
+    {
+        [Fact]
+        public void Dispose_DoesntClearResolvedServices()
+        {
+            var serviceProviderEngineScope = new ServiceProviderEngineScope(null);
+            serviceProviderEngineScope.ResolvedServices.Add(new ServiceCacheKey(typeof(IFakeService), 0), null);
+            serviceProviderEngineScope.Dispose();
+
+            Assert.Single(serviceProviderEngineScope.ResolvedServices);
+        }
+    }
+}

--- a/src/DependencyInjection/DependencyInjection.sln
+++ b/src/DependencyInjection/DependencyInjection.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28508.60
+MinimumVisualStudioVersion = 16.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DI", "DI", "{B4373F1E-3E9F-49DA-B1BD-CA440932CF52}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.DependencyInjection.Performance", "DI\perf\Microsoft.Extensions.DependencyInjection.Performance.csproj", "{27C11410-9269-452B-ACF6-BC2E46695DC3}"


### PR DESCRIPTION
The race that was happening is the following:

1. IL compilation is kicked off for the service on the background thread
2. The container is disposed clearing singleton cache
3. As optimization IL compilation tries to resolve direct reference to a singleton service that it knows should already be resolved and cached
4. Because the cache is cleared new object is created triggering the Assert.

The solution is to keep service cache around and let GC clean it.

Fixes: https://github.com/aspnet/Extensions/issues/1043