### PR TITLE
Produce reference assemblies and include them in the nuget package

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -36,6 +36,23 @@
     <IsImplementationProject Condition=" '$(IsImplementationProject)' == '' AND '$(IsTestAssetProject)' != 'true' AND '$(IsUnitTestProject)' != 'true' AND '$(IsBenchmarkProject)' != 'true' AND '$(IsSampleProject)' != 'true' ">true</IsImplementationProject>
     <!-- This determines whether a project is available as a <Reference> to other projects in this repo. -->
     <IsProjectReferenceProvider Condition=" '$(IsProjectReferenceProvider)' == '' AND '$(IsImplementationProject)' == 'true' AND '$(PackAsTool)' != 'true' ">true</IsProjectReferenceProvider>
+
+    <!--
+      Setting back to empty because this value is set by default to 'false' by Microsoft.Common.CurrentVersion.targets before this file is evaluated.
+      Projects in this repo that need to suppress ref assembly generation should set DisableReferenceAssemblyGeneration=true instead.
+    -->
+    <ProduceReferenceAssembly Condition="'$(DisableReferenceAssemblyGeneration)' != 'true' "/>
+
+    <!-- Instructs the compiler to produce reference assemblies. -->
+    <ProduceReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == '' AND '$(IsProjectReferenceProvider)' == 'true' ">true</ProduceReferenceAssembly>
+    <!-- Enables the target in eng/targets/Packaging.targets which puts the reference assembly in the nuget package. -->
+    <PackageReferenceAssembly Condition=" '$(ProduceReferenceAssembly)' == 'true' ">true</PackageReferenceAssembly>
+
+    <!--
+      Copied from https://github.com/Microsoft/msbuild/blob/3a844ce00a873d8ca6ba0a8abc0c6b64f772d937/src/Tasks/Microsoft.Common.CurrentVersion.targets#L288.
+      This is here to workaround for problems caused by setting ProduceReferenceAssembly=true after Microsoft.Common.CurrentVersion.targets is evaluated.
+    -->
+    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' ">$([MSBuild]::NormalizePath($(TargetDir), 'ref', $(TargetFileName)))</TargetRefPath>
   </PropertyGroup>
 
   <Import Project="eng\targets\Packaging.targets" Condition=" '$(MSBuildProjectExtension)' == '.csproj' " />

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -7,4 +7,31 @@
                  See $(RepoRoot)eng\tools\BaselineGenerator\README.md for instructions on updating this baseline." />
   </Target>
 
+  <!-- Package reference assemblies -->
+  <Target Name="_PackageRefAssembly" BeforeTargets="_GetPackageFiles"
+          Condition=" '$(PackageReferenceAssembly)' == 'true' "
+          Returns="@(_RefAssemblyToPack)">
+
+    <ItemGroup Condition="'$(TargetFramework)' == ''">
+      <_TargetFrameworks Remove="@(_TargetFrameworks)" />
+      <_TargetFrameworks Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <MSBuild Condition="'$(TargetFramework)' == ''"
+             Targets="_PackageRefAssembly"
+             BuildInParallel="true"
+             Projects="$(MSBuildProjectFullPath)"
+             Properties="TargetFramework=%(_TargetFrameworks.Identity)">
+      <Output TaskParameter="TargetOutputs" ItemName="_RefAssemblyToPack" />
+    </MSBuild>
+
+    <ItemGroup Condition="'$(TargetFramework)' != ''">
+      <_RefAssemblyToPack Include="@(IntermediateRefAssembly->'%(FullPath)')" PackagePath="ref/$(TargetFramework)/" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="@(_RefAssemblyToPack)" Pack="true" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
@@ -39,7 +39,8 @@
         targetframework=$(TargetFramework);
         AssemblyName=$(AssemblyName);
 
-        OutputBinary=@(BuiltProjectOutputGroupOutput);
+        OutputBinary=$(TargetPath);
+        OutputRefBinary=$(TargetRefPath);
         OutputSymbol=@(DebugSymbolsProjectOutputGroupOutput);
         OutputDocumentation=@(DocumentationProjectOutputGroupOutput);
 

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.nuspec
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.nuspec
@@ -20,6 +20,7 @@
   </metadata>
 
   <files>
+    <file src="$OutputRefBinary$" target="ref\$targetframework$\" />
     <file src="$OutputBinary$" target="lib\$targetframework$\" />
     <file src="$OutputSymbol$" target="lib\$targetframework$\" />
     <file src="$OutputDocumentation$" target="lib\$targetframework$\" />


### PR DESCRIPTION
This enables the C# compiler feature which produces reference assemblies automatically from the implementation code. Impact of this change:

* It adds a `ref/` folder to every .nupkg produce by this repo.
* Inner dev-loop should be faster. In theory, when you change code that doesn't touch public API, Visual Studio and command line builds are smart enough to avoid unnecessary work.
* The generated reference assemblies these packages will end up in the targeting pack for Microsoft.AspNetCore.App.

Note: this does not complete reference assembly work. 

TODO:
* Figure out how to produce reference assemblies with consistent assembly versions in aspnetcore while still consuming higher assembly version implementations (important for patching scenarios)
* Build reference assemblies from generated source (replacement for API check)
* Add tests for this somehow. I manually verified the packages, but we don't have NuGetPackageVerifier anymore, so we don't have a good way to prevent regressions in packaging structure.
