### PR TITLE
Collect dumps on failing memory cache capacity tests

### DIFF
--- a/src/Caching/Memory/test/CapacityTests.cs
+++ b/src/Caching/Memory/test/CapacityTests.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [CollectDump]
         public async Task DoNotAddIfSizeOverflows()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -146,6 +147,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [CollectDump]
         public async Task ExceedsCapacityCompacts()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -239,6 +241,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [CollectDump]
         public async Task AddingReplacementWhenTotalSizeExceedsCapacityDoesNotUpdateRemovesOldEntryAndTriggersCompaction()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -308,6 +311,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [CollectDump]
         public async Task ExpiringEntryDecreasesCacheSize()
         {
             var cache = new MemoryCache(new MemoryCacheOptions
@@ -343,6 +347,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [CollectDump]
         public async Task CompactsToLessThanLowWatermarkUsingLRUWhenHighWatermarkExceeded()
         {
             var testClock = new TestClock();


### PR DESCRIPTION
Adding dumps to help debug https://github.com/aspnet/AspNetCore-Internal/issues/1741. Since all branches are equally likely to see the failure, I'm going to add this to all of 2.1, 2.2 and master.