### PR TITLE
Don't use parameter that doesn't exist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,10 +102,7 @@ jobs:
         condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         inputs:
           pathtoPublish: artifacts/packages/
-          ${{ if eq(parameters.artifacts.name, '') }}:
-            artifactName: artifacts
-          ${{ if ne(parameters.artifacts.name, '') }}:
-            artifactName: ${{ parameters.artifacts.name }}
+          artifactName: artifacts
           artifactType: Container
           parallel: true
 


### PR DESCRIPTION
I have no idea why this started failing, but we can fix it by removing the offending code, since it wasn't needed anyway.

CC @Tratcher