### PR TITLE
Update package branding to 3.0.0-preview3

### DIFF
--- a/version.props
+++ b/version.props
@@ -4,7 +4,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview3</PreReleaseVersionLabel>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Per latest 3.0 release plan, we'll start including the preview number in the package branding.

cc @leecow 