### PR TITLE
Deprecate and replace IHostingEnvronment & IApplicationLifetime

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,6 +56,7 @@
   <Import Project="eng\Dependencies.props" />
   <Import Project="eng\PatchConfig.props" />
   <Import Project="eng\ProjectReferences.props" />
+  <Import Project="eng\targets\Csharp.Refs.props" Condition="'$(IsReferenceAssemblyProject)' == 'true'" />
 
-  <Import Project="eng\targets\Npm.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
+  <Import Project="eng\targets\Npm.Common.props" Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
 </Project>

--- a/eng/targets/Csharp.Refs.props
+++ b/eng/targets/Csharp.Refs.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/eng/targets/ReferenceAssembly.targets
+++ b/eng/targets/ReferenceAssembly.targets
@@ -28,7 +28,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>@(_ResultTargetFramework)</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   @(ProjectListContentItem->'%(Identity)', '%0A')
 </Project>

--- a/src/Caching/Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.csproj
+++ b/src/Caching/Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Caching.Abstractions.netstandard2.0.cs" />

--- a/src/Caching/Memory/ref/Microsoft.Extensions.Caching.Memory.csproj
+++ b/src/Caching/Memory/ref/Microsoft.Extensions.Caching.Memory.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Caching.Memory.netstandard2.0.cs" />

--- a/src/Caching/SqlServer/ref/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/ref/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Caching.SqlServer.netstandard2.0.cs" />

--- a/src/Caching/StackExchangeRedis/ref/Microsoft.Extensions.Caching.StackExchangeRedis.csproj
+++ b/src/Caching/StackExchangeRedis/ref/Microsoft.Extensions.Caching.StackExchangeRedis.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Caching.StackExchangeRedis.netstandard2.0.cs" />

--- a/src/Configuration/Config.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.csproj
+++ b/src/Configuration/Config.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.Abstractions.netstandard2.0.cs" />

--- a/src/Configuration/Config.AzureKeyVault/ref/Microsoft.Extensions.Configuration.AzureKeyVault.csproj
+++ b/src/Configuration/Config.AzureKeyVault/ref/Microsoft.Extensions.Configuration.AzureKeyVault.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.AzureKeyVault.netstandard2.0.cs" />

--- a/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.csproj
+++ b/src/Configuration/Config.Binder/ref/Microsoft.Extensions.Configuration.Binder.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.Binder.netstandard2.0.cs" />

--- a/src/Configuration/Config.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.csproj
+++ b/src/Configuration/Config.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.CommandLine.netstandard2.0.cs" />

--- a/src/Configuration/Config.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/Configuration/Config.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.EnvironmentVariables.netstandard2.0.cs" />

--- a/src/Configuration/Config.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.csproj
+++ b/src/Configuration/Config.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.FileExtensions.netstandard2.0.cs" />

--- a/src/Configuration/Config.Ini/ref/Microsoft.Extensions.Configuration.Ini.csproj
+++ b/src/Configuration/Config.Ini/ref/Microsoft.Extensions.Configuration.Ini.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.Ini.netstandard2.0.cs" />

--- a/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.csproj
+++ b/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.Json.netstandard2.0.cs" />

--- a/src/Configuration/Config.KeyPerFile/ref/Microsoft.Extensions.Configuration.KeyPerFile.csproj
+++ b/src/Configuration/Config.KeyPerFile/ref/Microsoft.Extensions.Configuration.KeyPerFile.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.KeyPerFile.netstandard2.0.cs" />

--- a/src/Configuration/Config.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.csproj
+++ b/src/Configuration/Config.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.UserSecrets.netstandard2.0.cs" />

--- a/src/Configuration/Config.Xml/ref/Microsoft.Extensions.Configuration.Xml.csproj
+++ b/src/Configuration/Config.Xml/ref/Microsoft.Extensions.Configuration.Xml.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.Xml.netstandard2.0.cs" />

--- a/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.csproj
+++ b/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Configuration.netstandard2.0.cs" />

--- a/src/DependencyInjection/DI.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
+++ b/src/DependencyInjection/DI.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.DependencyInjection.Abstractions.netstandard2.0.cs" />

--- a/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/DependencyInjection/DI/ref/Microsoft.Extensions.DependencyInjection.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Microsoft.Extensions.DependencyInjection.netcoreapp3.0.cs" />

--- a/src/DiagnosticAdapter/ref/Microsoft.Extensions.DiagnosticAdapter.csproj
+++ b/src/DiagnosticAdapter/ref/Microsoft.Extensions.DiagnosticAdapter.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.DiagnosticAdapter.netstandard2.0.cs" />

--- a/src/FileProviders/Abstractions/ref/Microsoft.Extensions.FileProviders.Abstractions.csproj
+++ b/src/FileProviders/Abstractions/ref/Microsoft.Extensions.FileProviders.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.FileProviders.Abstractions.netstandard2.0.cs" />

--- a/src/FileProviders/Composite/ref/Microsoft.Extensions.FileProviders.Composite.csproj
+++ b/src/FileProviders/Composite/ref/Microsoft.Extensions.FileProviders.Composite.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.FileProviders.Composite.netstandard2.0.cs" />

--- a/src/FileProviders/Embedded/ref/Microsoft.Extensions.FileProviders.Embedded.csproj
+++ b/src/FileProviders/Embedded/ref/Microsoft.Extensions.FileProviders.Embedded.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.FileProviders.Embedded.netstandard2.0.cs" />

--- a/src/FileProviders/Physical/ref/Microsoft.Extensions.FileProviders.Physical.csproj
+++ b/src/FileProviders/Physical/ref/Microsoft.Extensions.FileProviders.Physical.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.FileProviders.Physical.netstandard2.0.cs" />

--- a/src/FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.csproj
+++ b/src/FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.FileSystemGlobbing.netstandard2.0.cs" />

--- a/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.csproj
+++ b/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netstandard2.0.cs" />

--- a/src/HealthChecks/HealthChecks/ref/Microsoft.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/HealthChecks/HealthChecks/ref/Microsoft.Extensions.Diagnostics.HealthChecks.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Diagnostics.HealthChecks.netstandard2.0.cs" />

--- a/src/Hosting/Abstractions/ref/Directory.Build.props
+++ b/src/Hosting/Abstractions/ref/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\..\..\..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <NoWarn>CS0618</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/Hosting/Abstractions/ref/Directory.Build.props
+++ b/src/Hosting/Abstractions/ref/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\..\..\..\, Directory.Build.props))\Directory.Build.props" />
-
-  <PropertyGroup>
-    <NoWarn>CS0618</NoWarn>
-  </PropertyGroup>
-</Project>

--- a/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.csproj
+++ b/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Hosting.Abstractions.netstandard2.0.cs" />

--- a/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netcoreapp3.0.cs
+++ b/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netcoreapp3.0.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Hosting
     {
         public HostBuilderContext(System.Collections.Generic.IDictionary<object, object> properties) { }
         public Microsoft.Extensions.Configuration.IConfiguration Configuration { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public Microsoft.Extensions.Hosting.IHostingEnvironment HostingEnvironment { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Extensions.Hosting.IHostEnvironment HostingEnvironment { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IDictionary<object, object> Properties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public static partial class HostDefaults
@@ -37,6 +37,13 @@ namespace Microsoft.Extensions.Hosting
         public static readonly string ApplicationKey;
         public static readonly string ContentRootKey;
         public static readonly string EnvironmentKey;
+    }
+    public static partial class HostEnvironmentEnvExtensions
+    {
+        public static bool IsDevelopment(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment) { throw null; }
+        public static bool IsEnvironment(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment, string environmentName) { throw null; }
+        public static bool IsProduction(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment) { throw null; }
+        public static bool IsStaging(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment) { throw null; }
     }
     public static partial class HostingAbstractionsHostBuilderExtensions
     {
@@ -62,6 +69,7 @@ namespace Microsoft.Extensions.Hosting
         public static bool IsProduction(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
         public static bool IsStaging(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
     }
+    [System.ObsoleteAttribute("Use IHostApplicationLifetime instead.", false)]
     public partial interface IApplicationLifetime
     {
         System.Threading.CancellationToken ApplicationStarted { get; }
@@ -74,6 +82,13 @@ namespace Microsoft.Extensions.Hosting
         System.IServiceProvider Services { get; }
         System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public partial interface IHostApplicationLifetime
+    {
+        System.Threading.CancellationToken ApplicationStarted { get; }
+        System.Threading.CancellationToken ApplicationStopped { get; }
+        System.Threading.CancellationToken ApplicationStopping { get; }
+        void StopApplication();
     }
     public partial interface IHostBuilder
     {
@@ -91,6 +106,14 @@ namespace Microsoft.Extensions.Hosting
         System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken);
     }
+    public partial interface IHostEnvironment
+    {
+        string ApplicationName { get; set; }
+        Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; }
+        string ContentRootPath { get; set; }
+        string EnvironmentName { get; set; }
+    }
+    [System.ObsoleteAttribute("Use IHostEnvironment instead.", false)]
     public partial interface IHostingEnvironment
     {
         string ApplicationName { get; set; }

--- a/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netstandard2.0.cs
+++ b/src/Hosting/Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.netstandard2.0.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Hosting
     {
         public HostBuilderContext(System.Collections.Generic.IDictionary<object, object> properties) { }
         public Microsoft.Extensions.Configuration.IConfiguration Configuration { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public Microsoft.Extensions.Hosting.IHostingEnvironment HostingEnvironment { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Extensions.Hosting.IHostEnvironment HostingEnvironment { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public System.Collections.Generic.IDictionary<object, object> Properties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public static partial class HostDefaults
@@ -37,6 +37,13 @@ namespace Microsoft.Extensions.Hosting
         public static readonly string ApplicationKey;
         public static readonly string ContentRootKey;
         public static readonly string EnvironmentKey;
+    }
+    public static partial class HostEnvironmentEnvExtensions
+    {
+        public static bool IsDevelopment(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment) { throw null; }
+        public static bool IsEnvironment(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment, string environmentName) { throw null; }
+        public static bool IsProduction(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment) { throw null; }
+        public static bool IsStaging(this Microsoft.Extensions.Hosting.IHostEnvironment hostEnvironment) { throw null; }
     }
     public static partial class HostingAbstractionsHostBuilderExtensions
     {
@@ -62,6 +69,7 @@ namespace Microsoft.Extensions.Hosting
         public static bool IsProduction(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
         public static bool IsStaging(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
     }
+    [System.ObsoleteAttribute("Use IHostApplicationLifetime instead.", false)]
     public partial interface IApplicationLifetime
     {
         System.Threading.CancellationToken ApplicationStarted { get; }
@@ -74,6 +82,13 @@ namespace Microsoft.Extensions.Hosting
         System.IServiceProvider Services { get; }
         System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public partial interface IHostApplicationLifetime
+    {
+        System.Threading.CancellationToken ApplicationStarted { get; }
+        System.Threading.CancellationToken ApplicationStopped { get; }
+        System.Threading.CancellationToken ApplicationStopping { get; }
+        void StopApplication();
     }
     public partial interface IHostBuilder
     {
@@ -91,6 +106,14 @@ namespace Microsoft.Extensions.Hosting
         System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken);
     }
+    public partial interface IHostEnvironment
+    {
+        string ApplicationName { get; set; }
+        Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; }
+        string ContentRootPath { get; set; }
+        string EnvironmentName { get; set; }
+    }
+    [System.ObsoleteAttribute("Use IHostEnvironment instead.", false)]
     public partial interface IHostingEnvironment
     {
         string ApplicationName { get; set; }

--- a/src/Hosting/Abstractions/src/HostBuilderContext.cs
+++ b/src/Hosting/Abstractions/src/HostBuilderContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -17,9 +17,9 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// The <see cref="IHostingEnvironment" /> initialized by the <see cref="IHost" />.
+        /// The <see cref="IHostEnvironment" /> initialized by the <see cref="IHost" />.
         /// </summary>
-        public IHostingEnvironment HostingEnvironment { get; set; }
+        public IHostEnvironment HostingEnvironment { get; set; }
 
         /// <summary>
         /// The <see cref="IConfiguration" /> containing the merged configuration of the application and the <see cref="IHost" />.

--- a/src/Hosting/Abstractions/src/HostDefaults.cs
+++ b/src/Hosting/Abstractions/src/HostDefaults.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Extensions.Hosting
     public static class HostDefaults
     {
         /// <summary>
-        /// The configuration key used to set <see cref="IHostingEnvironment.ApplicationName"/>.
+        /// The configuration key used to set <see cref="IHostEnvironment.ApplicationName"/>.
         /// </summary>
         public static readonly string ApplicationKey = "applicationName";
 
         /// <summary>
-        /// The configuration key used to set <see cref="IHostingEnvironment.EnvironmentName"/>.
+        /// The configuration key used to set <see cref="IHostEnvironment.EnvironmentName"/>.
         /// </summary>
         public static readonly string EnvironmentKey = "environment";
 
         /// <summary>
-        /// The configuration key used to set <see cref="IHostingEnvironment.ContentRootPath"/>
-        /// and <see cref="IHostingEnvironment.ContentRootFileProvider"/>.
+        /// The configuration key used to set <see cref="IHostEnvironment.ContentRootPath"/>
+        /// and <see cref="IHostEnvironment.ContentRootFileProvider"/>.
         /// </summary>
         public static readonly string ContentRootKey = "contentRoot";
     }

--- a/src/Hosting/Abstractions/src/HostEnvironmentEnvExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostEnvironmentEnvExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Hosting
     /// <summary>
     /// Extension methods for <see cref="IHostEnvironment"/>.
     /// </summary>
-    public static class HostEnvironmentExtensions
+    public static class HostEnvironmentEnvExtensions
     {
         /// <summary>
         /// Checks if the current host environment name is <see cref="EnvironmentName.Development"/>.

--- a/src/Hosting/Abstractions/src/HostEnvironmentExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostEnvironmentExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Hosting
+{
+    /// <summary>
+    /// Extension methods for <see cref="IHostEnvironment"/>.
+    /// </summary>
+    public static class HostEnvironmentExtensions
+    {
+        /// <summary>
+        /// Checks if the current host environment name is <see cref="EnvironmentName.Development"/>.
+        /// </summary>
+        /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
+        /// <returns>True if the environment name is <see cref="EnvironmentName.Development"/>, otherwise false.</returns>
+        public static bool IsDevelopment(this IHostEnvironment hostEnvironment)
+        {
+            if (hostEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostEnvironment));
+            }
+
+            return hostEnvironment.IsEnvironment(EnvironmentName.Development);
+        }
+
+        /// <summary>
+        /// Checks if the current host environment name is <see cref="EnvironmentName.Staging"/>.
+        /// </summary>
+        /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
+        /// <returns>True if the environment name is <see cref="EnvironmentName.Staging"/>, otherwise false.</returns>
+        public static bool IsStaging(this IHostEnvironment hostEnvironment)
+        {
+            if (hostEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostEnvironment));
+            }
+
+            return hostEnvironment.IsEnvironment(EnvironmentName.Staging);
+        }
+
+        /// <summary>
+        /// Checks if the current host environment name is <see cref="EnvironmentName.Production"/>.
+        /// </summary>
+        /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
+        /// <returns>True if the environment name is <see cref="EnvironmentName.Production"/>, otherwise false.</returns>
+        public static bool IsProduction(this IHostEnvironment hostEnvironment)
+        {
+            if (hostEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostEnvironment));
+            }
+
+            return hostEnvironment.IsEnvironment(EnvironmentName.Production);
+        }
+
+        /// <summary>
+        /// Compares the current host environment name against the specified value.
+        /// </summary>
+        /// <param name="hostEnvironment">An instance of <see cref="IHostEnvironment"/>.</param>
+        /// <param name="environmentName">Environment name to validate against.</param>
+        /// <returns>True if the specified name is the same as the current environment, otherwise false.</returns>
+        public static bool IsEnvironment(
+            this IHostEnvironment hostEnvironment,
+            string environmentName)
+        {
+            if (hostEnvironment == null)
+            {
+                throw new ArgumentNullException(nameof(hostEnvironment));
+            }
+
+            return string.Equals(
+                hostEnvironment.EnvironmentName,
+                environmentName,
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Hosting/Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -85,11 +85,11 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="token">The token to trigger shutdown.</param>
         public static async Task WaitForShutdownAsync(this IHost host, CancellationToken token = default)
         {
-            var applicationLifetime = host.Services.GetService<IApplicationLifetime>();
+            var applicationLifetime = host.Services.GetService<IAppLifetime>();
 
             token.Register(state =>
             {
-                ((IApplicationLifetime)state).StopApplication();
+                ((IAppLifetime)state).StopApplication();
             },
             applicationLifetime);
 

--- a/src/Hosting/Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -85,11 +85,11 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="token">The token to trigger shutdown.</param>
         public static async Task WaitForShutdownAsync(this IHost host, CancellationToken token = default)
         {
-            var applicationLifetime = host.Services.GetService<IAppLifetime>();
+            var applicationLifetime = host.Services.GetService<IHostApplicationLifetime>();
 
             token.Register(state =>
             {
-                ((IAppLifetime)state).StopApplication();
+                ((IHostApplicationLifetime)state).StopApplication();
             },
             applicationLifetime);
 

--- a/src/Hosting/Abstractions/src/HostingEnvironmentExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingEnvironmentExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
@@ -77,3 +78,4 @@ namespace Microsoft.Extensions.Hosting
         }
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Hosting/Abstractions/src/IAppLifetime.cs
+++ b/src/Hosting/Abstractions/src/IAppLifetime.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 
 namespace Microsoft.Extensions.Hosting
@@ -9,8 +8,7 @@ namespace Microsoft.Extensions.Hosting
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    [Obsolete("Use IAppLifetime instead.", error: false)]
-    public interface IApplicationLifetime
+    public interface IAppLifetime
     {
         /// <summary>
         /// Triggered when the application host has fully started and is about to wait

--- a/src/Hosting/Abstractions/src/IApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IApplicationLifetime.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Hosting
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    [Obsolete("Use IAppLifetime instead.", error: false)]
+    [Obsolete("Use IHostApplicationLifetime instead.", error: false)]
     public interface IApplicationLifetime
     {
         /// <summary>

--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -6,26 +6,24 @@ using System.Threading;
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
-    /// Allows consumers to perform cleanup during a graceful shutdown.
+    /// Allows consumers to be notified of application lifetime events.
     /// </summary>
-    public interface IAppLifetime
+    public interface IHostApplicationLifetime
     {
         /// <summary>
-        /// Triggered when the application host has fully started and is about to wait
-        /// for a graceful shutdown.
+        /// Triggered when the application host has fully started.
         /// </summary>
         CancellationToken ApplicationStarted { get; }
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
-        /// Requests may still be in flight. Shutdown will block until this event completes.
+        /// Shutdown will block until this event completes.
         /// </summary>
         CancellationToken ApplicationStopping { get; }
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
-        /// All requests should be complete at this point. Shutdown will block
-        /// until this event completes.
+        /// Shutdown will block until this event completes.
         /// </summary>
         CancellationToken ApplicationStopped { get; }
 

--- a/src/Hosting/Abstractions/src/IHostBuilder.cs
+++ b/src/Hosting/Abstractions/src/IHostBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Hosting
         IDictionary<object, object> Properties { get; }
 
         /// <summary>
-        /// Set up the configuration for the builder itself. This will be used to initialize the <see cref="IHostingEnvironment"/>
+        /// Set up the configuration for the builder itself. This will be used to initialize the <see cref="IHostEnvironment"/>
         /// for use later in the build process. This can be called multiple times and the results will be additive.
         /// </summary>
         /// <param name="configureDelegate">The delegate for configuring the <see cref="IConfigurationBuilder"/> that will be used

--- a/src/Hosting/Abstractions/src/IHostEnvironment.cs
+++ b/src/Hosting/Abstractions/src/IHostEnvironment.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Extensions.Hosting
     /// <summary>
     /// Provides information about the hosting environment an application is running in.
     /// </summary>
-    [Obsolete("Use IHostEnvironment instead.", error: false)]
-    public interface IHostingEnvironment
+    public interface IHostEnvironment
     {
         /// <summary>
         /// Gets or sets the name of the environment. The host automatically sets this property to the value of the

--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.csproj
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Hosting.netstandard2.0.cs" />

--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netcoreapp3.0.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netcoreapp3.0.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Hosting
 }
 namespace Microsoft.Extensions.Hosting.Internal
 {
-    public partial class ApplicationLifetime : Microsoft.Extensions.Hosting.IApplicationLifetime
+    public partial class ApplicationLifetime : Microsoft.Extensions.Hosting.IApplicationLifetime, Microsoft.Extensions.Hosting.IHostApplicationLifetime
     {
         public ApplicationLifetime(Microsoft.Extensions.Logging.ILogger<Microsoft.Extensions.Hosting.Internal.ApplicationLifetime> logger) { }
         public System.Threading.CancellationToken ApplicationStarted { get { throw null; } }
@@ -61,13 +61,13 @@ namespace Microsoft.Extensions.Hosting.Internal
     }
     public partial class ConsoleLifetime : Microsoft.Extensions.Hosting.IHostLifetime, System.IDisposable
     {
-        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostingEnvironment environment, Microsoft.Extensions.Hosting.IApplicationLifetime applicationLifetime) { }
-        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostingEnvironment environment, Microsoft.Extensions.Hosting.IApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime) { }
+        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task WaitForStartAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
-    public partial class HostingEnvironment : Microsoft.Extensions.Hosting.IHostingEnvironment
+    public partial class HostingEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment, Microsoft.Extensions.Hosting.IHostingEnvironment
     {
         public HostingEnvironment() { }
         public string ApplicationName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netstandard2.0.cs
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.netstandard2.0.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Hosting
 }
 namespace Microsoft.Extensions.Hosting.Internal
 {
-    public partial class ApplicationLifetime : Microsoft.Extensions.Hosting.IApplicationLifetime
+    public partial class ApplicationLifetime : Microsoft.Extensions.Hosting.IApplicationLifetime, Microsoft.Extensions.Hosting.IHostApplicationLifetime
     {
         public ApplicationLifetime(Microsoft.Extensions.Logging.ILogger<Microsoft.Extensions.Hosting.Internal.ApplicationLifetime> logger) { }
         public System.Threading.CancellationToken ApplicationStarted { get { throw null; } }
@@ -61,13 +61,13 @@ namespace Microsoft.Extensions.Hosting.Internal
     }
     public partial class ConsoleLifetime : Microsoft.Extensions.Hosting.IHostLifetime, System.IDisposable
     {
-        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostingEnvironment environment, Microsoft.Extensions.Hosting.IApplicationLifetime applicationLifetime) { }
-        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostingEnvironment environment, Microsoft.Extensions.Hosting.IApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime) { }
+        public ConsoleLifetime(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.ConsoleLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task WaitForStartAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
-    public partial class HostingEnvironment : Microsoft.Extensions.Hosting.IHostingEnvironment
+    public partial class HostingEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment, Microsoft.Extensions.Hosting.IHostingEnvironment
     {
         public HostingEnvironment() { }
         public string ApplicationName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Hosting
         private IConfiguration _hostConfiguration;
         private IConfiguration _appConfiguration;
         private HostBuilderContext _hostBuilderContext;
-        private IHostingEnvironment _hostingEnvironment;
+        private HostingEnvironment _hostingEnvironment;
         private IServiceProvider _appServices;
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Hosting
         public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
         /// <summary>
-        /// Set up the configuration for the builder itself. This will be used to initialize the <see cref="IHostingEnvironment"/>
+        /// Set up the configuration for the builder itself. This will be used to initialize the <see cref="IHostEnvironment"/>
         /// for use later in the build process. This can be called multiple times and the results will be additive.
         /// </summary>
         /// <param name="configureDelegate"></param>
@@ -185,10 +185,16 @@ namespace Microsoft.Extensions.Hosting
         private void CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddSingleton(_hostingEnvironment);
+#pragma warning disable CS0618 // Type or member is obsolete
+            services.AddSingleton<IHostingEnvironment>(_hostingEnvironment);
+#pragma warning restore CS0618 // Type or member is obsolete
+            services.AddSingleton<IHostEnvironment>(_hostingEnvironment);
             services.AddSingleton(_hostBuilderContext);
             services.AddSingleton(_appConfiguration);
-            services.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+#pragma warning disable CS0618 // Type or member is obsolete
+            services.AddSingleton<IApplicationLifetime>(s => (IApplicationLifetime)s.GetService<IAppLifetime>());
+#pragma warning restore CS0618 // Type or member is obsolete
+            services.AddSingleton<IAppLifetime, ApplicationLifetime>();
             services.AddSingleton<IHostLifetime, ConsoleLifetime>();
             services.AddSingleton<IHost, Internal.Host>();
             services.AddOptions();

--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -192,9 +192,9 @@ namespace Microsoft.Extensions.Hosting
             services.AddSingleton(_hostBuilderContext);
             services.AddSingleton(_appConfiguration);
 #pragma warning disable CS0618 // Type or member is obsolete
-            services.AddSingleton<IApplicationLifetime>(s => (IApplicationLifetime)s.GetService<IAppLifetime>());
+            services.AddSingleton<IApplicationLifetime>(s => (IApplicationLifetime)s.GetService<IHostApplicationLifetime>());
 #pragma warning restore CS0618 // Type or member is obsolete
-            services.AddSingleton<IAppLifetime, ApplicationLifetime>();
+            services.AddSingleton<IHostApplicationLifetime, ApplicationLifetime>();
             services.AddSingleton<IHostLifetime, ConsoleLifetime>();
             services.AddSingleton<IHost, Internal.Host>();
             services.AddOptions();

--- a/src/Hosting/Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/HostingHostBuilderExtensions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IApplicationLifetime.StopApplication"/> to start the shutdown process.
+        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IAppLifetime.StopApplication"/> to start the shutdown process.
         /// This will unblock extensions like RunAsync and WaitForShutdownAsync.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IApplicationLifetime.StopApplication"/> to start the shutdown process.
+        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IAppLifetime.StopApplication"/> to start the shutdown process.
         /// This will unblock extensions like RunAsync and WaitForShutdownAsync.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>

--- a/src/Hosting/Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/HostingHostBuilderExtensions.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IAppLifetime.StopApplication"/> to start the shutdown process.
+        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IHostApplicationLifetime.StopApplication"/> to start the shutdown process.
         /// This will unblock extensions like RunAsync and WaitForShutdownAsync.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IAppLifetime.StopApplication"/> to start the shutdown process.
+        /// Listens for Ctrl+C or SIGTERM and calls <see cref="IHostApplicationLifetime.StopApplication"/> to start the shutdown process.
         /// This will unblock extensions like RunAsync and WaitForShutdownAsync.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>

--- a/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
@@ -8,10 +8,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Hosting.Internal
 {
+    // Type or member is obsolete
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    public class ApplicationLifetime : IApplicationLifetime
+#pragma warning disable CS0618 // Type or member is obsolete
+    public class ApplicationLifetime : IApplicationLifetime, IAppLifetime
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();

--- a/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
@@ -2,13 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Hosting.Internal
 {
-    // Type or member is obsolete
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>

--- a/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting.Internal
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
 #pragma warning disable CS0618 // Type or member is obsolete
-    public class ApplicationLifetime : IApplicationLifetime, IAppLifetime
+    public class ApplicationLifetime : IApplicationLifetime, IHostApplicationLifetime
 #pragma warning restore CS0618 // Type or member is obsolete
     {
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();

--- a/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Extensions.Hosting.Internal
         private CancellationTokenRegistration _applicationStartedRegistration;
         private CancellationTokenRegistration _applicationStoppingRegistration;
 
-        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostingEnvironment environment, IApplicationLifetime applicationLifetime)
+        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IAppLifetime applicationLifetime)
             : this(options, environment, applicationLifetime, NullLoggerFactory.Instance) { }
 
-        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostingEnvironment environment, IApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory)
+        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IAppLifetime applicationLifetime, ILoggerFactory loggerFactory)
         {
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             Environment = environment ?? throw new ArgumentNullException(nameof(environment));
@@ -32,9 +32,9 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private ConsoleLifetimeOptions Options { get; }
 
-        private IHostingEnvironment Environment { get; }
+        private IHostEnvironment Environment { get; }
 
-        private IApplicationLifetime ApplicationLifetime { get; }
+        private IAppLifetime ApplicationLifetime { get; }
 
         private ILogger Logger { get; }
 

--- a/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ConsoleLifetime.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Extensions.Hosting.Internal
         private CancellationTokenRegistration _applicationStartedRegistration;
         private CancellationTokenRegistration _applicationStoppingRegistration;
 
-        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IAppLifetime applicationLifetime)
+        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime)
             : this(options, environment, applicationLifetime, NullLoggerFactory.Instance) { }
 
-        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IAppLifetime applicationLifetime, ILoggerFactory loggerFactory)
+        public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory)
         {
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             Environment = environment ?? throw new ArgumentNullException(nameof(environment));
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private IHostEnvironment Environment { get; }
 
-        private IAppLifetime ApplicationLifetime { get; }
+        private IHostApplicationLifetime ApplicationLifetime { get; }
 
         private ILogger Logger { get; }
 

--- a/src/Hosting/Hosting/src/Internal/Host.cs
+++ b/src/Hosting/Hosting/src/Internal/Host.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         private readonly HostOptions _options;
         private IEnumerable<IHostedService> _hostedServices;
 
-        public Host(IServiceProvider services, IApplicationLifetime applicationLifetime, ILogger<Host> logger,
+        public Host(IServiceProvider services, IAppLifetime applicationLifetime, ILogger<Host> logger,
             IHostLifetime hostLifetime, IOptions<HostOptions> options)
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 await hostedService.StartAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            // Fire IApplicationLifetime.Started
+            // Fire IAppLifetime.Started
             _applicationLifetime?.NotifyStarted();
 
             _logger.Started();
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken))
             {
                 var token = linkedCts.Token;
-                // Trigger IApplicationLifetime.ApplicationStopping
+                // Trigger IAppLifetime.ApplicationStopping
                 _applicationLifetime?.StopApplication();
 
                 IList<Exception> exceptions = new List<Exception>();
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 token.ThrowIfCancellationRequested();
                 await _hostLifetime.StopAsync(token);
 
-                // Fire IApplicationLifetime.Stopped
+                // Fire IAppLifetime.Stopped
                 _applicationLifetime?.NotifyStopped();
 
                 if (exceptions.Count > 0)

--- a/src/Hosting/Hosting/src/Internal/Host.cs
+++ b/src/Hosting/Hosting/src/Internal/Host.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 await hostedService.StartAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            // Fire IAppLifetime.Started
+            // Fire IHostApplicationLifetime.Started
             _applicationLifetime?.NotifyStarted();
 
             _logger.Started();
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken))
             {
                 var token = linkedCts.Token;
-                // Trigger IAppLifetime.ApplicationStopping
+                // Trigger IHostApplicationLifetime.ApplicationStopping
                 _applicationLifetime?.StopApplication();
 
                 IList<Exception> exceptions = new List<Exception>();
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 token.ThrowIfCancellationRequested();
                 await _hostLifetime.StopAsync(token);
 
-                // Fire IAppLifetime.Stopped
+                // Fire IHostApplicationLifetime.Stopped
                 _applicationLifetime?.NotifyStopped();
 
                 if (exceptions.Count > 0)

--- a/src/Hosting/Hosting/src/Internal/Host.cs
+++ b/src/Hosting/Hosting/src/Internal/Host.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         private readonly HostOptions _options;
         private IEnumerable<IHostedService> _hostedServices;
 
-        public Host(IServiceProvider services, IAppLifetime applicationLifetime, ILogger<Host> logger,
+        public Host(IServiceProvider services, IHostApplicationLifetime applicationLifetime, ILogger<Host> logger,
             IHostLifetime hostLifetime, IOptions<HostOptions> options)
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));

--- a/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
@@ -1,11 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.Extensions.Hosting.Internal
 {
-    public class HostingEnvironment : IHostingEnvironment
+#pragma warning disable CS0618 // Type or member is obsolete
+    public class HostingEnvironment : IHostingEnvironment, IHostEnvironment
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         public string EnvironmentName { get; set; }
 

--- a/src/Hosting/Hosting/test/HostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/HostBuilderTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         [Fact]
-        public void DefaultIHostingEnvironmentValues()
+        public void DefaultIHostEnvironmentValues()
         {
             var hostBuilder = new HostBuilder()
                 .ConfigureAppConfiguration((hostContext, appConfig) =>
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Hosting
 
             using (var host = hostBuilder.Build())
             {
-                var env = host.Services.GetRequiredService<IHostingEnvironment>();
+                var env = host.Services.GetRequiredService<IHostEnvironment>();
                 Assert.Equal(EnvironmentName.Production, env.EnvironmentName);
                 Assert.Null(env.ApplicationName);
                 Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
@@ -185,7 +185,7 @@ namespace Microsoft.Extensions.Hosting
 
             using (var host = hostBuilder.Build())
             {
-                Assert.Equal("EnvB", host.Services.GetRequiredService<IHostingEnvironment>().EnvironmentName);
+                Assert.Equal("EnvB", host.Services.GetRequiredService<IHostEnvironment>().EnvironmentName);
             }
         }
 
@@ -208,7 +208,7 @@ namespace Microsoft.Extensions.Hosting
                 .UseEnvironment(expected)
                 .Build())
             {
-                Assert.Equal(expected, host.Services.GetService<IHostingEnvironment>().EnvironmentName);
+                Assert.Equal(expected, host.Services.GetService<IHostEnvironment>().EnvironmentName);
             }
         }
 
@@ -235,7 +235,7 @@ namespace Microsoft.Extensions.Hosting
                 .UseContentRoot("/")
                 .Build())
             {
-                Assert.Equal("/", host.Services.GetService<IHostingEnvironment>().ContentRootPath);
+                Assert.Equal("/", host.Services.GetService<IHostEnvironment>().ContentRootPath);
             }
         }
 
@@ -255,7 +255,7 @@ namespace Microsoft.Extensions.Hosting
                     config.AddInMemoryCollection(parameters);
                 }).Build();
 
-            var env = host.Services.GetRequiredService<IHostingEnvironment>();
+            var env = host.Services.GetRequiredService<IHostEnvironment>();
 
             Assert.Equal("MyProjectReference", env.ApplicationName);
             Assert.Equal(EnvironmentName.Development, env.EnvironmentName);
@@ -269,7 +269,7 @@ namespace Microsoft.Extensions.Hosting
                 .UseContentRoot("testroot")
                 .Build())
             {
-                var basePath = host.Services.GetRequiredService<IHostingEnvironment>().ContentRootPath;
+                var basePath = host.Services.GetRequiredService<IHostEnvironment>().ContentRootPath;
                 Assert.True(Path.IsPathRooted(basePath));
                 Assert.EndsWith(Path.DirectorySeparatorChar + "testroot", basePath);
             }
@@ -282,7 +282,7 @@ namespace Microsoft.Extensions.Hosting
                 .Build())
             {
                 var appBase = AppContext.BaseDirectory;
-                Assert.Equal(appBase, host.Services.GetService<IHostingEnvironment>().ContentRootPath);
+                Assert.Equal(appBase, host.Services.GetService<IHostEnvironment>().ContentRootPath);
             }
         }
 
@@ -292,10 +292,16 @@ namespace Microsoft.Extensions.Hosting
             using (var host = new HostBuilder()
                 .Build())
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.NotNull(host.Services.GetRequiredService<IHostingEnvironment>());
+#pragma warning restore CS0618 // Type or member is obsolete
+                Assert.NotNull(host.Services.GetRequiredService<IHostEnvironment>());
                 Assert.NotNull(host.Services.GetRequiredService<IConfiguration>());
                 Assert.NotNull(host.Services.GetRequiredService<HostBuilderContext>());
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.NotNull(host.Services.GetRequiredService<IApplicationLifetime>());
+#pragma warning restore CS0618 // Type or member is obsolete
+                Assert.NotNull(host.Services.GetRequiredService<IAppLifetime>());
                 Assert.NotNull(host.Services.GetRequiredService<ILoggerFactory>());
                 Assert.NotNull(host.Services.GetRequiredService<IOptions<FakeOptions>>());
             }
@@ -485,7 +491,7 @@ namespace Microsoft.Extensions.Hosting
                     });
                 })
                 .Build();
-            var env = host.Services.GetRequiredService<IHostingEnvironment>();
+            var env = host.Services.GetRequiredService<IHostEnvironment>();
 
             Assert.Equal(Path.GetFullPath("."), env.ContentRootPath);
             Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);

--- a/src/Hosting/Hosting/test/HostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/HostBuilderTests.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Extensions.Hosting
 #pragma warning disable CS0618 // Type or member is obsolete
                 Assert.NotNull(host.Services.GetRequiredService<IApplicationLifetime>());
 #pragma warning restore CS0618 // Type or member is obsolete
-                Assert.NotNull(host.Services.GetRequiredService<IAppLifetime>());
+                Assert.NotNull(host.Services.GetRequiredService<IHostApplicationLifetime>());
                 Assert.NotNull(host.Services.GetRequiredService<ILoggerFactory>());
                 Assert.NotNull(host.Services.GetRequiredService<IOptions<FakeOptions>>());
             }

--- a/src/Hosting/Hosting/test/HostTests.cs
+++ b/src/Hosting/Hosting/test/HostTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Hosting
             var host = builder.Build();
             var config = host.Services.GetRequiredService<IConfiguration>();
             Assert.Equal(expected, config["ContentRoot"]);
-            var env = host.Services.GetRequiredService<IHostingEnvironment>();
+            var env = host.Services.GetRequiredService<IHostEnvironment>();
             Assert.Equal(expected, env.ContentRootPath);
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Hosting
             var expected = Directory.GetParent(Directory.GetCurrentDirectory()).FullName; // It must exist
             var builder = Host.CreateDefaultBuilder(new string[] { "--contentroot", expected });
             var host = builder.Build();
-            var env = host.Services.GetRequiredService<IHostingEnvironment>();
+            var env = host.Services.GetRequiredService<IHostEnvironment>();
             Assert.Equal(expected, env.ContentRootPath);
         }
 

--- a/src/Hosting/Hosting/test/Internal/HostTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 .Build())
             {
                 await host.StartAsync();
-                var env = host.Services.GetService<IHostingEnvironment>();
+                var env = host.Services.GetService<IHostEnvironment>();
                 Assert.Equal("WithHostingEnvironment", env.EnvironmentName);
             }
         }
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             using (var host = CreateBuilder().Build())
             {
-                var env = host.Services.GetService<IHostingEnvironment>();
+                var env = host.Services.GetService<IHostEnvironment>();
                 Assert.Equal(EnvironmentName.Production, env.EnvironmentName);
             }
         }
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
             using (var host = CreateBuilder(config).Build())
             {
-                var env = host.Services.GetService<IHostingEnvironment>();
+                var env = host.Services.GetService<IHostEnvironment>();
                 Assert.Equal(EnvironmentName.Staging, env.EnvironmentName);
             }
         }
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var host = CreateBuilder().Build())
             {
                 await host.StartAsync();
-                var env = host.Services.GetRequiredService<IHostingEnvironment>();
+                var env = host.Services.GetRequiredService<IHostEnvironment>();
                 Assert.True(env.IsEnvironment(EnvironmentName.Production));
                 Assert.True(env.IsEnvironment("producTion"));
             }
@@ -146,7 +146,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                    })
                    .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
                 lifetime.StopApplication();
 
                 var svc = (TestHostedService)host.Services.GetRequiredService<IHostedService>();
@@ -434,7 +434,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 .ConfigureServices((services) => services.AddSingleton<IHostedService, FakeHostedService>())
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
                 service = (FakeHostedService)host.Services.GetRequiredService<IHostedService>();
 
                 var cts = new CancellationTokenSource();
@@ -560,7 +560,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var host = CreateBuilder()
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
                 var applicationStartedEvent = new ManualResetEventSlim(false);
                 var applicationStoppingEvent = new ManualResetEventSlim(false);
                 var applicationStoppedEvent = new ManualResetEventSlim(false);
@@ -651,7 +651,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var host = CreateBuilder()
                 .Build())
             {
-                var applicationLifetime = host.Services.GetService<IApplicationLifetime>();
+                var applicationLifetime = host.Services.GetService<IAppLifetime>();
 
                 Assert.False(applicationLifetime.ApplicationStarted.IsCancellationRequested);
 
@@ -661,12 +661,12 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         [Fact]
-        public async Task HostNotifiesAllIApplicationLifetimeCallbacksEvenIfTheyThrow()
+        public async Task HostNotifiesAllIAppLifetimeCallbacksEvenIfTheyThrow()
         {
             using (var host = CreateBuilder()
                 .Build())
             {
-                var applicationLifetime = host.Services.GetService<IApplicationLifetime>();
+                var applicationLifetime = host.Services.GetService<IAppLifetime>();
 
                 var started = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStarted);
                 var stopping = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStopping);
@@ -709,7 +709,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
                 lifetime.StopApplication();
 
                 await host.StartAsync();
@@ -731,7 +731,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                    })
                    .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
                 lifetime.StopApplication();
 
                 await host.StartAsync();
@@ -772,7 +772,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
 
                 Assert.Equal(0, startedCalls);
 
@@ -824,7 +824,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
 
                 Assert.Equal(0, startedCalls);
                 await host.StartAsync();
@@ -839,7 +839,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         [Fact]
-        public async Task HostDoesNotNotifyIApplicationLifetimeCallbacksIfIHostedServicesThrow()
+        public async Task HostDoesNotNotifyIAppLifetimeCallbacksIfIHostedServicesThrow()
         {
             bool[] events1 = null;
             bool[] events2 = null;
@@ -852,7 +852,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var applicationLifetime = host.Services.GetService<IApplicationLifetime>();
+                var applicationLifetime = host.Services.GetService<IAppLifetime>();
 
                 var started = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStarted);
                 var stopping = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStopping);
@@ -927,9 +927,9 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private class TestHostedService : IHostedService, IDisposable
         {
-            private readonly IApplicationLifetime _lifetime;
+            private readonly IAppLifetime _lifetime;
 
-            public TestHostedService(IApplicationLifetime lifetime)
+            public TestHostedService(IAppLifetime lifetime)
             {
                 _lifetime = lifetime;
             }

--- a/src/Hosting/Hosting/test/Internal/HostTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                    })
                    .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
                 lifetime.StopApplication();
 
                 var svc = (TestHostedService)host.Services.GetRequiredService<IHostedService>();
@@ -434,7 +434,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 .ConfigureServices((services) => services.AddSingleton<IHostedService, FakeHostedService>())
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
                 service = (FakeHostedService)host.Services.GetRequiredService<IHostedService>();
 
                 var cts = new CancellationTokenSource();
@@ -560,7 +560,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var host = CreateBuilder()
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
                 var applicationStartedEvent = new ManualResetEventSlim(false);
                 var applicationStoppingEvent = new ManualResetEventSlim(false);
                 var applicationStoppedEvent = new ManualResetEventSlim(false);
@@ -651,7 +651,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var host = CreateBuilder()
                 .Build())
             {
-                var applicationLifetime = host.Services.GetService<IAppLifetime>();
+                var applicationLifetime = host.Services.GetService<IHostApplicationLifetime>();
 
                 Assert.False(applicationLifetime.ApplicationStarted.IsCancellationRequested);
 
@@ -666,7 +666,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using (var host = CreateBuilder()
                 .Build())
             {
-                var applicationLifetime = host.Services.GetService<IAppLifetime>();
+                var applicationLifetime = host.Services.GetService<IHostApplicationLifetime>();
 
                 var started = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStarted);
                 var stopping = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStopping);
@@ -709,7 +709,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
                 lifetime.StopApplication();
 
                 await host.StartAsync();
@@ -731,7 +731,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                    })
                    .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
                 lifetime.StopApplication();
 
                 await host.StartAsync();
@@ -772,7 +772,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
                 Assert.Equal(0, startedCalls);
 
@@ -824,7 +824,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var lifetime = host.Services.GetRequiredService<IAppLifetime>();
+                var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
                 Assert.Equal(0, startedCalls);
                 await host.StartAsync();
@@ -852,7 +852,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                var applicationLifetime = host.Services.GetService<IAppLifetime>();
+                var applicationLifetime = host.Services.GetService<IHostApplicationLifetime>();
 
                 var started = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStarted);
                 var stopping = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStopping);
@@ -927,9 +927,9 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private class TestHostedService : IHostedService, IDisposable
         {
-            private readonly IAppLifetime _lifetime;
+            private readonly IHostApplicationLifetime _lifetime;
 
-            public TestHostedService(IAppLifetime lifetime)
+            public TestHostedService(IHostApplicationLifetime lifetime)
             {
                 _lifetime = lifetime;
             }

--- a/src/Hosting/Hosting/test/Internal/HostTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostTests.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         [Fact]
-        public async Task HostNotifiesAllIAppLifetimeCallbacksEvenIfTheyThrow()
+        public async Task HostNotifiesAllIHostApplicationLifetimeCallbacksEvenIfTheyThrow()
         {
             using (var host = CreateBuilder()
                 .Build())
@@ -839,7 +839,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         [Fact]
-        public async Task HostDoesNotNotifyIAppLifetimeCallbacksIfIHostedServicesThrow()
+        public async Task HostDoesNotNotifyIHostApplicationLifetimeCallbacksIfIHostedServicesThrow()
         {
             bool[] events1 = null;
             bool[] events2 = null;

--- a/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs" />

--- a/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs
+++ b/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs
@@ -12,8 +12,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
 {
     public partial class ServiceBaseLifetime : System.ServiceProcess.ServiceBase, Microsoft.Extensions.Hosting.IHostLifetime
     {
-        public ServiceBaseLifetime(Microsoft.Extensions.Hosting.IHostingEnvironment environment, Microsoft.Extensions.Hosting.IApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
-        public Microsoft.Extensions.Hosting.IHostingEnvironment Environment { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public ServiceBaseLifetime(Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         protected override void OnStart(string[] args) { }
         protected override void OnStop() { }
         public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/Hosting/WindowsServices/src/ServiceBaseLifetime.cs
+++ b/src/Hosting/WindowsServices/src/ServiceBaseLifetime.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
     {
         private TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>();
 
-        public ServiceBaseLifetime(IHostingEnvironment environment, IApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory)
+        public ServiceBaseLifetime(IHostingEnvironment environment, IAppLifetime applicationLifetime, ILoggerFactory loggerFactory)
         {
             Environment = environment ?? throw new ArgumentNullException(nameof(environment));
             ApplicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
@@ -21,8 +21,8 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         public IHostingEnvironment Environment { get; }
-        private IApplicationLifetime ApplicationLifetime { get; }
         private ILogger Logger { get; }
+        private IAppLifetime ApplicationLifetime { get; }
 
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {

--- a/src/Hosting/WindowsServices/src/ServiceBaseLifetime.cs
+++ b/src/Hosting/WindowsServices/src/ServiceBaseLifetime.cs
@@ -13,16 +13,16 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
     {
         private TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>();
 
-        public ServiceBaseLifetime(IHostingEnvironment environment, IAppLifetime applicationLifetime, ILoggerFactory loggerFactory)
+        public ServiceBaseLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory)
         {
             Environment = environment ?? throw new ArgumentNullException(nameof(environment));
             ApplicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
             Logger = loggerFactory.CreateLogger("Microsoft.Hosting.Lifetime");
         }
 
-        public IHostingEnvironment Environment { get; }
+        private IHostEnvironment Environment { get; }
         private ILogger Logger { get; }
-        private IAppLifetime ApplicationLifetime { get; }
+        private IHostApplicationLifetime ApplicationLifetime { get; }
 
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {

--- a/src/Hosting/WindowsServices/src/ServiceBaseLifetime.cs
+++ b/src/Hosting/WindowsServices/src/ServiceBaseLifetime.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             Logger = loggerFactory.CreateLogger("Microsoft.Hosting.Lifetime");
         }
 
+        private IHostApplicationLifetime ApplicationLifetime { get; }
         private IHostEnvironment Environment { get; }
         private ILogger Logger { get; }
-        private IHostApplicationLifetime ApplicationLifetime { get; }
 
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {

--- a/src/Hosting/samples/SampleMsmqHost/Program.cs
+++ b/src/Hosting/samples/SampleMsmqHost/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Messaging;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,7 +59,7 @@ namespace SampleMsmqHost
         private static void StartReadLoop(IHost host)
         {
             var connection = host.Services.GetRequiredService<IMsmqConnection>();
-            var applicationLifetime = host.Services.GetRequiredService<IApplicationLifetime>();
+            var applicationLifetime = host.Services.GetRequiredService<IAppLifetime>();
 
             // run the read loop in a background thread so that it can be stopped with CTRL+C
             Task.Run(() => ReadLoop(connection, applicationLifetime.ApplicationStopping));

--- a/src/Hosting/samples/SampleMsmqHost/Program.cs
+++ b/src/Hosting/samples/SampleMsmqHost/Program.cs
@@ -59,7 +59,7 @@ namespace SampleMsmqHost
         private static void StartReadLoop(IHost host)
         {
             var connection = host.Services.GetRequiredService<IMsmqConnection>();
-            var applicationLifetime = host.Services.GetRequiredService<IAppLifetime>();
+            var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
             // run the read loop in a background thread so that it can be stopped with CTRL+C
             Task.Run(() => ReadLoop(connection, applicationLifetime.ApplicationStopping));

--- a/src/HttpClientFactory/Http/ref/Microsoft.Extensions.Http.csproj
+++ b/src/HttpClientFactory/Http/ref/Microsoft.Extensions.Http.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Http.netstandard2.0.cs" />

--- a/src/HttpClientFactory/Polly/ref/Microsoft.Extensions.Http.Polly.csproj
+++ b/src/HttpClientFactory/Polly/ref/Microsoft.Extensions.Http.Polly.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Http.Polly.netstandard2.0.cs" />

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.JSInterop.netstandard2.0.cs" />

--- a/src/JSInterop/Mono.WebAssembly.Interop/ref/Mono.WebAssembly.Interop.csproj
+++ b/src/JSInterop/Mono.WebAssembly.Interop/ref/Mono.WebAssembly.Interop.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Mono.WebAssembly.Interop.netstandard2.0.cs" />

--- a/src/Localization/Abstractions/ref/Microsoft.Extensions.Localization.Abstractions.csproj
+++ b/src/Localization/Abstractions/ref/Microsoft.Extensions.Localization.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Localization.Abstractions.netstandard2.0.cs" />

--- a/src/Localization/Localization/ref/Microsoft.Extensions.Localization.csproj
+++ b/src/Localization/Localization/ref/Microsoft.Extensions.Localization.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Localization.netstandard2.0.cs" />

--- a/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/Logging/Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.Abstractions.netstandard2.0.cs" />

--- a/src/Logging/Logging.AzureAppServices/ref/Microsoft.Extensions.Logging.AzureAppServices.csproj
+++ b/src/Logging/Logging.AzureAppServices/ref/Microsoft.Extensions.Logging.AzureAppServices.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.AzureAppServices.netstandard2.0.cs" />

--- a/src/Logging/Logging.Configuration/ref/Microsoft.Extensions.Logging.Configuration.csproj
+++ b/src/Logging/Logging.Configuration/ref/Microsoft.Extensions.Logging.Configuration.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.Configuration.netstandard2.0.cs" />

--- a/src/Logging/Logging.Console/ref/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/Logging/Logging.Console/ref/Microsoft.Extensions.Logging.Console.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.Console.netstandard2.0.cs" />

--- a/src/Logging/Logging.Debug/ref/Microsoft.Extensions.Logging.Debug.csproj
+++ b/src/Logging/Logging.Debug/ref/Microsoft.Extensions.Logging.Debug.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.Debug.netstandard2.0.cs" />

--- a/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.EventLog.netstandard2.0.cs" />

--- a/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.EventSource.netstandard2.0.cs" />

--- a/src/Logging/Logging.TraceSource/ref/Microsoft.Extensions.Logging.TraceSource.csproj
+++ b/src/Logging/Logging.TraceSource/ref/Microsoft.Extensions.Logging.TraceSource.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.TraceSource.netstandard2.0.cs" />

--- a/src/Logging/Logging/ref/Microsoft.Extensions.Logging.csproj
+++ b/src/Logging/Logging/ref/Microsoft.Extensions.Logging.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.netstandard2.0.cs" />

--- a/src/ObjectPool/ref/Microsoft.Extensions.ObjectPool.csproj
+++ b/src/ObjectPool/ref/Microsoft.Extensions.ObjectPool.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.ObjectPool.netstandard2.0.cs" />

--- a/src/Options/ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.csproj
+++ b/src/Options/ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Options.ConfigurationExtensions.netstandard2.0.cs" />

--- a/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.csproj
+++ b/src/Options/DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Options.DataAnnotations.netstandard2.0.cs" />

--- a/src/Options/Options/ref/Microsoft.Extensions.Options.csproj
+++ b/src/Options/Options/ref/Microsoft.Extensions.Options.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Options.netstandard2.0.cs" />

--- a/src/Primitives/ref/Microsoft.Extensions.Primitives.csproj
+++ b/src/Primitives/ref/Microsoft.Extensions.Primitives.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Primitives.netstandard2.0.cs" />

--- a/src/WebEncoders/ref/Microsoft.Extensions.WebEncoders.csproj
+++ b/src/WebEncoders/ref/Microsoft.Extensions.WebEncoders.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.WebEncoders.netstandard2.0.cs" />

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -13,9 +13,13 @@ SET PATH=%DOTNET_ROOT%;%PATH%
 
 SET sln=%1
 
+IF "%sln%"=="" (
+    SET sln=Extensions.sln
+)
+
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
     echo .NET Core has not yet been installed. Running restore.cmd to install it.
     call restore.cmd
 )
 
-start %~dp0Extensions.sln
+start %sln%


### PR DESCRIPTION
 #966
- IHostingEnvronment -> IHostEnvronment 
- IApplicationLifetime -> IAppLifetime

@davidfowl since the old types still exist the namespace conflict remains. It might be better to remove the old types.

@glennc 