### PR TITLE
Produce a transport package with symbols

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,7 @@ jobs:
 
           Release:
             _BuildConfig: Release
+            _BuildArgs:
             # PRs or external builds are not signed.
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               _SignType: test
@@ -86,10 +87,7 @@ jobs:
       steps:
       - checkout: self
         clean: true
-      - script: eng\common\cibuild.cmd
-          -configuration $(_BuildConfig)
-          -prepareMachine
-          $(_BuildArgs)
+      - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
         displayName: Build and Publish
       - powershell: eng\common\msbuild.ps1 eng/repo.targets /t:TagCiBuilds '/p:IsFinalBuild=$(IsFinalBuild)' '/p:CI=true'
         displayName: Set CI Tags

--- a/src/Internal/Refs/pkg/Microsoft.Internal.Extensions.Refs.csproj
+++ b/src/Internal/Refs/pkg/Microsoft.Internal.Extensions.Refs.csproj
@@ -1,0 +1,66 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <PackageDescription>For internal-use only. This package contains reference assemblies for Microsoft.Extensions projects.</PackageDescription>
+
+    <!--
+      This package is not meant to be used as a regular PackageReference. This is mean to transport
+      bits to the AspNetCore repo which builds a targeting pack with these assembies.
+    -->
+    <PackageType>Transport</PackageType>
+    <RefAssemblyPackagePath>data/refs/$(TargetFramework)/</RefAssemblyPackagePath>
+
+    <!-- There are no symbols for reference assemblies. -->
+    <IncludeSymbols>false</IncludeSymbols>
+
+    <!-- The project representing the shared framework doesn't produce a .NET assembly or symbols. -->
+    <DebugType>none</DebugType>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+
+    <!-- This project should not be referenced via the `<Reference>` impementation. -->
+    <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="@(ProjectReferenceProvider->Metadata(RefProjectPath))" />
+
+    <Content Include="Microsoft.Internal.Extensions.Refs.props" PackagePath="build/" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <BuildDependsOn>
+      $(BuildDependsOn);
+      _ResolveTargetingPackContent;
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->
+  <Target Name="GetTargetPath" />
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
+
+  <!-- This project doesn't compile anything. -->
+  <Target Name="CoreCompile" />
+
+  <!-- Completely disable default targets for copying to output. -->
+  <Target Name="CopyFilesToOutputDirectory" />
+
+  <!-- This target finds the reference assemblies. -->
+  <Target Name="_ResolveTargetingPackContent"
+          BeforeTargets="_GetPackageFiles"
+          DependsOnTargets="ResolveReferences;FindReferenceAssembliesForReferences">
+    <ItemGroup>
+      <_PackageFiles
+          Include="@(ReferencePathWithRefAssemblies->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))"
+          PackagePath="$(RefAssemblyPackagePath)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Internal/Refs/pkg/Microsoft.Internal.Extensions.Refs.props
+++ b/src/Internal/Refs/pkg/Microsoft.Internal.Extensions.Refs.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftExtensionsReferenceAssemblyRoot>$(MSBuildThisFileDirectory)..\data\refs\</MicrosoftExtensionsReferenceAssemblyRoot>
+  </PropertyGroup>
+</Project>

--- a/src/Internal/Symbols/pkg/Microsoft.Internal.Extensions.Symbols.csproj
+++ b/src/Internal/Symbols/pkg/Microsoft.Internal.Extensions.Symbols.csproj
@@ -5,13 +5,15 @@
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <PackageDescription>For internal-use only. This package contains symbols for Microsoft.Extensions projects.</PackageDescription>
 
-    <!-- Subject to change: see https://github.com/dotnet/designs/pull/50 -->
-    <PackageType>TargetingPack</PackageType>
-    <RefAssemblyPackagePath>ref/$(TargetFramework)/</RefAssemblyPackagePath>
-
-    <!-- There are no symbols for reference assemblies. -->
-    <IncludeSymbols>false</IncludeSymbols>
+    <!--
+      This package is not meant to be used as a regular PackageReference. This is mean to transport
+      bits to the AspNetCore repo which builds a targeting pack with these assembies.
+    -->
+    <PackageType>Transport</PackageType>
+    <SymbolsPackagePath>data/symbols/$(TargetFramework)/</SymbolsPackagePath>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <!-- The project representing the shared framework doesn't produce a .NET assembly or symbols. -->
     <DebugType>none</DebugType>
@@ -26,21 +28,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="@(ProjectReferenceProvider->Metadata(RefProjectPath))" />
+    <ProjectReference Include="@(ProjectReferenceProvider->HasMetadata('RefProjectPath')->Metadata('ProjectPath'))" />
+
+    <Content Include="Microsoft.Internal.Extensions.Symbols.props" PackagePath="build/" />
   </ItemGroup>
 
   <PropertyGroup>
     <BuildDependsOn>
       $(BuildDependsOn);
-      _ResolveTargetingPackContent;
+      _ResolveSymbolsPackageContent;
     </BuildDependsOn>
   </PropertyGroup>
 
   <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->
   <Target Name="GetTargetPath" />
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)">
-    <Message Importance="High" Text="$(MSBuildProjectName) -> $(TargetDir)" />
-  </Target>
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
 
   <!-- This project doesn't compile anything. -->
   <Target Name="CoreCompile" />
@@ -49,16 +51,13 @@
   <Target Name="CopyFilesToOutputDirectory" />
 
   <!-- This target finds the reference assemblies. -->
-  <Target Name="_ResolveTargetingPackContent"
+  <Target Name="_ResolveSymbolsPackageContent"
           BeforeTargets="_GetPackageFiles"
-          DependsOnTargets="ResolveReferences;FindReferenceAssembliesForReferences">
+          DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <AspNetCoreReferenceAssemblyPath
-          Include="@(ReferencePathWithRefAssemblies->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-
-      <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" />
-
-      <_PackageFiles Include="@(RefPackContent)" PackagePath="$(RefAssemblyPackagePath)" />
+      <_PackageFiles
+          Include="@(_ResolvedProjectReferencePaths->'%(RootDir)%(Directory)%(FileName).pdb')"
+          PackagePath="$(SymbolsPackagePath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Internal/Symbols/pkg/Microsoft.Internal.Extensions.Symbols.props
+++ b/src/Internal/Symbols/pkg/Microsoft.Internal.Extensions.Symbols.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftExtensionsSymbolsRoot>$(MSBuildThisFileDirectory)..\data\symbols\</MicrosoftExtensionsSymbolsRoot>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Many of the assemblies from this repo are used in the AspNetCore shared framework. These symbols are needed so the crossgen tool can re-generate symbols.

We can't use regular `.symbols.nupkg` files because these are not actually available on a restore feed as a package.

cref https://github.com/aspnet/AspNetCore/issues/7073