### PR TITLE
Fail when activate is executed instead of 'dot sourced'

### DIFF
--- a/activate.ps1
+++ b/activate.ps1
@@ -1,8 +1,15 @@
 #
 # This file must be used by invoking ". .\activate.ps1" from the command line.
-# You cannot run it directly.
+# You cannot run it directly. See https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_scripts#script-scope-and-dot-sourcing
+#
 # To exit from the environment this creates, execute the 'deactivate' function.
 #
+
+if ($MyInvocation.CommandOrigin -eq 'runspace') {
+    Write-Host -f Red "This script cannot be invoked directly."
+    Write-Host -f Red "To function correctly, this script file must be 'dot sourced' by calling `". $PSCommandPath`" (notice the dot at the beginning)."
+    exit 1
+}
 
 function deactivate ([switch]$init) {
 

--- a/activate.sh
+++ b/activate.sh
@@ -27,8 +27,8 @@ else # All other shells: examine $0 for known shell binary filenames
 fi
 
 if [ $sourced -eq 0 ]; then
-    echo -e "${_RED}This script cannot be invoked directly.${_RESET}"
-    echo -e "${_RED}To function correctly, this script file must be sourced by calling \"source $0\".${_RESET}"
+    printf "${_RED}This script cannot be invoked directly.${_RESET}\n"
+    printf "${_RED}To function correctly, this script file must be sourced by calling \"source $0\".${_RESET}\n"
     exit 1
 fi
 
@@ -85,10 +85,10 @@ if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
     hash -r 2>/dev/null
 fi
 
-echo -e "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}"
+printf "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}\n"
 
 if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
-    echo -e "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}"
+    printf "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}\n"
 else
-    echo -e "dotnet = $DOTNET_ROOT/dotnet"
+    printf "dotnet = $DOTNET_ROOT/dotnet\n"
 fi

--- a/activate.sh
+++ b/activate.sh
@@ -3,9 +3,34 @@
 # You cannot run it directly.
 # To exit from the environment this creates, execute the 'deactivate' function.
 
+_RED="\033[0;31m"
 _MAGENTA="\033[0;95m"
 _YELLOW="\033[0;33m"
 _RESET="\033[0m"
+
+# This detects if a script was sourced or invoked directly
+# See https://stackoverflow.com/a/28776166/2526265
+sourced=0
+if [ -n "$ZSH_EVAL_CONTEXT" ]; then
+  case $ZSH_EVAL_CONTEXT in *:file) sourced=1;; esac
+  THIS_SCRIPT="${0:-}"
+elif [ -n "$KSH_VERSION" ]; then
+  [ "$(cd $(dirname -- $0) && pwd -P)/$(basename -- $0)" != "$(cd $(dirname -- ${.sh.file}) && pwd -P)/$(basename -- ${.sh.file})" ] && sourced=1
+  THIS_SCRIPT="${0:-}"
+elif [ -n "$BASH_VERSION" ]; then
+  (return 2>/dev/null) && sourced=1
+  THIS_SCRIPT="$BASH_SOURCE"
+else # All other shells: examine $0 for known shell binary filenames
+  # Detects `sh` and `dash`; add additional shell filenames as needed.
+  case ${0##*/} in sh|dash) sourced=1;; esac
+  THIS_SCRIPT="${0:-}"
+fi
+
+if [ $sourced -eq 0 ]; then
+    echo -e "${_RED}This script cannot be invoked directly.${_RESET}"
+    echo -e "${_RED}To function correctly, this script file must be sourced by calling \"source $0\".${_RESET}"
+    exit 1
+fi
 
 deactivate () {
 
@@ -38,7 +63,7 @@ deactivate () {
 # Cleanup the environment
 deactivate init
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "$THIS_SCRIPT" )" && pwd )"
 _OLD_PATH="$PATH"
 # Tell dotnet where to find itself
 export DOTNET_ROOT="$DIR/.dotnet"
@@ -60,10 +85,10 @@ if [ -n "${BASH:-}" ] || [ -n "${ZSH_VERSION:-}" ] ; then
     hash -r 2>/dev/null
 fi
 
-echo "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}"
+echo -e "${_MAGENTA}Enabled the .NET Core environment. Execute 'deactivate' to exit.${_RESET}"
 
 if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
-    echo "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}"
+    echo -e "${_YELLOW}.NET Core has not been installed yet. Run $DIR/restore.sh to install it.${_RESET}"
 else
-    echo "dotnet = $DOTNET_ROOT/dotnet"
+    echo -e "dotnet = $DOTNET_ROOT/dotnet"
 fi

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -53,8 +53,10 @@ Because we are using pre-release versions of .NET Core, you have to set a handfu
 to make the .NET Core command line tool work well. You can set these environment variables like this
 
 On Windows (requires PowerShell):
-```
-. activate.ps1
+```ps1
+# The extra dot at the beginning is required to 'dot source' this file into the right scope.
+
+. .\activate.ps1
 ```
 
 On macOS/Linux:


### PR DESCRIPTION
Helps users avoid a common mistake which is otherwise not obvious.

![image](https://user-images.githubusercontent.com/2696087/53064777-dcb64580-347d-11e9-86b1-a24ea45d29c0.png)

