### PR TITLE
Set copyright and package license

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,10 +23,15 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\Workarounds.AfterArcade.props" />
 
+  <PropertyGroup Condition="'$(CopyrightMicrosoft)' != ''">
+    <Copyright>$(CopyrightMicrosoft)</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+  </PropertyGroup>
+
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
     <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseUrl Condition="'$(PackageLicenseExpression)' == ''">https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt</PackageLicenseUrl>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageProjectUrl>https://asp.net</PackageProjectUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
Prepares repo for change https://github.com/dotnet/arcade/pull/2003 by setting `Copyright` and `PackageLicenseExpression` properties. These values will be required to be set by each repository once https://github.com/dotnet/arcade/pull/2003 is merged.

In order to not break the current builds this change sets the properties conditionally. This condition can be removed once all repos switch to Arcade that has https://github.com/dotnet/arcade/pull/2003.

@markwilkie
