### PR TITLE
Atomically swap config data

### DIFF
--- a/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Configuration/Config.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
 
         internal void Load(IDictionary envVariables)
         {
-            Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             var filteredEnvVariables = envVariables
                 .Cast<DictionaryEntry>()
@@ -58,8 +58,10 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             foreach (var envVariable in filteredEnvVariables)
             {
                 var key = ((string)envVariable.Key).Substring(_prefix.Length);
-                Data[key] = (string)envVariable.Value;
+                data[key] = (string)envVariable.Value;
             }
+
+            Data = data;
         }
 
         private static string NormalizeKey(string key)

--- a/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
+++ b/src/Configuration/Config.EnvironmentVariables/test/EnvironmentVariablesTest.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration.Test;
 using Xunit;
 
@@ -147,6 +151,49 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
 
             Assert.Equal("connection", envConfigSrc.Get("data:ConnectionString"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:_db1_ProviderName"));
+        }
+
+        [Fact]
+        public void BindingDoesNotThrowIfReloadedDuringBinding()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Number", "-2"},
+                {"Text", "Foo"}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            configurationBuilder.AddEnvironmentVariables();
+            var config = configurationBuilder.Build();
+
+            MyOptions options = null;
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250)))
+            {
+                void ReloadLoop()
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        config.Reload();
+                    }
+                }
+
+                _ = Task.Run(ReloadLoop);
+
+                while (!cts.IsCancellationRequested)
+                {
+                    options = config.Get<MyOptions>();
+                }
+            }
+
+            Assert.Equal(-2, options.Number);
+            Assert.Equal("Foo", options.Text);
+        }
+
+        private sealed class MyOptions
+        {
+            public int Number { get; set; }
+            public string Text { get; set; }
         }
     }
 }

--- a/src/Configuration/Config.KeyPerFile/src/KeyPerFileConfigurationProvider.cs
+++ b/src/Configuration/Config.KeyPerFile/src/KeyPerFileConfigurationProvider.cs
@@ -31,12 +31,13 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
         /// </summary>
         public override void Load()
         {
-            Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             if (Source.FileProvider == null)
             {
                 if (Source.Optional)
                 {
+                    Data = data;
                     return;
                 }
 
@@ -61,10 +62,12 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
                 {
                     if (Source.IgnoreCondition == null || !Source.IgnoreCondition(file.Name))
                     {
-                        Data.Add(NormalizeKey(file.Name), TrimNewLine(streamReader.ReadToEnd()));
+                        data.Add(NormalizeKey(file.Name), TrimNewLine(streamReader.ReadToEnd()));
                     }
                 }
             }
+
+            Data = data;
         }
 
         private string GetDirectoryName()

--- a/src/Configuration/test/Config.FunctionalTests/ConfigurationTests.cs
+++ b/src/Configuration/test/Config.FunctionalTests/ConfigurationTests.cs
@@ -944,9 +944,7 @@ IniKey1=IniValue2");
             Assert.True(token.HasChanged);
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "File watching is flaky on non windows.")]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "File watching is flaky on non windows.")]
+        [Fact]
         public void BindingDoesNotThrowIfReloadedDuringBinding()
         {
             WriteTestFiles();

--- a/src/Configuration/test/Config.FunctionalTests/ConfigurationTests.cs
+++ b/src/Configuration/test/Config.FunctionalTests/ConfigurationTests.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Configuration.Ini;
 using Microsoft.Extensions.Configuration.Json;
-using Microsoft.Extensions.Configuration.Xml;
 using Microsoft.Extensions.Configuration.UserSecrets;
+using Microsoft.Extensions.Configuration.Xml;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using Xunit;
@@ -944,6 +944,50 @@ IniKey1=IniValue2");
             Assert.True(token.HasChanged);
         }
 
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "File watching is flaky on non windows.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "File watching is flaky on non windows.")]
+        public void BindingDoesNotThrowIfReloadedDuringBinding()
+        {
+            WriteTestFiles();
+
+            var configurationBuilder = CreateBuilder();
+            configurationBuilder.Add(new TestIniSourceProvider(_iniFile));
+            configurationBuilder.Add(new TestJsonSourceProvider(_jsonFile));
+            configurationBuilder.Add(new TestXmlSourceProvider(_xmlFile));
+            configurationBuilder.AddEnvironmentVariables();
+            configurationBuilder.AddCommandLine(new[] { "--CmdKey1=CmdValue1" });
+            configurationBuilder.AddInMemoryCollection(_memConfigContent);
+
+            var config = configurationBuilder.Build();
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250)))
+            {
+                void ReloadLoop()
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        config.Reload();
+                    }
+                }
+
+                _ = Task.Run(ReloadLoop);
+
+                MyOptions options = null;
+
+                while (!cts.IsCancellationRequested)
+                {
+                    options = config.Get<MyOptions>();
+                }
+
+                Assert.Equal("CmdValue1", options.CmdKey1);
+                Assert.Equal("IniValue1", options.IniKey1);
+                Assert.Equal("JsonValue1", options.JsonKey1);
+                Assert.Equal("MemValue1", options.MemKey1);
+                Assert.Equal("XmlValue1", options.XmlKey1);
+            }
+        }
+
         public void Dispose()
         {
             _fileProvider.Dispose();
@@ -965,6 +1009,19 @@ IniKey1=IniValue2");
 
                 await Task.Delay(_msDelay);
             }
+        }
+
+        private sealed class MyOptions
+        {
+            public string CmdKey1 { get; set; }
+
+            public string IniKey1 { get; set; }
+
+            public string JsonKey1 { get; set; }
+
+            public string MemKey1 { get; set; }
+
+            public string XmlKey1 { get; set; }
         }
     }
 }

--- a/src/Configuration/test/Config.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
+++ b/src/Configuration/test/Config.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
@@ -9,6 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
+    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <Reference Include="Microsoft.Extensions.Configuration.Ini" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration.Xml" />


### PR DESCRIPTION
Swap the config providers' data atomically instead of changing the property.

This is so that any enumeration of the dictionary running during a (re)load operation does not throw an `InvalidOperationException` due to the collection being modified.

Addresses #1189
