### PR TITLE
Use TryGetValue() for dictionary

### DIFF
--- a/src/Configuration/Config.CommandLine/src/CommandLineConfigurationProvider.cs
+++ b/src/Configuration/Config.CommandLine/src/CommandLineConfigurationProvider.cs
@@ -76,9 +76,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                         }
 
                         // If the switch is a key in given switch mappings, interpret it
-                        if (_switchMappings != null && _switchMappings.ContainsKey(currentArg))
+                        if (_switchMappings != null && _switchMappings.TryGetValue(currentArg, out var mappedKey))
                         {
-                            key = _switchMappings[currentArg];
+                            key = mappedKey;
                         }
                         // If the switch starts with a single "-" and it isn't in given mappings , it is an invalid usage so ignore it
                         else if (keyStartIndex == 1)
@@ -105,9 +105,9 @@ namespace Microsoft.Extensions.Configuration.CommandLine
                         var keySegment = currentArg.Substring(0, separator);
 
                         // If the switch is a key in given switch mappings, interpret it
-                        if (_switchMappings != null && _switchMappings.ContainsKey(keySegment))
+                        if (_switchMappings != null && _switchMappings.TryGetValue(keySegment, out var mappedKeySegment))
                         {
-                            key = _switchMappings[keySegment];
+                            key = mappedKeySegment;
                         }
                         // If the switch starts with a single "-" and it isn't in given mappings , it is an invalid usage
                         else if (keyStartIndex == 1)


### PR DESCRIPTION
Use `TryGetValue()` when accessing the mapping dictionary, rather than `ContainsKey()` + `[]`.
