### PR TITLE
Use Array.Empty<T>()

### DIFF
--- a/src/Configuration/Config/src/ConfigurationKeyComparer.cs
+++ b/src/Configuration/Config/src/ConfigurationKeyComparer.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Extensions.Configuration
         /// <returns></returns>
         public int Compare(string x, string y)
         {
-            var xParts = x?.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
-            var yParts = y?.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
+            var xParts = x?.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+            var yParts = y?.Split(_keyDelimiterArray, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
 
             // Compare each part until we get two parts that are not equal
             for (int i = 0; i < Math.Min(xParts.Length, yParts.Length); i++)
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.Configuration
                 var xIsInt = x != null && int.TryParse(x, out value1);
                 var yIsInt = y != null && int.TryParse(y, out value2);
 
-                int result = 0;
+                int result;
 
                 if (!xIsInt && !yIsInt)
                 {


### PR DESCRIPTION
Use `Array.Empty<string>()` instead of allocating a new array if either of the strings for comparison are null.
