### PR TITLE
Fix aspnet/AspNetCore-Internal#1869

### DIFF
--- a/src/HttpClientFactory/Http/test/DefaultHttpClientFactoryTest.cs
+++ b/src/HttpClientFactory/Http/test/DefaultHttpClientFactoryTest.cs
@@ -482,7 +482,11 @@ namespace Microsoft.Extensions.Http
                 kvp = default;
             }
 
-            // Act - 1
+            // Let's verify the the ActiveHandlerTrackingEntry is gone. This would be prevent
+            // the handler from being disposed if it was still rooted.
+            Assert.Empty(factory.ActiveEntryState);
+
+            // Act - 1 - Run a cleanup cycle, this will not dispose the handler, because the client is still live.
             factory.CleanupTimer_Tick();
 
             // Assert
@@ -496,6 +500,7 @@ namespace Microsoft.Extensions.Http
             lock (this)
             {
                 // Prevent reordering
+                GC.KeepAlive(client1);
                 client1 = null;
             }
 


### PR DESCRIPTION
I think the issue here is that the HttpClient goes out of scope too
early and the cleanup pass is able to dispose it before we intend for it
to be disposed.

GC.Keepalive will preserve the liveness until the point we're ready to
null it out.
