### PR TITLE
Make our usage of TypeBuilder single-threaded

### DIFF
--- a/src/DiagnosticAdapter/src/Internal/ProxyAssembly.cs
+++ b/src/DiagnosticAdapter/src/Internal/ProxyAssembly.cs
@@ -14,13 +14,16 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
     // The use peverify or another tool to look at the generated code.
     public static class ProxyAssembly
     {
-        private static volatile int Counter = 0;
+        private static readonly object Lock;
+        private static int Counter;
 
         private static AssemblyBuilder AssemblyBuilder;
         private static ModuleBuilder ModuleBuilder;
 
         static ProxyAssembly()
         {
+            Lock = new object();
+
             var assemblyName = new AssemblyName("Microsoft.Extensions.DiagnosticAdapter.ProxyAssembly");
 #if GENERATE_ASSEMBLIES
             var access = AssemblyBuilderAccess.RunAndSave;
@@ -38,8 +41,11 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
             Type baseType,
             Type[] interfaces)
         {
-            name = name + "_" + Counter++;
-            return ModuleBuilder.DefineType(name, attributes, baseType, interfaces);
+            lock (Lock)
+            {
+                name = name + "_" + Counter++;
+                return ModuleBuilder.DefineType(name, attributes, baseType, interfaces);
+            }
         }
 
 #if GENERATE_ASSEMBLIES


### PR DESCRIPTION
Fixes aspnet/AspNet-Internal#1797

From what we're seeing in the logs, the most likely case is that the
generated constructor for some proxy type is using the wrong data, ie: a
thread-safety issue.

The other clue is that the generated type name is
`Proxy_From_Person_To_IPerson_5` - this means that several tests were
trying to use the same simple type names, and there's the potential for
contention declaring these names.

It turns out that the way we're generating these types names isn't
atomic. TypeBuilder/ModuleBuilder try to protect agaisnt duplicate
names, and try to be thread safe, but it's not clear to me that it works
end to end.

I'm making a change here to make this code operate single-threaded. We
shouldn't expect any major performance hit from changing this since we
already cache proxies up front.
