### PR TITLE
add FlakyAttribute to mark flaky tests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,5 +47,8 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\Workarounds.AfterArcade.targets" />
 
+  <!-- Only needed on AzDO: Flaky Test handling -->
+  <Import Project="eng\FlakyTests.targets" Condition="'$(BUILD_BUILDNUMBER)' != ''" />
+
   <Import Project="eng\targets\Npm.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
 </Project>

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -22,7 +22,6 @@
       <!-- Replace the previous runs -->
       <TestToRun Remove="@(TestToRun)" />
 
-
       <!-- TODO: Replace with below when https://github.com/dotnet/arcade/issues/2182 is in -->
       <!-- <TestToRun Include="@(NonFlakyRuns);@(FlakyRuns)" /> -->
       <TestToRun Include="@(NonFlakyRuns)" />

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -1,8 +1,8 @@
 <Project>
   <Target Name="_GenerateTestPasses" DependsOnTargets="$(_GetTestsToRunTarget)">
     <PropertyGroup>
-      <_FlakyRunAdditionalArgs>-trait "Flaky:AzDO=true"</_FlakyRunAdditionalArgs>
-      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzDO=true"</_NonFlakyRunAdditionalArgs>
+      <_FlakyRunAdditionalArgs>-trait "Flaky:AzDO:all=true"</_FlakyRunAdditionalArgs>
+      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzDO:all=true"</_NonFlakyRunAdditionalArgs>
     </PropertyGroup>
     <ItemGroup>
       <!-- Take the TestToRun values and update them to only run non-flaky tests -->

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -22,10 +22,10 @@
       <!-- Replace the previous runs -->
       <TestToRun Remove="@(TestToRun)" />
 
-      <!-- <TestToRun Include="@(NonFlakyRuns)" /> -->
 
-      <!-- TODO: Uncomment when [arcade issue to enable ignoring exit code] is in -->
-      <TestToRun Include="@(NonFlakyRuns);@(FlakyRuns)" />
+      <!-- TODO: Replace with below when https://github.com/dotnet/arcade/issues/2182 is in -->
+      <!-- <TestToRun Include="@(NonFlakyRuns);@(FlakyRuns)" /> -->
+      <TestToRun Include="@(NonFlakyRuns)" />
     </ItemGroup>
   </Target>
 

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -1,8 +1,8 @@
 <Project>
   <Target Name="_GenerateTestPasses" DependsOnTargets="$(_GetTestsToRunTarget)">
     <PropertyGroup>
-      <_FlakyRunAdditionalArgs>-trait "Flaky:AzP:OS:all=true" -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_FlakyRunAdditionalArgs>
-      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzP:OS:all=true" -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_NonFlakyRunAdditionalArgs>
+      <_FlakyRunAdditionalArgs>-trait "Flaky:All=true" -trait "Flaky:AzP:All=true" -trait "Flaky:AzP:OS:$(AGENT_OS)=true"</_FlakyRunAdditionalArgs>
+      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:All=true" -notrait "Flaky:AzP:All=true" -notrait "Flaky:AzP:OS:$(AGENT_OS)=true"</_NonFlakyRunAdditionalArgs>
     </PropertyGroup>
     <ItemGroup>
       <!-- Take the TestToRun values and update them to only run non-flaky tests -->

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -1,8 +1,8 @@
 <Project>
   <Target Name="_GenerateTestPasses" DependsOnTargets="$(_GetTestsToRunTarget)">
     <PropertyGroup>
-      <_FlakyRunAdditionalArgs>-trait "Flaky:AzP:all=true"</_FlakyRunAdditionalArgs>
-      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzP:all=true"</_NonFlakyRunAdditionalArgs>
+      <_FlakyRunAdditionalArgs>-trait "Flaky:AzP:OS:all=true" -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_FlakyRunAdditionalArgs>
+      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzP:OS:all=true"< -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_NonFlakyRunAdditionalArgs>
     </PropertyGroup>
     <ItemGroup>
       <!-- Take the TestToRun values and update them to only run non-flaky tests -->

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -1,0 +1,34 @@
+<Project>
+  <Target Name="_GenerateTestPasses" DependsOnTargets="$(_GetTestsToRunTarget)">
+    <PropertyGroup>
+      <_FlakyRunAdditionalArgs>-trait "Flaky:AzDO=true"</_FlakyRunAdditionalArgs>
+      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzDO=true"</_NonFlakyRunAdditionalArgs>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Take the TestToRun values and update them to only run non-flaky tests -->
+      <NonFlakyRuns Include="@(TestToRun)">
+        <TestRunnerAdditionalArguments>%(TestRunnerAdditionalArguments) $(_NonFlakyRunAdditionalArgs)</TestRunnerAdditionalArguments>
+      </NonFlakyRuns>
+
+      <!-- Add new runs that do run flaky tests but ignore the exit code -->
+      <FlakyRuns Include="@(TestToRun)">
+        <TestRunnerAdditionalArguments>%(TestRunnerAdditionalArguments) $(_FlakyRunAdditionalArgs)</TestRunnerAdditionalArguments>
+        <TestRunnerIgnoreExitCode>true</TestRunnerIgnoreExitCode>
+        <ResultsHtmlPath>$([System.IO.Path]::ChangeExtension(%(ResultsHtmlPath), '.flaky.html'))</ResultsHtmlPath>
+        <ResultsStdOutPath>$([System.IO.Path]::ChangeExtension(%(ResultsStdOutPath), '.flaky.log'))</ResultsStdOutPath>
+        <ResultsXmlPath>$([System.IO.Path]::ChangeExtension(%(ResultsXmlPath), '.flaky.xml'))</ResultsXmlPath>
+      </FlakyRuns>
+
+      <!-- Replace the previous runs -->
+      <TestToRun Remove="@(TestToRun)" />
+
+      <!-- <TestToRun Include="@(NonFlakyRuns)" /> -->
+
+      <!-- TODO: Uncomment when [arcade issue to enable ignoring exit code] is in -->
+      <TestToRun Include="@(NonFlakyRuns);@(FlakyRuns)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Replace Arcade's Test target with a custom one -->
+  <Target Name="Test" DependsOnTargets="_GenerateTestPasses;RunTests" Condition="'$(IsUnitTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true'" />
+</Project>

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -2,7 +2,7 @@
   <Target Name="_GenerateTestPasses" DependsOnTargets="$(_GetTestsToRunTarget)">
     <PropertyGroup>
       <_FlakyRunAdditionalArgs>-trait "Flaky:AzP:OS:all=true" -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_FlakyRunAdditionalArgs>
-      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzP:OS:all=true"< -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_NonFlakyRunAdditionalArgs>
+      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzP:OS:all=true" -trait "Flazy:AzP:OS:$(AGENT_OS)=true"</_NonFlakyRunAdditionalArgs>
     </PropertyGroup>
     <ItemGroup>
       <!-- Take the TestToRun values and update them to only run non-flaky tests -->

--- a/eng/FlakyTests.targets
+++ b/eng/FlakyTests.targets
@@ -1,8 +1,8 @@
 <Project>
   <Target Name="_GenerateTestPasses" DependsOnTargets="$(_GetTestsToRunTarget)">
     <PropertyGroup>
-      <_FlakyRunAdditionalArgs>-trait "Flaky:AzDO:all=true"</_FlakyRunAdditionalArgs>
-      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzDO:all=true"</_NonFlakyRunAdditionalArgs>
+      <_FlakyRunAdditionalArgs>-trait "Flaky:AzP:all=true"</_FlakyRunAdditionalArgs>
+      <_NonFlakyRunAdditionalArgs>-notrait "Flaky:AzP:all=true"</_NonFlakyRunAdditionalArgs>
     </PropertyGroup>
     <ItemGroup>
       <!-- Take the TestToRun values and update them to only run non-flaky tests -->

--- a/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
+++ b/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
@@ -91,6 +91,14 @@ namespace Microsoft.Extensions.Logging.Testing
 
         public virtual void Dispose()
         {
+            if(_testLog == null)
+            {
+                // It seems like sometimes the MSBuild goop that adds the test framework can end up in a bad state and not actually add it
+                // Not sure yet why that happens but the exception isn't clear so I'm adding this error so we can detect it better.
+                // -anurse
+                throw new InvalidOperationException("LoggedTest base class was used but nothing initialized it! The test framework may not be enabled. Try cleaning your 'obj' directory.");
+            }
+
             _initializationException?.Throw();
             _testLog.Dispose();
         }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
@@ -12,6 +12,6 @@ namespace Microsoft.AspNetCore.Testing
         public const string Linux = OsPrefix + "Linux";
 
         private const string Prefix = "AzP:";
-        private const string OsPrefix = Prefix + "AzP:OS:";
+        private const string OsPrefix = Prefix + "OS:";
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public static class AzurePipelines
+    {
+        // Job names end in ';' because it makes it easier to concat these into a list using a constant expression:
+        //  AzurePipelines.macOS + AzurePipelines.Windows
+
+        public const string All = "all;";
+        public const string None = "none;";
+    }
+}

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
@@ -6,13 +6,12 @@ namespace Microsoft.AspNetCore.Testing
 {
     public static class AzurePipelines
     {
-        // OS names end in ';' because it makes it easier to concat these into a list using a constant expression:
-        //  AzurePipelines.macOS + AzurePipelines.Windows
+        public const string All = Prefix + "All";
+        public const string Windows = OsPrefix + "Windows_NT";
+        public const string macOS = OsPrefix + "Darwin";
+        public const string Linux = OsPrefix + "Linux";
 
-        public const string All = "all;";
-        public const string None = "none;";
-        public const string Windows = "Windows_NT;";
-        public const string macOS = "Darwin;";
-        public const string Linux = "Linux;";
+        private const string Prefix = "AzP:";
+        private const string OsPrefix = Prefix + "AzP:OS:";
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/AzurePipelines.cs
@@ -6,10 +6,13 @@ namespace Microsoft.AspNetCore.Testing
 {
     public static class AzurePipelines
     {
-        // Job names end in ';' because it makes it easier to concat these into a list using a constant expression:
+        // OS names end in ';' because it makes it easier to concat these into a list using a constant expression:
         //  AzurePipelines.macOS + AzurePipelines.Windows
 
         public const string All = "all;";
         public const string None = "none;";
+        public const string Windows = "Windows_NT;";
+        public const string macOS = "Darwin;";
+        public const string Linux = "Linux;";
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
@@ -6,23 +6,21 @@ namespace Microsoft.AspNetCore.Testing
 {
     public static class HelixQueues
     {
-        // Queue names end in ';' because it makes it easier to concat these into a list using a constant expression:
-        //  HelixQueues.Fedora28 + HelixQueues.Centos7
+        public const string All = Prefix + "All";
 
-        public const string All = "all;";
-        public const string None = "none;";
+        public const string Fedora28Amd64 = QueuePrefix + "Fedora.28." + Amd64Suffix;
+        public const string Fedora27Amd64 = QueuePrefix + "Fedora.27." + Amd64Suffix;
+        public const string Redhat7Amd64 = QueuePrefix + "Redhat.7." + Amd64Suffix;
+        public const string Debian9Amd64 = QueuePrefix + "Debian.9." + Amd64Suffix;
+        public const string Debian8Amd64 = QueuePrefix + "Debian.8." + Amd64Suffix;
+        public const string Centos7Amd64 = QueuePrefix + "Centos.7." + Amd64Suffix;
+        public const string Ubuntu1604Amd64 = QueuePrefix + "Ubuntu.1604." + Amd64Suffix;
+        public const string Ubuntu1810Amd64 = QueuePrefix + "Ubuntu.1810." + Amd64Suffix;
+        public const string macOS1012Amd64 = QueuePrefix + "OSX.1012." + Amd64Suffix;
+        public const string Windows10Amd64 = QueuePrefix + "Windows.10.Amd64.ClientRS4.VS2017.Open"; // Doesn't have the default suffix!
 
-        public const string Fedora28Amd64 = "Fedora.28." + Amd64Suffix + ";";
-        public const string Fedora27Amd64 = "Fedora.27." + Amd64Suffix + ";";
-        public const string Redhat7Amd64 = "Redhat.7." + Amd64Suffix + ";";
-        public const string Debian9Amd64 = "Debian.9." + Amd64Suffix + ";";
-        public const string Debian8Amd64 = "Debian.8." + Amd64Suffix + ";";
-        public const string Centos7Amd64 = "Centos.7." + Amd64Suffix + ";";
-        public const string Ubuntu1604Amd64 = "Ubuntu.1604." + Amd64Suffix + ";";
-        public const string Ubuntu1810Amd64 = "Ubuntu.1810." + Amd64Suffix + ";";
-        public const string macOS1012Amd64 = "OSX.1012." + Amd64Suffix + ";";
-        public const string Windows10Amd64 = "Windows.10.Amd64.ClientRS4.VS2017.Open;"; // Doesn't have the default suffix!
-
+        private const string Prefix = "Helix:";
+        private const string QueuePrefix = Prefix + "Queue:";
         private const string Amd64Suffix = "Amd64.Open";
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    public static class HelixQueues
+    {
+        public const string All = "all";
+        public const string None = "none";
+
+        // Queue names end in ';' because it makes it easier to concat these into a list using a constant expression:
+        //  HelixQueues.Fedora28 + HelixQueues.Centos7
+
+        public const string Fedora28 = "Fedora.28." + HelixSuffix + ";";
+        public const string Fedora27 = "Fedora.27." + HelixSuffix + ";";
+        public const string Redhat7 = "Redhat.7." + HelixSuffix + ";";
+        public const string Debian9 = "Debian.9." + HelixSuffix + ";";
+        public const string Debian8 = "Debian.8." + HelixSuffix + ";";
+        public const string Centos7 = "Centos.7." + HelixSuffix + ";";
+        public const string Ubuntu1604 = "Ubuntu.1604." + HelixSuffix + ";";
+        public const string Ubuntu1810 = "Ubuntu.1810." + HelixSuffix + ";";
+        public const string macOS1012 = "OSX.1012." + HelixSuffix + ";";
+        public const string Windows10 = "Windows.10.Amd64.ClientRS4.VS2017.Open;"; // Doesn't have the default suffix!
+
+        private const string HelixSuffix = "Amd64.Open";
+    }
+}

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
@@ -6,11 +6,11 @@ namespace Microsoft.AspNetCore.Testing
 {
     public static class HelixQueues
     {
-        public const string All = "all";
-        public const string None = "none";
-
         // Queue names end in ';' because it makes it easier to concat these into a list using a constant expression:
         //  HelixQueues.Fedora28 + HelixQueues.Centos7
+
+        public const string All = "all;";
+        public const string None = "none;";
 
         public const string Fedora28Amd64 = "Fedora.28." + Amd64Suffix + ";";
         public const string Fedora27Amd64 = "Fedora.27." + Amd64Suffix + ";";

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HelixQueues.cs
@@ -12,17 +12,17 @@ namespace Microsoft.AspNetCore.Testing
         // Queue names end in ';' because it makes it easier to concat these into a list using a constant expression:
         //  HelixQueues.Fedora28 + HelixQueues.Centos7
 
-        public const string Fedora28 = "Fedora.28." + HelixSuffix + ";";
-        public const string Fedora27 = "Fedora.27." + HelixSuffix + ";";
-        public const string Redhat7 = "Redhat.7." + HelixSuffix + ";";
-        public const string Debian9 = "Debian.9." + HelixSuffix + ";";
-        public const string Debian8 = "Debian.8." + HelixSuffix + ";";
-        public const string Centos7 = "Centos.7." + HelixSuffix + ";";
-        public const string Ubuntu1604 = "Ubuntu.1604." + HelixSuffix + ";";
-        public const string Ubuntu1810 = "Ubuntu.1810." + HelixSuffix + ";";
-        public const string macOS1012 = "OSX.1012." + HelixSuffix + ";";
-        public const string Windows10 = "Windows.10.Amd64.ClientRS4.VS2017.Open;"; // Doesn't have the default suffix!
+        public const string Fedora28Amd64 = "Fedora.28." + Amd64Suffix + ";";
+        public const string Fedora27Amd64 = "Fedora.27." + Amd64Suffix + ";";
+        public const string Redhat7Amd64 = "Redhat.7." + Amd64Suffix + ";";
+        public const string Debian9Amd64 = "Debian.9." + Amd64Suffix + ";";
+        public const string Debian8Amd64 = "Debian.8." + Amd64Suffix + ";";
+        public const string Centos7Amd64 = "Centos.7." + Amd64Suffix + ";";
+        public const string Ubuntu1604Amd64 = "Ubuntu.1604." + Amd64Suffix + ";";
+        public const string Ubuntu1810Amd64 = "Ubuntu.1810." + Amd64Suffix + ";";
+        public const string macOS1012Amd64 = "OSX.1012." + Amd64Suffix + ";";
+        public const string Windows10Amd64 = "Windows.10.Amd64.ClientRS4.VS2017.Open;"; // Doesn't have the default suffix!
 
-        private const string HelixSuffix = "Amd64.Open";
+        private const string Amd64Suffix = "Amd64.Open";
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -4,6 +4,51 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Testing.xunit
 {
+    /// <summary>
+    /// Marks a test as "Flaky" so that the build will sequester it and ignore failures.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This attribute works by applying xUnit.net "Traits" based on the criteria specified in the attribute
+    /// properties. Once these traits are applied, build scripts can include/exclude tests based on them.
+    /// </para>
+    /// <para>
+    /// All flakiness-related traits start with <code>Flaky:</code> and are grouped first by the process running the tests: Azure Pipelines (AzP) or Helix.
+    /// Then there is a segment specifying the "selector" which indicates where the test is flaky. Finally a segment specifying the value of that selector.
+    /// The value of these traits is always either "true" or the trait is not present. We encode the entire selector in the name of the trait because xUnit.net only
+    /// provides "==" and "!=" operators for traits, there is no way to check if a trait "contains" or "does not contain" a value. VSTest does support "contains" checks
+    /// but does not appear to support "does not contain" checks. Using this pattern means we can use simple "==" and "!=" checks to either only run flaky tests, or exclude
+    /// flaky tests.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [Fact]
+    /// [Flaky(OnHelix = HelixQueues.Fedora28Amd64, OnAzP = AzurePipelines.macOS)]
+    /// public void FlakyTest()
+    /// {
+    ///     // Flakiness
+    /// }
+    /// </code>
+    ///
+    /// <para>
+    /// The above example generates the following facets:
+    /// </para>
+    ///
+    /// <list type="bullet">
+    /// <item>
+    ///     <description><c>Flaky:Helix:Queue:Fedora.28.Amd64.Open</c> = <c>true</c></description>
+    /// </item>
+    /// <item>
+    ///     <description><c>Flaky:AzP:OS:Darwin</c> = <c>true</c></description>
+    /// </item>
+    /// </list>
+    ///
+    /// <para>
+    /// Given the above attribute, the Azure Pipelines macOS run can easily filter this test out by passing <c>-notrait "Flaky:AzP:OS:all=true" -notrait "Flaky:AzP:OS:Darwin=true"</c>
+    /// to <c>xunit.console.exe</c>. Similarly, it can run only flaky tests using <c>-trait "Flaky:AzP:OS:all=true" -trait "Flaky:AzP:OS:Darwin=true"</c>
+    /// </para>
+    /// </example>
     [TraitDiscoverer("Microsoft.AspNetCore.Testing.xunit.FlakyTestDiscoverer", "Microsoft.AspNetCore.Testing")]
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class FlakyAttribute : Attribute, ITraitAttribute

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
     /// <example>
     /// <code>
     /// [Fact]
-    /// [Flaky(OnHelix = HelixQueues.Fedora28Amd64, OnAzP = AzurePipelines.macOS)]
+    /// [Flaky("...", HelixQueues.Fedora28Amd64, AzurePipelines.macOS)]
     /// public void FlakyTest()
     /// {
     ///     // Flakiness
@@ -53,47 +53,23 @@ namespace Microsoft.AspNetCore.Testing.xunit
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class FlakyAttribute : Attribute, ITraitAttribute
     {
-        private List<string> _helixQueues = new List<string>() { HelixQueues.All };
-        private List<string> _azurePipelinesOSes = new List<string>() { AzurePipelines.All };
-
         /// <summary>
         /// Gets a URL to a GitHub issue tracking this flaky test.
         /// </summary>
         public string GitHubIssueUrl { get; }
 
-        /// <summary>
-        /// Gets or sets a list of helix queues on which this test is flaky. Defaults to <see cref="HelixQueues.All"/> indicating it is flaky on all Helix queues. See
-        /// <see cref="HelixQueues"/> for a list of valid values.
-        /// </summary>
-        public string OnHelix
-        {
-            get => string.Join(";", _helixQueues);
-            set => _helixQueues = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
-        }
+        public IReadOnlyList<string> Filters { get; }
 
         /// <summary>
-        /// Gets or sets a list of Azure Pipelines (AzP) operating systems on which this test is flaky. Defaults to <see cref="AzurePipelines.All"/> indicating it is flaky on all AzP OSes.
-        /// See <see cref="AzurePipelines"/> for a list of valid values.
+        /// Initializes a new instance of the <see cref="FlakyAttribute"/> class with the specified <see cref="GitHubIssueUrl"/> and a list of <see cref="Filters"/>. If no
+        /// filters are provided, the test is considered flaky in all environments.
         /// </summary>
-        public string OnAzP
-        {
-            get => string.Join(";", _azurePipelinesOSes);
-            set => _azurePipelinesOSes = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
-        }
-
-        /// <summary>
-        /// Gets a list of Helix queues on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
-        /// </summary>
-        public IReadOnlyList<string> FlakyHelixQueues => _helixQueues;
-
-        /// <summary>
-        /// Gets a list of Azure Pipelines operating systems on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
-        /// </summary>
-        public IReadOnlyList<string> FlakyAzurePipelinesOSes => _azurePipelinesOSes;
-
-        public FlakyAttribute(string gitHubIssueUrl)
+        /// <param name="gitHubIssueUrl">The URL to a GitHub issue tracking this flaky test.</param>
+        /// <param name="filters">A list of filters that define where this test is flaky. Use values in <see cref="AzurePipelines"/> and <see cref="HelixQueues"/>.</param>
+        public FlakyAttribute(string gitHubIssueUrl, params string[] filters)
         {
             GitHubIssueUrl = gitHubIssueUrl;
+            Filters = new List<string>(filters);
         }
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
     public sealed class FlakyAttribute : Attribute, ITraitAttribute
     {
         private List<string> _helixQueues = new List<string>() { HelixQueues.All };
-        private List<string> _azPJobs = new List<string>() { AzurePipelines.All };
+        private List<string> _azurePipelinesOSes = new List<string>() { AzurePipelines.All };
 
         /// <summary>
         /// Gets a URL to a GitHub issue tracking this flaky test.
@@ -20,19 +20,20 @@ namespace Microsoft.AspNetCore.Testing.xunit
         /// Gets or sets a list of helix queues on which this test is flaky. Defaults to <see cref="HelixQueues.All"/> indicating it is flaky on all Helix queues. See
         /// <see cref="HelixQueues"/> for a list of valid values.
         /// </summary>
-        public string OnHelixQueues
+        public string OnHelix
         {
             get => string.Join(";", _helixQueues);
             set => _helixQueues = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
         }
 
         /// <summary>
-        /// Gets or sets a boolean indicating if this test is flaky on Azure DevOps Pipelines. Defaults to <see langword="true" />.
+        /// Gets or sets a list of Azure Pipelines (AzP) operating systems on which this test is flaky. Defaults to <see cref="AzurePipelines.All"/> indicating it is flaky on all AzP OSes.
+        /// See <see cref="AzurePipelines"/> for a list of valid values.
         /// </summary>
-        public string OnAzPJobs
+        public string OnAzP
         {
-            get => string.Join(";", _azPJobs);
-            set => _azPJobs = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+            get => string.Join(";", _azurePipelinesOSes);
+            set => _azurePipelinesOSes = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
         }
 
         /// <summary>
@@ -41,9 +42,9 @@ namespace Microsoft.AspNetCore.Testing.xunit
         public IReadOnlyList<string> FlakyHelixQueues => _helixQueues;
 
         /// <summary>
-        /// Gets a list of Azure Pipelines jobs on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
+        /// Gets a list of Azure Pipelines operating systems on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
         /// </summary>
-        public IReadOnlyList<string> FlakyAzPJobs => _helixQueues;
+        public IReadOnlyList<string> FlakyAzurePipelinesOSes => _azurePipelinesOSes;
 
         public FlakyAttribute(string gitHubIssueUrl)
         {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Testing.xunit
+{
+    [TraitDiscoverer("Microsoft.AspNetCore.Testing.xunit.FlakyTestDiscoverer", "Microsoft.AspNetCore.Testing")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class FlakyAttribute : Attribute, ITraitAttribute
+    {
+        private List<string> _queues = new List<string>() { "all" };
+
+        /// <summary>
+        /// Gets a URL to a GitHub issue tracking this flaky test.
+        /// </summary>
+        public string GitHubIssueUrl { get; }
+
+        /// <summary>
+        /// Gets or sets a list of helix queues on which this test is flaky. Defaults to <see cref="HelixQueues.All"/> indicating it is flaky on all Helix queues. See
+        /// <see cref="HelixQueues"/> for a list of valid values.
+        /// </summary>
+        public string OnHelixQueues
+        {
+            get => string.Join(";", _queues);
+            set => _queues = new List<string>(value.Split(';'));
+        }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating if this test is flaky on Azure DevOps Pipelines. Defaults to <see langword="true" />.
+        /// </summary>
+        public bool OnAzDO { get; set; } = true;
+
+        /// <summary>
+        /// Gets a list of Helix queues on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
+        /// </summary>
+        public IReadOnlyList<string> FlakyQueues => _queues;
+
+        public FlakyAttribute(string gitHubIssueUrl)
+        {
+            GitHubIssueUrl = gitHubIssueUrl;
+        }
+    }
+}

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -8,7 +8,8 @@ namespace Microsoft.AspNetCore.Testing.xunit
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class FlakyAttribute : Attribute, ITraitAttribute
     {
-        private List<string> _queues = new List<string>() { "all" };
+        private List<string> _helixQueues = new List<string>() { HelixQueues.All };
+        private List<string> _azPJobs = new List<string>() { AzurePipelines.All };
 
         /// <summary>
         /// Gets a URL to a GitHub issue tracking this flaky test.
@@ -21,19 +22,28 @@ namespace Microsoft.AspNetCore.Testing.xunit
         /// </summary>
         public string OnHelixQueues
         {
-            get => string.Join(";", _queues);
-            set => _queues = new List<string>(value.Split(';'));
+            get => string.Join(";", _helixQueues);
+            set => _helixQueues = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
         }
 
         /// <summary>
         /// Gets or sets a boolean indicating if this test is flaky on Azure DevOps Pipelines. Defaults to <see langword="true" />.
         /// </summary>
-        public bool OnAzDO { get; set; } = true;
+        public string OnAzPJobs
+        {
+            get => string.Join(";", _azPJobs);
+            set => _azPJobs = new List<string>(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+        }
 
         /// <summary>
         /// Gets a list of Helix queues on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
         /// </summary>
-        public IReadOnlyList<string> FlakyQueues => _queues;
+        public IReadOnlyList<string> FlakyHelixQueues => _helixQueues;
+
+        /// <summary>
+        /// Gets a list of Azure Pipelines jobs on which the test is flaky (including <see cref="HelixQueues.All"/> if specified).
+        /// </summary>
+        public IReadOnlyList<string> FlakyAzPJobs => _helixQueues;
 
         public FlakyAttribute(string gitHubIssueUrl)
         {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -21,14 +22,16 @@ namespace Microsoft.AspNetCore.Testing.xunit
 
         private IEnumerable<KeyValuePair<string, string>> GetTraitsCore(FlakyAttribute attribute)
         {
-            foreach(var os in attribute.FlakyAzurePipelinesOSes)
+            if (attribute.Filters.Count > 0)
             {
-                yield return new KeyValuePair<string, string>($"Flaky:AzP:OS:{os}", "true");
+                foreach (var filter in attribute.Filters)
+                {
+                    yield return new KeyValuePair<string, string>($"Flaky:{filter}", "true");
+                }
             }
-
-            foreach(var queue in attribute.FlakyHelixQueues)
+            else
             {
-                yield return new KeyValuePair<string, string>($"Flaky:Helix:Queue:{queue}", "true");
+                yield return new KeyValuePair<string, string>($"Flaky:All", "true");
             }
         }
     }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNetCore.Testing.xunit
+{
+    public class FlakyTestDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            if (traitAttribute is ReflectionAttributeInfo attribute && attribute.Attribute is FlakyAttribute flakyAttribute)
+            {
+                return GetTraitsCore(flakyAttribute);
+            }
+            else
+            {
+                throw new InvalidOperationException("The 'Flaky' attribute is only supported via reflection.");
+            }
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> GetTraitsCore(FlakyAttribute attribute)
+        {
+            if(attribute.OnAzDO)
+            {
+                yield return new KeyValuePair<string, string>("Flaky:AzDO", "true");
+            }
+
+            foreach(var queue in attribute.FlakyQueues)
+            {
+                yield return new KeyValuePair<string, string>($"Flaky:Helix:{queue}", "true");
+            }
+        }
+    }
+}

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
         {
             foreach(var job in attribute.FlakyAzPJobs)
             {
-                yield return new KeyValuePair<string, string>($"Flaky:AzDO:{job}", "true");
+                yield return new KeyValuePair<string, string>($"Flaky:AzP:{job}", "true");
             }
 
             foreach(var queue in attribute.FlakyHelixQueues)

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
@@ -21,14 +21,14 @@ namespace Microsoft.AspNetCore.Testing.xunit
 
         private IEnumerable<KeyValuePair<string, string>> GetTraitsCore(FlakyAttribute attribute)
         {
-            foreach(var job in attribute.FlakyAzPJobs)
+            foreach(var os in attribute.FlakyAzurePipelinesOSes)
             {
-                yield return new KeyValuePair<string, string>($"Flaky:AzP:{job}", "true");
+                yield return new KeyValuePair<string, string>($"Flaky:AzP:OS:{os}", "true");
             }
 
             foreach(var queue in attribute.FlakyHelixQueues)
             {
-                yield return new KeyValuePair<string, string>($"Flaky:Helix:{queue}", "true");
+                yield return new KeyValuePair<string, string>($"Flaky:Helix:Queue:{queue}", "true");
             }
         }
     }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyTestDiscoverer.cs
@@ -21,12 +21,12 @@ namespace Microsoft.AspNetCore.Testing.xunit
 
         private IEnumerable<KeyValuePair<string, string>> GetTraitsCore(FlakyAttribute attribute)
         {
-            if(attribute.OnAzDO)
+            foreach(var job in attribute.FlakyAzPJobs)
             {
-                yield return new KeyValuePair<string, string>("Flaky:AzDO", "true");
+                yield return new KeyValuePair<string, string>($"Flaky:AzDO:{job}", "true");
             }
 
-            foreach(var queue in attribute.FlakyQueues)
+            foreach(var queue in attribute.FlakyHelixQueues)
             {
                 yield return new KeyValuePair<string, string>($"Flaky:Helix:{queue}", "true");
             }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnAzDO = false, OnHelixQueues = HelixQueues.macOS1012 + HelixQueues.Fedora28)]
+        [Flaky("http://example.com", OnAzDO = false, OnHelixQueues = HelixQueues.macOS1012Amd64 + HelixQueues.Fedora28Amd64)]
         public void FlakyInSpecificHelixQueue()
         {
             var queueName = Environment.GetEnvironmentVariable("HELIX");
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
                     queueName = $"{queueName};";
                 }
 
-                var failingQueues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { HelixQueues.macOS1012, HelixQueues.Fedora28 };
+                var failingQueues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { HelixQueues.macOS1012Amd64, HelixQueues.Fedora28Amd64 };
                 if (failingQueues.Contains(queueName))
                 {
                     throw new Exception("Flaky on Helix!");

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnAzP = AzurePipelines.None)]
+        [Flaky("http://example.com", HelixQueues.All)]
         public void FlakyInHelixOnly()
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX")))
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnAzP = AzurePipelines.None, OnHelix = HelixQueues.macOS1012Amd64 + HelixQueues.Fedora28Amd64)]
+        [Flaky("http://example.com", HelixQueues.macOS1012Amd64, HelixQueues.Fedora28Amd64)]
         public void FlakyInSpecificHelixQueue()
         {
             // Today we don't run Extensions tests on Helix, but this test should light up when we do.
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnHelix = HelixQueues.None)]
+        [Flaky("http://example.com", AzurePipelines.All)]
         public void FlakyInAzDoOnly()
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")))

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com", OnAzDO = false)]
         public void FlakyInHelixOnly()
         {
-            // TODO: Use actual Helix detection variable ;)
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX")))
             {
                 throw new Exception("Flaky on Helix!");
@@ -29,7 +28,6 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com", OnAzDO = false, OnHelixQueues = HelixQueues.macOS1012 + HelixQueues.Fedora28)]
         public void FlakyInSpecificHelixQueue()
         {
-            // TODO: Use actual Helix detection variable ;)
             var queueName = Environment.GetEnvironmentVariable("HELIX");
             if (!string.IsNullOrEmpty(queueName))
             {
@@ -52,8 +50,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com", OnHelixQueues = HelixQueues.None)]
         public void FlakyInAzDoOnly()
         {
-            // TODO: Use actual AzDO detection variable ;)
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZDO")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")))
             {
                 throw new Exception("Flaky on AzDO!");
             }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -11,7 +11,10 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com")]
         public void AlwaysFlaky()
         {
-            throw new Exception("Flakey!");
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX")) || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER")))
+            {
+                throw new Exception("Flaky!");
+            }
         }
 
         [Fact]

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -35,13 +35,6 @@ namespace Microsoft.AspNetCore.Testing.Tests
             var queueName = Environment.GetEnvironmentVariable("HELIX");
             if (!string.IsNullOrEmpty(queueName))
             {
-
-                // Normalize the queue name to have a trailing ';' (this is only for testing anyway)
-                if (!queueName.EndsWith(";"))
-                {
-                    queueName = $"{queueName};";
-                }
-
                 var failingQueues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { HelixQueues.macOS1012Amd64, HelixQueues.Fedora28Amd64 };
                 if (failingQueues.Contains(queueName))
                 {
@@ -52,7 +45,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
 
         [Fact]
         [Flaky("http://example.com", AzurePipelines.All)]
-        public void FlakyInAzDoOnly()
+        public void FlakyInAzPOnly()
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")))
             {
@@ -64,7 +57,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com", AzurePipelines.Windows)]
         public void FlakyInAzPWindowsOnly()
         {
-            if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), "Windows_NT"))
+            if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), AzurePipelines.Windows))
             {
                 throw new Exception("Flaky on AzP Windows!");
             }
@@ -74,7 +67,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com", AzurePipelines.macOS)]
         public void FlakyInAzPmacOSOnly()
         {
-            if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), "Darwin"))
+            if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), AzurePipelines.macOS))
             {
                 throw new Exception("Flaky on AzP macOS!");
             }
@@ -84,7 +77,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         [Flaky("http://example.com", AzurePipelines.Linux)]
         public void FlakyInAzPLinuxOnly()
         {
-            if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), "Linux"))
+            if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), AzurePipelines.Linux))
             {
                 throw new Exception("Flaky on AzP Linux!");
             }
@@ -95,7 +88,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         public void FlakyInAzPNonWindowsOnly()
         {
             var agentOs = Environment.GetEnvironmentVariable("AGENT_OS");
-            if (string.Equals(agentOs, "Linux") || string.Equals(agentOs, "Darwin"))
+            if (string.Equals(agentOs, "Linux") || string.Equals(agentOs, AzurePipelines.macOS))
             {
                 throw new Exception("Flaky on AzP non-Windows!");
             }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Testing.xunit;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Testing.Tests
+{
+    public class FlakyAttributeTest
+    {
+        [Fact]
+        [Flaky("http://example.com")]
+        public void AlwaysFlaky()
+        {
+            throw new Exception("Flakey!");
+        }
+
+        [Fact]
+        [Flaky("http://example.com", OnAzDO = false)]
+        public void FlakyInHelixOnly()
+        {
+            // TODO: Use actual Helix detection variable ;)
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX")))
+            {
+                throw new Exception("Flaky on Helix!");
+            }
+        }
+
+        [Fact]
+        [Flaky("http://example.com", OnAzDO = false, OnHelixQueues = HelixQueues.macOS1012 + HelixQueues.Fedora28)]
+        public void FlakyInSpecificHelixQueue()
+        {
+            // TODO: Use actual Helix detection variable ;)
+            var queueName = Environment.GetEnvironmentVariable("HELIX");
+            if (!string.IsNullOrEmpty(queueName))
+            {
+
+                // Normalize the queue name to have a trailing ';' (this is only for testing anyway)
+                if (!queueName.EndsWith(";"))
+                {
+                    queueName = $"{queueName};";
+                }
+
+                var failingQueues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { HelixQueues.macOS1012, HelixQueues.Fedora28 };
+                if (failingQueues.Contains(queueName))
+                {
+                    throw new Exception("Flaky on Helix!");
+                }
+            }
+        }
+
+        [Fact]
+        [Flaky("http://example.com", OnHelixQueues = HelixQueues.None)]
+        public void FlakyInAzDoOnly()
+        {
+            // TODO: Use actual AzDO detection variable ;)
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZDO")))
+            {
+                throw new Exception("Flaky on AzDO!");
+            }
+        }
+    }
+}

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/FlakyAttributeTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnHelix = HelixQueues.None, OnAzP = AzurePipelines.Windows)]
+        [Flaky("http://example.com", AzurePipelines.Windows)]
         public void FlakyInAzPWindowsOnly()
         {
             if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), "Windows_NT"))
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnHelix = HelixQueues.None, OnAzP = AzurePipelines.macOS)]
+        [Flaky("http://example.com", AzurePipelines.macOS)]
         public void FlakyInAzPmacOSOnly()
         {
             if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), "Darwin"))
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnHelix = HelixQueues.None, OnAzP = AzurePipelines.Linux)]
+        [Flaky("http://example.com", AzurePipelines.Linux)]
         public void FlakyInAzPLinuxOnly()
         {
             if (string.Equals(Environment.GetEnvironmentVariable("AGENT_OS"), "Linux"))
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Testing.Tests
         }
 
         [Fact]
-        [Flaky("http://example.com", OnHelix = HelixQueues.None, OnAzP = AzurePipelines.Linux + AzurePipelines.macOS)]
+        [Flaky("http://example.com", AzurePipelines.Linux, AzurePipelines.macOS)]
         public void FlakyInAzPNonWindowsOnly()
         {
             var agentOs = Environment.GetEnvironmentVariable("AGENT_OS");


### PR DESCRIPTION
part of aspnet/AspNetCore#8237

The attribute does nothing but apply traits right now, we still need to change our build to respect those traits. As a result, this PR will **fail** right now since it will run the "Flaky on AzDO" test :).

Despite being a draft, the `FlakyAttribute` and friends code is **ready for review**.

Examples on how to run/skip

* Run all **non-flaky** tests on AzDO: `dotnet test --filter "Flaky:AzDO!=true"`
* Run all **non-flaky** tests on Helix Queue "X": `dotnet test --filter "Flaky:Helix:all!=true&Flaky:Helix:X!=true`
* Run all **flaky** tests on AzDO: `dotnet test --filter "Flaky:AzDO=true"`

TODO:
* [x] Add build goop to make this all work in Extensions (which uses Arcade)
* [x] Add support for selecting AzDO jobs to skip on

After this PR:
* Add build goop for aspnet/AspNetCore