### PR TITLE
Add variable for exension ref assembly location

### DIFF
--- a/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
+++ b/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
@@ -32,6 +32,10 @@
     <Reference Include="@(ProjectReferenceProvider)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="build\**\*.props" PackagePath="%(Identity)" />
+  </ItemGroup>
+
   <PropertyGroup>
     <BuildDependsOn>
       $(BuildDependsOn);

--- a/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/build/Microsoft.Internal.Extensions.Refs.props
+++ b/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/build/Microsoft.Internal.Extensions.Refs.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftInternalExtensionsRefsPath>$(MSBuildThisFileDirectory)..\ref\netcoreapp3.0\</MicrosoftInternalExtensionsRefsPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
I need to know this location in AspNetCore targeting pack build and there is no good way to get it from NuGet targets.