### PR TITLE
Updating dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,71 +10,71 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview4.19156.5">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.ComponentModel.Annotations" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview4.19154.9">
+    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview4.19154.9">
+    <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview4.19154.9">
+    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview4-27504-10">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview4-27506-9">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>ed6636c463f0ac5fe4183348b6b18e57c8345cb5</Sha>
     </Dependency>
@@ -92,9 +92,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>827c7896f8aa902136ad9dc68cb46147a43cd383</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview4.19154.9">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview4.19156.5">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,10 +39,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19156.5">
+    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19154.9">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
     </Dependency>
     <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview4.19156.5">
       <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,23 +19,23 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- Packages from dotnet/core-setup -->
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview4-27504-10</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview4-27506-9</MicrosoftNETCoreAppPackageVersion>
     <!-- Packages from dotnet/corefx -->
-    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview4.19154.9</MicrosoftBclJsonSourcesPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>4.6.0-preview4.19154.9</MicrosoftWin32RegistryPackageVersion>
-    <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview4.19154.9</SystemComponentModelAnnotationsPackageVersion>
-    <SystemDataSqlClientPackageVersion>4.7.0-preview4.19154.9</SystemDataSqlClientPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview4.19154.9</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19154.9</SystemDiagnosticsEventLogPackageVersion>
-    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19154.9</SystemIOPipelinesPackageVersion>
-    <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19154.9</SystemReflectionMetadataPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.6.0-preview4.19154.9</SystemRuntimeCompilerServicesUnsafePackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview4.19154.9</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview4.19154.9</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemServiceProcessServiceControllerPackageVersion>4.6.0-preview4.19154.9</SystemServiceProcessServiceControllerPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>4.6.0-preview4.19154.9</SystemTextEncodingsWebPackageVersion>
+    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview4.19156.5</MicrosoftBclJsonSourcesPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>4.6.0-preview4.19156.5</MicrosoftWin32RegistryPackageVersion>
+    <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview4.19156.5</SystemComponentModelAnnotationsPackageVersion>
+    <SystemDataSqlClientPackageVersion>4.7.0-preview4.19156.5</SystemDataSqlClientPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview4.19156.5</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19156.5</SystemDiagnosticsEventLogPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19156.5</SystemIOPipelinesPackageVersion>
+    <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19156.5</SystemReflectionMetadataPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.6.0-preview4.19156.5</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview4.19156.5</SystemSecurityCryptographyCngPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview4.19156.5</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemServiceProcessServiceControllerPackageVersion>4.6.0-preview4.19156.5</SystemServiceProcessServiceControllerPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>4.6.0-preview4.19156.5</SystemTextEncodingsWebPackageVersion>
     <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
-    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19154.9</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19156.5</MicrosoftNETCorePlatformsPackageVersion>
     <!-- Packages from dotnet/arcade -->
     <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19154.14</MicrosoftDotNetGenAPIPackageVersion>
   </PropertyGroup>
@@ -53,7 +53,7 @@
     <SystemMemoryPackageVersion>4.5.2</SystemMemoryPackageVersion>
     <SystemNetHttpPackageVersion>4.3.2</SystemNetHttpPackageVersion>
     <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
-    <SystemThreadingTasksExtensionsPackageVersion>4.5.2</SystemThreadingTasksExtensionsPackageVersion>
+    <SystemThreadingTasksExtensionsPackageVersion>4.6.0-preview.18624.2</SystemThreadingTasksExtensionsPackageVersion>
     <SystemValueTuplePackageVersion>4.5.0</SystemValueTuplePackageVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
     <SystemDataSqlClientPackageVersion>4.7.0-preview4.19156.5</SystemDataSqlClientPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview4.19156.5</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19156.5</SystemDiagnosticsEventLogPackageVersion>
-    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19156.5</SystemIOPipelinesPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19154.9</SystemIOPipelinesPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19156.5</SystemReflectionMetadataPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>4.6.0-preview4.19156.5</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview4.19156.5</SystemSecurityCryptographyCngPackageVersion>
@@ -53,7 +53,7 @@
     <SystemMemoryPackageVersion>4.5.2</SystemMemoryPackageVersion>
     <SystemNetHttpPackageVersion>4.3.2</SystemNetHttpPackageVersion>
     <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
-    <SystemThreadingTasksExtensionsPackageVersion>4.6.0-preview.18624.2</SystemThreadingTasksExtensionsPackageVersion>
+    <SystemThreadingTasksExtensionsPackageVersion>4.5.2</SystemThreadingTasksExtensionsPackageVersion>
     <SystemValueTuplePackageVersion>4.5.0</SystemValueTuplePackageVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
```
CoreFxVersion: 3.0.0-preview4.19156.5
CoreFxSha: ebe74b3ad7d1b7be02217bf199f5dedc05f76297
MicrosoftNetCoreAppVersion: 3.0.0-preview4-27506-9
CoreSetupSha: ed6636c463f0ac5fe4183348b6b18e57c8345cb5
```

Pipelines is not updated as it has a bug that prevents AspNetCore from building.