### PR TITLE
Fix typo in SqlServerCache.cs ctor

### DIFF
--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
                 cacheOptions.ExpiredItemsDeletionInterval.Value < MinimumExpiredItemsDeletionInterval)
             {
                 throw new ArgumentException(
-                    $"{nameof(SqlServerCacheOptions.ExpiredItemsDeletionInterval)} cannot be less the minimum " +
+                    $"{nameof(SqlServerCacheOptions.ExpiredItemsDeletionInterval)} cannot be less than the minimum " +
                     $"value of {MinimumExpiredItemsDeletionInterval.TotalMinutes} minutes.");
             }
             if (cacheOptions.DefaultSlidingExpiration <= TimeSpan.Zero)


### PR DESCRIPTION
Validation message:

`$"{nameof(SqlServerCacheOptions.ExpiredItemsDeletionInterval)} cannot be less the minimum "`

should be changed to:

`$"{nameof(SqlServerCacheOptions.ExpiredItemsDeletionInterval)} cannot be less than the minimum "`