### PR TITLE
Update to coherent dependencies using private `darc` build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
     <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageProjectUrl>https://asp.net</PackageProjectUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
 
     <Product>Microsoft .NET Extensions</Product>
     <RepositoryUrl>https://github.com/aspnet/Extensions</RepositoryUrl>

--- a/docs/ReferenceResolution.md
+++ b/docs/ReferenceResolution.md
@@ -68,9 +68,11 @@ Steps for adding a new package dependency to an existing project. Let's say I'm 
         If you don't know the commit hash of the source code used to produce "0.0.1-beta-1", you can use `000000` as a placeholder for `Sha`
         as its value is unimportant and will be updated the next time the bot runs.
 
-        If the new dependency comes from dotnet/CoreFx or dotnet/core-setup and is not `Microsoft.NetCore.App`, add a
-        `CoherentParentDependency` attribute to the `<Dependency>` element as shown below. This indicates
-        Microsoft.NETCore.App also brings in the System.Banana content and tells `darc` to make the versions coherent.
+        If the new dependency comes from dotnet/CoreFx, add a
+        `CoherentParentDependency` attribute to the `<Dependency>` element as shown below. This indicates the
+        dotnet/CoreFx dependency version should be determined based on the build that produced the chosen
+        Microsoft.NETCore.App. That is, the dotnet/CoreFx dependency and Microsoft.NETCore.App should be
+        coherent.
 
         ```xml
         <Dependency Name="System.Banana" Version="0.0.1-beta-1" CoherentParentDependency="Microsoft.NETCore.App">

--- a/docs/ReferenceResolution.md
+++ b/docs/ReferenceResolution.md
@@ -1,5 +1,4 @@
-`<Reference>` resolution
-========================
+# `<Reference>` resolution
 
 Most project files in this repo should use `<Reference>` instead of `<ProjectReference>` or `<PackageReference>`.
 This was done to enable ASP.NET Core's unique requirements without requiring most ASP.NET Core contributors
@@ -33,7 +32,7 @@ The requirements that led to this system are:
 * [eng/Dependencies.props](/eng/Dependencies.props) - contains a list of all package references that might be used in the repo.
 * [eng/PatchConfig.props](/eng/PatchConfig.props) - lists which assemblies or packages are patching in the current build.
 * [eng/ProjectReferences.props](/eng/ProjectReferences.props) - lists which assemblies or packages might be available to be referenced as a local project.
-* [eng/Versions.props](/eng/Versions.props) - contains a list of versions which may be updated by automation. This is used by MSBuild to restore and buid.
+* [eng/Versions.props](/eng/Versions.props) - contains a list of versions which may be updated by automation. This is used by MSBuild to restore and build.
 * [eng/Version.Details.xml](/eng/Version.Details.xml) - used by automation to update dependencies variables in other files.
 
 ## Example: adding a new project
@@ -58,8 +57,7 @@ Steps for adding a new package dependency to an existing project. Let's say I'm 
         ```xml
         <ProductDependencies>
           <!-- ... -->
-          </Dependency>
-            <Dependency Name="System.Banana" Version="0.0.1-beta-1">
+          <Dependency Name="System.Banana" Version="0.0.1-beta-1">
             <Uri>https://github.com/dotnet/corefx</Uri>
             <Sha>000000</Sha>
           </Dependency>
@@ -67,5 +65,25 @@ Steps for adding a new package dependency to an existing project. Let's say I'm 
         </ProductDependencies>
         ```
 
-       If you don't know the commit hash of the source code used to produce "0.0.1-beta-1", you can use `000000` as a placeholder for `Sha`
-       as its value is unimportant and will be updated the next time the bot runs.
+        If you don't know the commit hash of the source code used to produce "0.0.1-beta-1", you can use `000000` as a placeholder for `Sha`
+        as its value is unimportant and will be updated the next time the bot runs.
+
+        If the new dependency comes from dotnet/CoreFx or dotnet/core-setup and is not `Microsoft.NetCore.App`, add a
+        `CoherentParentDependency` attribute to the `<Dependency>` element as shown below. This indicates
+        Microsoft.NETCore.App also brings in the System.Banana content and tells `darc` to make the versions coherent.
+
+        ```xml
+        <Dependency Name="System.Banana" Version="0.0.1-beta-1" CoherentParentDependency="Microsoft.NETCore.App">
+          <!-- ... -->
+        </Dependency>
+        ```
+
+## Updating dependencies manually
+
+If the `dotnet-maestro` bot has not correctly updated the dependencies, it may be worthwhile running `darc` manually:
+
+1. Install `darc` as described in https://github.com/dotnet/arcade/blob/master/Documentation/Darc.md#setting-up-your-darc-client
+2. Run `darc update-dependencies --channel '.NET Core 3 Dev'`
+   * Use `'.NET Core 3 Release'` in a `release/3.0-*` branch
+3. `git diff` to confirm the tool's changes
+4. Proceed with usual commit and PR&hellip;

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,73 +10,61 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview4.19156.5">
+    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.ComponentModel.Annotations" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19154.9">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.IO.Pipelines" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a730a6ecd96fef04d74e1807c8b1d193e0a5f16</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Reflection.Metadata" Version="1.7.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview4.19156.5">
-      <CoherentParentDependency>Microsoft.NETCore.App</CoherentParentDependency>
+    <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview4-27506-9">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview4-27507-11">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>ed6636c463f0ac5fe4183348b6b18e57c8345cb5</Sha>
+      <Sha>f29404381af19d286daa133e5a67b4721308d278</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
@@ -92,9 +80,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4b2966daf2675f9588d27cdb06803dda6d5a7ec5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview4.19156.5">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview4.19157.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>ebe74b3ad7d1b7be02217bf199f5dedc05f76297</Sha>
+      <Sha>1f7c6362d3ad7cebeb748aabfc7e8303b703ed48</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,23 +18,23 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- Packages from dotnet/core-setup -->
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview4-27506-9</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview4-27507-11</MicrosoftNETCoreAppPackageVersion>
     <!-- Packages from dotnet/corefx -->
-    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview4.19156.5</MicrosoftBclJsonSourcesPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>4.6.0-preview4.19156.5</MicrosoftWin32RegistryPackageVersion>
-    <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview4.19156.5</SystemComponentModelAnnotationsPackageVersion>
-    <SystemDataSqlClientPackageVersion>4.7.0-preview4.19156.5</SystemDataSqlClientPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview4.19156.5</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19156.5</SystemDiagnosticsEventLogPackageVersion>
-    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19154.9</SystemIOPipelinesPackageVersion>
-    <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19156.5</SystemReflectionMetadataPackageVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.6.0-preview4.19156.5</SystemRuntimeCompilerServicesUnsafePackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview4.19156.5</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview4.19156.5</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemServiceProcessServiceControllerPackageVersion>4.6.0-preview4.19156.5</SystemServiceProcessServiceControllerPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>4.6.0-preview4.19156.5</SystemTextEncodingsWebPackageVersion>
+    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview4.19157.3</MicrosoftBclJsonSourcesPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>4.6.0-preview4.19157.3</MicrosoftWin32RegistryPackageVersion>
+    <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview4.19157.3</SystemComponentModelAnnotationsPackageVersion>
+    <SystemDataSqlClientPackageVersion>4.7.0-preview4.19157.3</SystemDataSqlClientPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview4.19157.3</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview4.19157.3</SystemDiagnosticsEventLogPackageVersion>
+    <SystemIOPipelinesPackageVersion>4.6.0-preview4.19157.3</SystemIOPipelinesPackageVersion>
+    <SystemReflectionMetadataPackageVersion>1.7.0-preview4.19157.3</SystemReflectionMetadataPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>4.6.0-preview4.19157.3</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>4.6.0-preview4.19157.3</SystemSecurityCryptographyCngPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview4.19157.3</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemServiceProcessServiceControllerPackageVersion>4.6.0-preview4.19157.3</SystemServiceProcessServiceControllerPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>4.6.0-preview4.19157.3</SystemTextEncodingsWebPackageVersion>
     <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
-    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19156.5</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19157.3</MicrosoftNETCorePlatformsPackageVersion>
     <!-- Packages from dotnet/arcade -->
     <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19157.13</MicrosoftDotNetGenAPIPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
- correct `CoherentParentDependency` syntax then run `darc update-subscriptions ...`
- improve ResolutionResolution.md
  - correct a spelling error and avoid the MD003 warning about inconsistent heading styles
  - add `darc` pointers and information about the `CoherentParentDependency` attribute