### PR TITLE
Avoiding a ReverseIterator object allocation in ConfigurationRoot get

### DIFF
--- a/src/Configuration/Config/src/ConfigurationRoot.cs
+++ b/src/Configuration/Config/src/ConfigurationRoot.cs
@@ -52,8 +52,10 @@ namespace Microsoft.Extensions.Configuration
         {
             get
             {
-                foreach (var provider in _providers.Reverse())
+                for (var i = _providers.Count - 1; i >= 0; i--)
                 {
+                    var provider = _providers[i];
+
                     if (provider.TryGet(key, out var value))
                     {
                         return value;


### PR DESCRIPTION
 - Replacing the `Reverse` method call with a for loop, hence avoiding the [`ReverseIterator`](https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/Reverse.cs#L19) new object allocation.

Here is the result of a [benchmark I ran](https://gist.github.com/kshyju/8ee72dd3ab948ffd2f1e4e4d45ec9094) where ConfigurationRoot was built using 2 MemoryConfigurationProviders.




``` ini


BenchmarkDotNet=v0.10.13, OS=Windows 10.0.17763
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical cores and 6 physical cores
.NET Core SDK=3.0.100-preview3-010280
  [Host]     : .NET Core 3.0.0-preview3-27414-8 (CoreCLR 4.6.27414.77, CoreFX 4.7.19.10906), 64bit RyuJIT
  Job-MAAXQT : .NET Core 3.0.0-preview3-27414-8 (CoreCLR 4.6.27414.77, CoreFX 4.7.19.10906), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET Core 3.0  
RunStrategy=Throughput  

```
|       Method |      Mean |    Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|------------- |----------:|---------:|----------:|-------------:|-------:|----------:|
| UsingReverse | 256.55 ns | 5.213 ns | 13.079 ns |  3,897,916.7 | 0.0010 |      88 B |
| UsingForLoop |  80.39 ns | 1.604 ns |  2.680 ns | 12,439,488.4 |      - |       0 B |
