### PR TITLE
Update caching's null value semantics for TryGetValue<TItem>

### DIFF
--- a/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/Caching/Abstractions/src/MemoryCacheExtensions.cs
@@ -24,6 +24,12 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             if (cache.TryGetValue(key, out object result))
             {
+                if (result == null)
+                {
+                    value = default;
+                    return true;
+                }
+
                 if (result is TItem item)
                 {
                     value = item;

--- a/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
+++ b/src/Caching/Memory/test/MemoryCacheSetAndRemoveTests.cs
@@ -213,6 +213,32 @@ namespace Microsoft.Extensions.Caching.Memory
             Assert.False(cache.TryGetValue(key, out string obj));
         }
 
+
+        [Fact]
+        public void TryGetValue_WillCreateDefaultValueAndSucceed_WhenValueNull()
+        {
+            var cache = CreateCache();
+            string key = "myKey";
+            string value = null;
+
+            cache.Set(key, value);
+
+            Assert.True(cache.TryGetValue(key, out string obj));
+        }
+
+        [Fact]
+        public void TryGetValue_WillCreateDefaultValueAndSucceed_WhenValueNullForValueType()
+        {
+            var cache = CreateCache();
+            string key = "myKey";
+            string value = null;
+
+            cache.Set(key, value);
+
+            Assert.True(cache.TryGetValue(key, out int obj));
+            Assert.Equal(default, obj);
+        }
+
         [Fact]
         public void SetOverwritesAndInvokesCallbacks()
         {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - TryGetValue<TItem> will return true and assign the default value to result when a null object value is stored for a given key.
 - Tests added to validate resulting semantics of TryGetValue<TItem>

Addresses #1255 .

#### Notes
Test `TryGetValue_WillCreateDefaultValueAndSucceed_WhenValueNullForValueType` exercises a potentially less-than-desirable semantic that results from this -- storing a null object (of any type) and using TryGetValue<TItem> for any value type will return true and result in the default value for that value type.  This technically falls in line with the fact that TryGetValue<TItem> will return true and result in a null object of any type even if the originally stored type isn't the same as the requested type.


Changes were made while working for employer, Fifty Seven Pounds.  CLA should already be signed but can be re-signed if needed.