### PR TITLE
Shrink StringValues

### DIFF
--- a/src/Primitives/perf/StringValuesBenchmark.cs
+++ b/src/Primitives/perf/StringValuesBenchmark.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.Extensions.Primitives.Performance
+{
+    public class StringValuesBenchmark
+    {
+        const int Iterations = 40;
+
+        private readonly string _string = "Hello world!";
+        private readonly string[] _stringArray = new[] { "Hello", "world", "!" };
+        private readonly StringValues _stringBased = new StringValues("Hello world!");
+        private readonly StringValues _arrayBased = new StringValues(new[] { "Hello", "world", "!" });
+
+#pragma warning disable CS0414
+        private HeaderReferences _headers;
+#pragma warning restore CS0414
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void ClearHeaders()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                ClearHeaders_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ClearHeaders_Body()
+        {
+            _headers = default;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void Ctor_String()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                Ctor_String_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private StringValues Ctor_String_Body()
+        {
+            return new StringValues(_string);
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void Ctor_Array()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                Ctor_Array_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private StringValues Ctor_Array_Body()
+        {
+            return new StringValues(_stringArray);
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void Index_FirstElement_String()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                Index_FirstElement_String_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string Index_FirstElement_String_Body()
+        {
+            return _stringBased[0];
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void Index_FirstElement_Array()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                Index_FirstElement_Array_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string Index_FirstElement_Array_Body()
+        {
+            return _arrayBased[0];
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void Count_String()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                Count_String_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int Count_String_Body()
+        {
+            return _stringBased.Count;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void Count_Array()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                Count_Array_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int Count_Array_Body()
+        {
+            return _arrayBased.Count;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void ForEach_String()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                ForEach_String_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string ForEach_String_Body()
+        {
+            var s = "";
+            foreach (var item in _stringBased)
+            {
+                s = item;
+            }
+
+            return s;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void ForEach_Array()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                ForEach_Array_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string ForEach_Array_Body()
+        {
+            var s = "";
+            foreach (var item in _arrayBased)
+            {
+                s = item;
+            }
+
+            return s;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void PassByValue()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                PassByValue_Body();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string PassByValue_Body()
+        {
+            return ByValue(_stringBased);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private string ByValue(StringValues val) => val.ToString();
+
+#pragma warning disable CS0649
+        private struct HeaderReferences
+        {
+            public StringValues _CacheControl;
+            public StringValues _Connection;
+            public StringValues _Date;
+            public StringValues _KeepAlive;
+            public StringValues _Pragma;
+            public StringValues _Trailer;
+            public StringValues _TransferEncoding;
+            public StringValues _Upgrade;
+            public StringValues _Via;
+            public StringValues _Warning;
+            public StringValues _Allow;
+            public StringValues _ContentType;
+            public StringValues _ContentEncoding;
+            public StringValues _ContentLanguage;
+            public StringValues _ContentLocation;
+            public StringValues _ContentMD5;
+            public StringValues _ContentRange;
+            public StringValues _Expires;
+            public StringValues _LastModified;
+            public StringValues _AcceptRanges;
+            public StringValues _Age;
+            public StringValues _ETag;
+            public StringValues _Location;
+            public StringValues _ProxyAuthenticate;
+            public StringValues _RetryAfter;
+            public StringValues _Server;
+            public StringValues _SetCookie;
+            public StringValues _Vary;
+            public StringValues _WWWAuthenticate;
+            public StringValues _AccessControlAllowCredentials;
+            public StringValues _AccessControlAllowHeaders;
+            public StringValues _AccessControlAllowMethods;
+            public StringValues _AccessControlAllowOrigin;
+            public StringValues _AccessControlExposeHeaders;
+            public StringValues _AccessControlMaxAge;
+
+            public byte[] _rawConnection;
+            public byte[] _rawDate;
+            public byte[] _rawTransferEncoding;
+            public byte[] _rawServer;
+        }
+#pragma warning restore CS0649
+    }
+}

--- a/src/Primitives/ref/Microsoft.Extensions.Primitives.netcoreapp3.0.cs
+++ b/src/Primitives/ref/Microsoft.Extensions.Primitives.netcoreapp3.0.cs
@@ -135,8 +135,8 @@ namespace Microsoft.Extensions.Primitives
         public static readonly Microsoft.Extensions.Primitives.StringValues Empty;
         public StringValues(string value) { throw null; }
         public StringValues(string[] values) { throw null; }
-        public int Count { get { throw null; } }
-        public string this[int index] { get { throw null; } }
+        public int Count { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
+        public string this[int index] { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
         bool System.Collections.Generic.ICollection<System.String>.IsReadOnly { get { throw null; } }
         string System.Collections.Generic.IList<System.String>.this[int index] { get { throw null; } set { } }
         public static Microsoft.Extensions.Primitives.StringValues Concat(Microsoft.Extensions.Primitives.StringValues values1, Microsoft.Extensions.Primitives.StringValues values2) { throw null; }

--- a/src/Primitives/ref/Microsoft.Extensions.Primitives.netstandard2.0.cs
+++ b/src/Primitives/ref/Microsoft.Extensions.Primitives.netstandard2.0.cs
@@ -135,8 +135,8 @@ namespace Microsoft.Extensions.Primitives
         public static readonly Microsoft.Extensions.Primitives.StringValues Empty;
         public StringValues(string value) { throw null; }
         public StringValues(string[] values) { throw null; }
-        public int Count { get { throw null; } }
-        public string this[int index] { get { throw null; } }
+        public int Count { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
+        public string this[int index] { [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]get { throw null; } }
         bool System.Collections.Generic.ICollection<System.String>.IsReadOnly { get { throw null; } }
         string System.Collections.Generic.IList<System.String>.this[int index] { get { throw null; } set { } }
         public static Microsoft.Extensions.Primitives.StringValues Concat(Microsoft.Extensions.Primitives.StringValues values1, Microsoft.Extensions.Primitives.StringValues values2) { throw null; }


### PR DESCRIPTION
Use a single field to shrink by 8 bytes; shrinking ResponseHeaders by 272 bytes and RequestHeaders by 352 bytes; or 624 bytes total (e.g. per connection).

```diff
                     Method |      Mean |     Error |    StdDev |          Op/s | Allocated |
 -------------------------- |----------:|----------:|----------:|--------------:|----------:|
-              ClearHeaders | 17.307 ns | 0.0695 ns | 0.0650 ns |  57,781,381.7 |       0 B |
+              ClearHeaders |  9.013 ns | 0.0243 ns | 0.0227 ns | 110,945,805.6 |       0 B |
-               Ctor_String |  3.687 ns | 0.0737 ns | 0.0932 ns | 271,251,797.5 |       0 B |
+               Ctor_String |  1.804 ns | 0.0065 ns | 0.0057 ns | 554,381,580.7 |       0 B |
-                Ctor_Array |  3.840 ns | 0.0122 ns | 0.0115 ns | 260,437,356.7 |       0 B |
+                Ctor_Array |  2.148 ns | 0.0076 ns | 0.0071 ns | 465,469,766.3 |       0 B |
- Index_FirstElement_String |  3.518 ns | 0.0184 ns | 0.0163 ns | 284,224,537.0 |       0 B |
+ Index_FirstElement_String |  2.647 ns | 0.0079 ns | 0.0074 ns | 377,742,529.8 |       0 B |
-  Index_FirstElement_Array |  4.185 ns | 0.0156 ns | 0.0146 ns | 238,951,422.2 |       0 B |
+  Index_FirstElement_Array |  2.711 ns | 0.0092 ns | 0.0077 ns | 368,895,093.2 |       0 B |
-              Count_String |  2.364 ns | 0.0075 ns | 0.0067 ns | 423,040,364.6 |       0 B |
+              Count_String |  2.439 ns | 0.0067 ns | 0.0049 ns | 410,002,357.0 |       0 B |
-               Count_Array |  2.448 ns | 0.0157 ns | 0.0139 ns | 408,524,150.6 |       0 B |
+               Count_Array |  3.067 ns | 0.0084 ns | 0.0074 ns | 326,031,846.5 |       0 B |
-            ForEach_String | 13.759 ns | 0.0395 ns | 0.0370 ns |  72,681,850.1 |       0 B |
+            ForEach_String | 13.759 ns | 0.0256 ns | 0.0227 ns |  72,678,544.0 |       0 B |
-             ForEach_Array | 23.041 ns | 0.0673 ns | 0.0597 ns |  43,401,774.7 |       0 B |
+             ForEach_Array | 21.331 ns | 0.0388 ns | 0.0303 ns |  46,879,326.7 |       0 B |
-               PassByValue |  5.475 ns | 0.0214 ns | 0.0200 ns | 182,652,278.6 |       0 B |
+               PassByValue |  4.615 ns | 0.0049 ns | 0.0036 ns | 216,697,441.6 |       0 B |
```

Resolves https://github.com/aspnet/Extensions/issues/1290