### PR TITLE
Move to BYOC queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,12 +40,12 @@ jobs:
     jobs:
     - job: Windows
       pool:
-        # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
-        # Will eventually change this to two BYOC pools.
-        ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-          name: dotnet-external-temp
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: dotnet-internal-temp
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          name: NetCorePublic-Int-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2017.Open
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: NetCoreInternal-Int-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2017
       variables:
       # Only enable publishing in official builds.
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -160,7 +160,10 @@ jobs:
     - job: OSX_10_13
       displayName: 'OSX'
       pool:
-        name: Hosted macOS
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          name: Hosted macOS
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          name: Hosted Mac Internal
         vmImage: macOS-10.13
       strategy:
         matrix:


### PR DESCRIPTION
- aspnet/AspNetCore-Internal#2033
- use conditions matching aspnet/Extensions and dotnet/Arcade
  - e.g. https://github.com/dotnet/arcade/blob/05cb24592af3989d8f274e68280a3c16520d2f71/azure-pipelines.yml#L49-L54
- also use recommended internal macOS queue when appropriate
  - no need to set `vmImage` for Mac builds; done in Arcade template
- no change needed for Linux builds