### PR TITLE
 Enable EventLog by default for WindowsService

### DIFF
--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -146,7 +146,8 @@ namespace Microsoft.Extensions.Hosting
 
             if (string.IsNullOrEmpty(_hostingEnvironment.ApplicationName))
             {
-                _hostingEnvironment.ApplicationName = Assembly.GetEntryAssembly().GetName().Name;
+                // Note GetEntryAssembly returns null for the net4x console test runner.
+                _hostingEnvironment.ApplicationName = Assembly.GetEntryAssembly()?.GetName().Name;
             }
 
             _hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(_hostingEnvironment.ContentRootPath);

--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Extensions.Hosting
                 EnvironmentName = _hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production,
                 ContentRootPath = ResolveContentRootPath(_hostConfiguration[HostDefaults.ContentRootKey], AppContext.BaseDirectory),
             };
+
+            if (string.IsNullOrEmpty(_hostingEnvironment.ApplicationName))
+            {
+                _hostingEnvironment.ApplicationName = Assembly.GetEntryAssembly().GetName().Name;
+            }
+
             _hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(_hostingEnvironment.ContentRootPath);
         }
 

--- a/src/Hosting/Hosting/test/HostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/HostBuilderTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Hosting
                 {
                     var env = hostContext.HostingEnvironment;
                     Assert.Equal(Environments.Production, env.EnvironmentName);
-                    Assert.Null(env.ApplicationName);
+                    Assert.Equal("testhost", env.ApplicationName);
                     Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
                     Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
                 });
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = host.Services.GetRequiredService<IHostEnvironment>();
                 Assert.Equal(Environments.Production, env.EnvironmentName);
-                Assert.Null(env.ApplicationName);
+                Assert.Equal("testhost", env.ApplicationName);
                 Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
                 Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
             }

--- a/src/Hosting/Hosting/test/HostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/HostBuilderTests.cs
@@ -143,7 +143,14 @@ namespace Microsoft.Extensions.Hosting
                 {
                     var env = hostContext.HostingEnvironment;
                     Assert.Equal(Environments.Production, env.EnvironmentName);
+#if NETCOREAPP3_0
                     Assert.NotNull(env.ApplicationName);
+#elif NET472
+                    // Note GetEntryAssembly returns null for the net4x console test runner.
+                    Assert.Null(env.ApplicationName);
+#else
+#error TFMs need to be updated
+#endif
                     Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
                     Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
                 });
@@ -152,7 +159,14 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = host.Services.GetRequiredService<IHostEnvironment>();
                 Assert.Equal(Environments.Production, env.EnvironmentName);
+#if NETCOREAPP3_0
                 Assert.NotNull(env.ApplicationName);
+#elif NET472
+                // Note GetEntryAssembly returns null for the net4x console test runner.
+                Assert.Null(env.ApplicationName);
+#else
+#error TFMs need to be updated
+#endif
                 Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
                 Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
             }

--- a/src/Hosting/Hosting/test/HostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/HostBuilderTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Hosting
                 {
                     var env = hostContext.HostingEnvironment;
                     Assert.Equal(Environments.Production, env.EnvironmentName);
-                    Assert.Equal("testhost", env.ApplicationName);
+                    Assert.NotNull(env.ApplicationName);
                     Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
                     Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
                 });
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = host.Services.GetRequiredService<IHostEnvironment>();
                 Assert.Equal(Environments.Production, env.EnvironmentName);
-                Assert.Equal("testhost", env.ApplicationName);
+                Assert.NotNull(env.ApplicationName);
                 Assert.Equal(AppContext.BaseDirectory, env.ContentRootPath);
                 Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
             }

--- a/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.csproj
@@ -6,6 +6,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs" />
     <Reference Include="Microsoft.Extensions.Hosting"  />
+    <Reference Include="Microsoft.Extensions.Logging.EventLog"  />
     <Reference Include="System.ServiceProcess.ServiceController"  />
   </ItemGroup>
 </Project>

--- a/src/Hosting/WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
+++ b/src/Hosting/WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Logging.EventLog" />
     <Reference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
 

--- a/src/Hosting/WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs
@@ -4,14 +4,20 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging.EventLog;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Extension methods for setting up WindowsServiceLifetime.
+    /// </summary>
     public static class WindowsServiceLifetimeHostBuilderExtensions
     {
         /// <summary>
-        /// Sets the host lifetime to WindowsServiceLifetime and sets the Content Root.
+        /// Sets the host lifetime to WindowsServiceLifetime, sets the Content Root,
+        /// and enables logging to the event log with the application name as the default source name.
         /// </summary>
         /// <remarks>
         /// This is context aware and will only activate if it detects the process is running
@@ -21,11 +27,41 @@ namespace Microsoft.Extensions.Hosting
         /// <returns></returns>
         public static IHostBuilder UseWindowsService(this IHostBuilder hostBuilder)
         {
+            return hostBuilder.UseWindowsService((context, settings) =>
+            {
+                settings.SourceName = context.HostingEnvironment.ApplicationName;
+            });
+        }
+
+        /// <summary>
+        /// Sets the host lifetime to WindowsServiceLifetime, sets the Content Root,
+        /// and enables logging to the event log.
+        /// </summary>
+        /// <remarks>
+        /// This is context aware and will only activate if it detects the process is running
+        /// as a Windows Service.
+        /// </remarks>
+        /// <param name="hostBuilder"></param>
+        /// <param name="configureEventLog"></param>
+        /// <returns></returns>
+        public static IHostBuilder UseWindowsService(this IHostBuilder hostBuilder, Action<HostBuilderContext, EventLogSettings> configureEventLog)
+        {
+            if (configureEventLog == null)
+            {
+                throw new ArgumentNullException(nameof(configureEventLog));
+            }
+
             if (IsWindowsService())
             {
-                // CurrentDirectory for services is c:\Windows\System32, but that's what Host.CreateDefaultBuilder uses for VS scenarios.
+                // Host.CreateDefaultBuilder uses CurrentDirectory for VS scenarios, but CurrentDirectory for services is c:\Windows\System32.
                 hostBuilder.UseContentRoot(AppContext.BaseDirectory);
-                return hostBuilder.ConfigureServices((hostContext, services) =>
+                hostBuilder.ConfigureLogging((hostingContext, logging) =>
+                {
+                    var settings = new EventLogSettings();
+                    configureEventLog(hostingContext, settings);
+                    logging.AddEventLog(settings);
+                })
+                .ConfigureServices((hostContext, services) =>
                 {
                     services.AddSingleton<IHostLifetime, WindowsServiceLifetime>();
                 });

--- a/src/Hosting/samples/GenericHostSample/GenericHostSample.csproj
+++ b/src/Hosting/samples/GenericHostSample/GenericHostSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <StartupObject>GenericHostSample.ServiceBaseControlled</StartupObject>
+    <StartupObject>GenericHostSample.WindowsServiceControlled</StartupObject>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Hosting/samples/GenericHostSample/WindowsServiceControlled.cs
+++ b/src/Hosting/samples/GenericHostSample/WindowsServiceControlled.cs
@@ -1,19 +1,14 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GenericHostSample
 {
-    public class ServiceBaseControlled
+    public class WindowsServiceControlled
     {
         public static async Task Main(string[] args)
         {
             var builder = Host.CreateDefaultBuilder(args)
-                .ConfigureLogging(logging =>
-                {
-                    logging.AddEventLog();
-                })
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.AddHostedService<MyServiceA>();

--- a/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.netstandard2.0.cs
+++ b/src/Logging/Logging.EventLog/ref/Microsoft.Extensions.Logging.EventLog.netstandard2.0.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Extensions.Logging
     {
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddEventLog(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { throw null; }
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddEventLog(this Microsoft.Extensions.Logging.ILoggingBuilder builder, Microsoft.Extensions.Logging.EventLog.EventLogSettings settings) { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddEventLog(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Logging.EventLog.EventLogSettings> configure) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Logging.EventLog
@@ -16,6 +17,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     {
         public EventLogLoggerProvider() { }
         public EventLogLoggerProvider(Microsoft.Extensions.Logging.EventLog.EventLogSettings settings) { }
+        public EventLogLoggerProvider(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Logging.EventLog.EventLogSettings> options) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name) { throw null; }
         public void Dispose() { }
         public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }

--- a/src/Logging/Logging.EventLog/src/EventLogLoggerProvider.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogLoggerProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.Options;
+
 namespace Microsoft.Extensions.Logging.EventLog
 {
     /// <summary>
@@ -9,7 +11,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     [ProviderAlias("EventLog")]
     public class EventLogLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
-        private readonly EventLogSettings _settings;
+        internal readonly EventLogSettings _settings;
 
         private IExternalScopeProvider _scopeProvider;
 
@@ -28,6 +30,15 @@ namespace Microsoft.Extensions.Logging.EventLog
         public EventLogLoggerProvider(EventLogSettings settings)
         {
             _settings = settings;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventLogLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="options">The <see cref="IOptions{EventLogSettings}"/>.</param>
+        public EventLogLoggerProvider(IOptions<EventLogSettings> options)
+            : this(options.Value)
+        {
         }
 
         /// <inheritdoc />

--- a/src/Logging/Logging.EventLog/src/EventLoggerFactoryExtensions.cs
+++ b/src/Logging/Logging.EventLog/src/EventLoggerFactoryExtensions.cs
@@ -50,5 +50,23 @@ namespace Microsoft.Extensions.Logging
 
             return builder;
         }
+
+        /// <summary>
+        /// Adds an event logger. Use <paramref name="configure"/> to enable logging for specific <see cref="LogLevel"/>s.
+        /// </summary>
+        /// <param name="builder">The extension method argument.</param>
+        /// <param name="configure">A delegate to configure the <see cref="EventLogSettings"/>.</param>
+        public static ILoggingBuilder AddEventLog(this ILoggingBuilder builder, Action<EventLogSettings> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddEventLog();
+            builder.Services.Configure(configure);
+
+            return builder;
+        }
     }
 }

--- a/src/Logging/Logging.EventLog/src/WindowsEventLog.cs
+++ b/src/Logging/Logging.EventLog/src/WindowsEventLog.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
+using System.Security;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
@@ -9,6 +11,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx
         private const int MaximumMessageSize = 31839;
+        private bool _enabled = true;
 
         public WindowsEventLog(string logName, string machineName, string sourceName)
         {
@@ -21,7 +24,30 @@ namespace Microsoft.Extensions.Logging.EventLog
 
         public void WriteEntry(string message, EventLogEntryType type, int eventID, short category)
         {
-            DiagnosticsEventLog.WriteEvent(new EventInstance(eventID, category, type), message);
+            try
+            {
+                if (_enabled)
+                {
+                    DiagnosticsEventLog.WriteEvent(new EventInstance(eventID, category, type), message);
+                }
+            }
+            catch (SecurityException sx)
+            {
+                _enabled = false;
+                // We couldn't create the log or source name. Disable logging.
+                try
+                {
+                    using (var backupLog = new System.Diagnostics.EventLog("Application", ".", "Application"))
+                    {
+                        backupLog.WriteEvent(new EventInstance(instanceId: 0, categoryId: 0, EventLogEntryType.Error),
+                            $"Unable to log .NET application events. {sx.Message}");
+                    }
+                }
+                catch (Exception)
+                {
+
+                }
+            }
         }
     }
 }

--- a/src/Logging/test/EventLogLoggerTest.cs
+++ b/src/Logging/test/EventLogLoggerTest.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.EventLog;
 using Xunit;
 
@@ -97,6 +99,27 @@ namespace Microsoft.Extensions.Logging
             Assert.Equal(settings.LogName, windowsEventLog.DiagnosticsEventLog.Log);
             Assert.Equal(settings.SourceName, windowsEventLog.DiagnosticsEventLog.Source);
             Assert.Equal(settings.MachineName, windowsEventLog.DiagnosticsEventLog.MachineName);
+        }
+
+        [Fact]
+        public void IOptions_CreatesWindowsEventLog_WithSuppliedEventLogSettings()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddEventLog());
+            serviceCollection.Configure<EventLogSettings>(settings =>
+            {
+                settings.SourceName = "foo";
+                settings.LogName = "bar";
+                settings.MachineName = "blah";
+                settings.EventLog = null;
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+            var provider = (EventLogLoggerProvider)(services.GetRequiredService<IEnumerable<ILoggerProvider>>().First());
+            var settings = provider._settings;
+            Assert.Equal("bar", settings.LogName);
+            Assert.Equal("foo", settings.SourceName);
+            Assert.Equal("blah", settings.MachineName);
         }
 
         [ConditionalTheory]

--- a/src/Logging/test/EventLogLoggerTest.cs
+++ b/src/Logging/test/EventLogLoggerTest.cs
@@ -106,12 +106,12 @@ namespace Microsoft.Extensions.Logging
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddLogging(builder => builder.AddEventLog());
-            serviceCollection.Configure<EventLogSettings>(settings =>
+            serviceCollection.Configure<EventLogSettings>(options =>
             {
-                settings.SourceName = "foo";
-                settings.LogName = "bar";
-                settings.MachineName = "blah";
-                settings.EventLog = null;
+                options.SourceName = "foo";
+                options.LogName = "bar";
+                options.MachineName = "blah";
+                options.EventLog = null;
             });
 
             var services = serviceCollection.BuildServiceProvider();


### PR DESCRIPTION
 #1286 The application's name will be used as the default source.

Additions:
- Generic host now provides a default application name.
- EventLog logger now handles errors when you're not allowed to create sources.
- EventLog support for IOptions