### PR TITLE
Remove "vm-image" from hosted pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,7 +119,6 @@ jobs:
       displayName: 'Ubuntu 16.04'
       pool:
         name: Hosted Ubuntu 1604
-        vmImage: ubuntu-16.04
       strategy:
         matrix:
           ${{ if in(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
@mmitche pointed out to me earlier this is some kind of breaking change from AzDO

Summary of the changes (Less than 80 chars)
 - Remove vm-image tag from hosted pool provider declaration

No bug filed; Addressed build failures like https://dev.azure.com/dnceng/public/_build/results?buildId=133627
