### PR TITLE
Port fix for #1041 to 2.2

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.5' ">
     <PackagesInPatch>
+      Microsoft.Extensions.HealthChecks;
     </PackagesInPatch>
   </PropertyGroup>
 

--- a/src/HealthChecks/HealthChecks/src/HealthCheckPublisherOptions.cs
+++ b/src/HealthChecks/HealthChecks/src/HealthCheckPublisherOptions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                     throw new ArgumentException($"The {nameof(Period)} must not be infinite.", nameof(value));
                 }
 
-                _delay = value;
+                _period = value;
             }
         }
 


### PR DESCRIPTION
## Impact

It's not possible to set the `Period` of the health check publisher hosted service without using reflection. The wrong backing field is set.

This isn't very discoverable because the bug manifests in a setting not being honoured. You might think you are publishing health data every 30 seconds, but it's going to always use the default period.

## Workaround

The workaround is to use reflection. 

## Risk

The risk here is that someone is setting `Period` - which actually sets `Delay` and they are relying on this detail. If a user actually wanted to set `Delay`, they can already do that.


