### PR TITLE
Fix #8612 JSInterop throws truncated call stack

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -79,6 +80,10 @@ namespace Microsoft.JSInterop
             if (!success && resultOrException is Exception)
             {
                 resultOrException = resultOrException.ToString();
+            }
+            else if (!success && resultOrException is ExceptionDispatchInfo edi)
+            {
+                resultOrException = edi.SourceException.ToString();
             }
 
             // We pass 0 as the async handle because we don't want the JS-side code to


### PR DESCRIPTION
The fix for this is to use more ExceptionDispatchInfo! Basically
everwhere that we handle an exception is now an EDI. It's easy to pass
these around and they do the right thing as far as perserving the stack
in.

I de-factored this code a little bit to make all of this work, but it's
now pretty unambiguously correct upon inspection.

I started out wanting to get rid of the continue-with because we've
found that pretty error prone overall. However making this method
async-void started to ask more questions than it answered. What happens
if serialization of the exception fails?