### PR TITLE
Re-enable tests skipped in JSInterop

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Json/SimpleJson/SimpleJson.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Json/SimpleJson/SimpleJson.cs
@@ -53,6 +53,7 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 #if !SIMPLE_JSON_NO_LINQ_EXPRESSION
 using System.Linq.Expressions;
@@ -2070,7 +2071,7 @@ namespace SimpleJson
             {
                 private readonly object _lock = new object();
                 private readonly ThreadSafeDictionaryValueFactory<TKey, TValue> _valueFactory;
-                private Dictionary<TKey, TValue> _dictionary;
+                private ConcurrentDictionary<TKey, TValue> _dictionary;
 
                 public ThreadSafeDictionary(ThreadSafeDictionaryValueFactory<TKey, TValue> valueFactory)
                 {
@@ -2094,7 +2095,7 @@ namespace SimpleJson
                     {
                         if (_dictionary == null)
                         {
-                            _dictionary = new Dictionary<TKey, TValue>();
+                            _dictionary = new ConcurrentDictionary<TKey, TValue>();
                             _dictionary[key] = value;
                         }
                         else
@@ -2102,7 +2103,7 @@ namespace SimpleJson
                             TValue val;
                             if (_dictionary.TryGetValue(key, out val))
                                 return val;
-                            Dictionary<TKey, TValue> dict = new Dictionary<TKey, TValue>(_dictionary);
+                            ConcurrentDictionary<TKey, TValue> dict = new ConcurrentDictionary<TKey, TValue>(_dictionary);
                             dict[key] = value;
                             _dictionary = dict;
                         }

--- a/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.JSInterop.Tests
             Assert.Equal($"The assembly '{thisAssemblyName}' does not contain a public method with [JSInvokableAttribute(\"{methodIdentifier}\")].", ex.Message);
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1733")]
+        [Fact]
         public Task CanInvokeStaticVoidMethod() => WithJSRuntime(jsRuntime =>
         {
             // Arrange/Act
@@ -109,7 +109,7 @@ namespace Microsoft.JSInterop.Tests
             Assert.Equal(456, result.IntVal);
         });
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1733")]
+        [Fact]
         public Task CanInvokeStaticWithParams() => WithJSRuntime(jsRuntime =>
         {
             // Arrange: Track a .NET object to use as an arg
@@ -140,7 +140,7 @@ namespace Microsoft.JSInterop.Tests
             Assert.Equal(1299, resultDto2.IntVal);
         });
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1733")]
+        [Fact]
         public Task CanInvokeInstanceVoidMethod() => WithJSRuntime(jsRuntime =>
         {
             // Arrange: Track some instance
@@ -155,7 +155,7 @@ namespace Microsoft.JSInterop.Tests
             Assert.True(targetInstance.DidInvokeMyInvocableInstanceVoid);
         });
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1733")]
+        [Fact]
         public Task CanInvokeBaseInstanceVoidMethod() => WithJSRuntime(jsRuntime =>
         {
             // Arrange: Track some instance
@@ -206,7 +206,7 @@ namespace Microsoft.JSInterop.Tests
             Assert.StartsWith("There is no tracked object with id '1'.", ex.Message);
         });
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1733")]
+        [Fact]
         public Task CanInvokeInstanceMethodWithParams() => WithJSRuntime(jsRuntime =>
         {
             // Arrange: Track some instance plus another object we'll pass as a param
@@ -242,7 +242,7 @@ namespace Microsoft.JSInterop.Tests
             Assert.Equal("In call to 'InvocableStaticWithParams', expected 3 parameters but received 4.", ex.Message);
         }
 
-        [Fact(Skip = "https://github.com/aspnet/AspNetCore-Internal/issues/1733")]
+        [Fact]
         public Task CanInvokeAsyncMethod() => WithJSRuntime(async jsRuntime =>
         {
             // Arrange: Track some instance plus another object we'll pass as a param


### PR DESCRIPTION
Fixes: aspnet/AspNetCore-Internal#1733

It's unclear what the cause of the original failures are but it was a
consistent failure. If this passes on the CI I will merge.

