### PR TITLE
Dispose configuration in host (Fixes #938)

### DIFF
--- a/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netstandard2.0.cs
+++ b/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netstandard2.0.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Extensions.Configuration
     public static partial class ChainedBuilderExtensions
     {
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddConfiguration(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddConfiguration(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Microsoft.Extensions.Configuration.IConfiguration config, bool shouldDisposeConfiguration) { throw null; }
     }
     public partial class ChainedConfigurationProvider : Microsoft.Extensions.Configuration.IConfigurationProvider, System.IDisposable
     {
@@ -21,6 +22,7 @@ namespace Microsoft.Extensions.Configuration
     {
         public ChainedConfigurationSource() { }
         public Microsoft.Extensions.Configuration.IConfiguration Configuration { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ShouldDisposeConfiguration { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Extensions.Configuration.IConfigurationProvider Build(Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { throw null; }
     }
     public partial class ConfigurationBuilder : Microsoft.Extensions.Configuration.IConfigurationBuilder

--- a/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netstandard2.0.cs
+++ b/src/Configuration/Config/ref/Microsoft.Extensions.Configuration.netstandard2.0.cs
@@ -7,9 +7,10 @@ namespace Microsoft.Extensions.Configuration
     {
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddConfiguration(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Microsoft.Extensions.Configuration.IConfiguration config) { throw null; }
     }
-    public partial class ChainedConfigurationProvider : Microsoft.Extensions.Configuration.IConfigurationProvider
+    public partial class ChainedConfigurationProvider : Microsoft.Extensions.Configuration.IConfigurationProvider, System.IDisposable
     {
         public ChainedConfigurationProvider(Microsoft.Extensions.Configuration.ChainedConfigurationSource source) { }
+        public void Dispose() { }
         public System.Collections.Generic.IEnumerable<string> GetChildKeys(System.Collections.Generic.IEnumerable<string> earlierKeys, string parentPath) { throw null; }
         public Microsoft.Extensions.Primitives.IChangeToken GetReloadToken() { throw null; }
         public void Load() { }

--- a/src/Configuration/Config/src/ChainedBuilderExtensions.cs
+++ b/src/Configuration/Config/src/ChainedBuilderExtensions.cs
@@ -18,6 +18,16 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="config">The <see cref="IConfiguration"/> to add.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddConfiguration(this IConfigurationBuilder configurationBuilder, IConfiguration config)
+            => AddConfiguration(configurationBuilder, config, shouldDisposeConfiguration: false);
+
+        /// <summary>
+        /// Adds an existing configuration to <paramref name="configurationBuilder"/>.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="config">The <see cref="IConfiguration"/> to add.</param>
+        /// <param name="shouldDisposeConfiguration">Whether the configuration should get disposed when the configuration provider is disposed.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddConfiguration(this IConfigurationBuilder configurationBuilder, IConfiguration config, bool shouldDisposeConfiguration)
         {
             if (configurationBuilder == null)
             {
@@ -28,7 +38,11 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(config));
             }
 
-            configurationBuilder.Add(new ChainedConfigurationSource { Configuration = config });
+            configurationBuilder.Add(new ChainedConfigurationSource
+            {
+                Configuration = config,
+                ShouldDisposeConfiguration = shouldDisposeConfiguration,
+            });
             return configurationBuilder;
         }
     }

--- a/src/Configuration/Config/src/ChainedConfigurationProvider.cs
+++ b/src/Configuration/Config/src/ChainedConfigurationProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.Configuration
     public class ChainedConfigurationProvider : IConfigurationProvider, IDisposable
     {
         private readonly IConfiguration _config;
+        private readonly bool _shouldDisposeConfig;
 
         /// <summary>
         /// Initialize a new instance from the source configuration.
@@ -31,6 +32,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             _config = source.Configuration;
+            _shouldDisposeConfig = source.ShouldDisposeConfiguration;
         }
 
         /// <summary>
@@ -86,7 +88,10 @@ namespace Microsoft.Extensions.Configuration
         /// <inheritdoc />
         public void Dispose()
         {
-            (_config as IDisposable)?.Dispose();
+            if (_shouldDisposeConfig)
+            {
+                (_config as IDisposable)?.Dispose();
+            }
         }
     }
 }

--- a/src/Configuration/Config/src/ChainedConfigurationProvider.cs
+++ b/src/Configuration/Config/src/ChainedConfigurationProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Configuration
     /// <summary>
     /// Chained implementation of <see cref="IConfigurationProvider"/>
     /// </summary>
-    public class ChainedConfigurationProvider : IConfigurationProvider
+    public class ChainedConfigurationProvider : IConfigurationProvider, IDisposable
     {
         private readonly IConfiguration _config;
 
@@ -81,6 +81,12 @@ namespace Microsoft.Extensions.Configuration
             keys.AddRange(children.Select(c => c.Key));
             return keys.Concat(earlierKeys)
                 .OrderBy(k => k, ConfigurationKeyComparer.Instance);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            (_config as IDisposable)?.Dispose();
         }
     }
 }

--- a/src/Configuration/Config/src/ChainedConfigurationSource.cs
+++ b/src/Configuration/Config/src/ChainedConfigurationSource.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Extensions.Configuration
         public IConfiguration Configuration { get; set; }
 
         /// <summary>
+        /// Whether the chained configuration should be disposed when the
+        /// configuration provider gets disposed.
+        /// </summary>
+        public bool ShouldDisposeConfiguration { get; set; }
+
+        /// <summary>
         /// Builds the <see cref="ChainedConfigurationProvider"/> for this source.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>

--- a/src/Configuration/Config/test/ConfigurationRootTest.cs
+++ b/src/Configuration/Config/test/ConfigurationRootTest.cs
@@ -55,6 +55,27 @@ namespace Microsoft.Extensions.Configuration.Test
             Assert.Empty(changeToken.Callbacks);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ChainedConfigurationIsDisposed(bool shouldDispose)
+        {
+            var provider = new DisposableTestConfigurationProvider("foo", "foo-value");
+            var chainedConfig = new ConfigurationRoot(new IConfigurationProvider[] {
+                provider
+            });
+
+            var config = new ConfigurationBuilder()
+                .AddConfiguration(chainedConfig, shouldDisposeConfiguration: shouldDispose)
+                .Build();
+
+            Assert.False(provider.IsDisposed);
+
+            (config as IDisposable).Dispose();
+
+            Assert.Equal(shouldDispose, provider.IsDisposed);
+        }
+
         private class TestConfigurationProvider : ConfigurationProvider
         {
             public TestConfigurationProvider(string key, string value)

--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -197,7 +197,8 @@ namespace Microsoft.Extensions.Hosting
 #pragma warning restore CS0618 // Type or member is obsolete
             services.AddSingleton<IHostEnvironment>(_hostingEnvironment);
             services.AddSingleton(_hostBuilderContext);
-            services.AddSingleton(_appConfiguration);
+            // register configuration as factory to make it dispose with the service provider
+            services.AddSingleton(_ => _appConfiguration);
 #pragma warning disable CS0618 // Type or member is obsolete
             services.AddSingleton<IApplicationLifetime>(s => (IApplicationLifetime)s.GetService<IHostApplicationLifetime>());
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -225,6 +226,10 @@ namespace Microsoft.Extensions.Hosting
             {
                 throw new InvalidOperationException($"The IServiceProviderFactory returned a null IServiceProvider.");
             }
+
+            // resolve configuration explicitly once to mark it as resolved within the
+            // service provider, ensuring it will be properly disposed with the provider
+            _ = _appServices.GetService<IConfiguration>();
         }
     }
 }

--- a/src/Hosting/Hosting/src/HostBuilder.cs
+++ b/src/Hosting/Hosting/src/HostBuilder.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Extensions.Hosting
         {
             var configBuilder = new ConfigurationBuilder()
                 .SetBasePath(_hostingEnvironment.ContentRootPath)
-                .AddConfiguration(_hostConfiguration);
+                .AddConfiguration(_hostConfiguration, shouldDisposeConfiguration: true);
 
             foreach (var buildAction in _configureAppConfigActions)
             {

--- a/src/Hosting/Hosting/test/Internal/HostTests.cs
+++ b/src/Hosting/Hosting/test/Internal/HostTests.cs
@@ -884,6 +884,54 @@ namespace Microsoft.Extensions.Hosting.Internal
             }
         }
 
+        [Fact]
+        public void Dispose_DisposesAppConfigurationProviders()
+        {
+            var providerMock = new Mock<ConfigurationProvider>().As<IDisposable>();
+            providerMock.Setup(d => d.Dispose());
+
+            var sourceMock = new Mock<IConfigurationSource>();
+            sourceMock.Setup(s => s.Build(It.IsAny<IConfigurationBuilder>()))
+                .Returns((ConfigurationProvider)providerMock.Object);
+
+            var host = CreateBuilder()
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.Add(sourceMock.Object);
+                })
+                .Build();
+
+            providerMock.Verify(c => c.Dispose(), Times.Never);
+
+            host.Dispose();
+
+            providerMock.Verify(c => c.Dispose(), Times.AtLeastOnce());
+        }
+
+        [Fact]
+        public void Dispose_DisposesHostConfigurationProviders()
+        {
+            var providerMock = new Mock<ConfigurationProvider>().As<IDisposable>();
+            providerMock.Setup(d => d.Dispose());
+
+            var sourceMock = new Mock<IConfigurationSource>();
+            sourceMock.Setup(s => s.Build(It.IsAny<IConfigurationBuilder>()))
+                .Returns((ConfigurationProvider)providerMock.Object);
+
+            var host = CreateBuilder()
+                .ConfigureHostConfiguration(configuration =>
+                {
+                    configuration.Add(sourceMock.Object);
+                })
+                .Build();
+
+            providerMock.Verify(c => c.Dispose(), Times.Never);
+
+            host.Dispose();
+
+            providerMock.Verify(c => c.Dispose(), Times.AtLeastOnce());
+        }
+
         private IHostBuilder CreateBuilder(IConfiguration config = null)
         {
             return new HostBuilder().ConfigureHostConfiguration(builder => builder.AddConfiguration(config ?? new ConfigurationBuilder().Build()));


### PR DESCRIPTION
This fixes #938: When disposing the host, the underlying configuration will also be disposed. Access to the configuration is provided by explicitly depending on the `IConfiguration` in `Host`. Since the host is internal and constructed by the `HostBuilder` through DI, this change does not affect users.

In addition, the host configuration that is created and managed by the `HostBuilder` is disposed when the `Host` is being built. At that point, the previous host configuration is only used to construct the app configuration and then every reference to the host configuration is replaced by the app configuration (e.g. in the `HostContext`). Since the host configuration is then never accessed again (the host can also not be built more than once) and since it also remains private to the host builder, the configuration can be safely disposed at that point.

This change combined with #928 will ultimately ensure that configuration providers will be properly disposed when the host gets disposed (or built).

A follow-up PR to AspNetCore will be made in a moment that backports this functionality to the legacy `WebHost` and `WebHostBuilder`.

/cc @davidfowl 