### PR TITLE
Onboard with async publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,10 @@ variables:
     value: AspNetCore
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: true
+  - name: _PublishUsingPipelines
+    value: true
+  - name: _DotNetArtifactsCategory
+    value: ASPNETEXTENSIONS
 
 # CI and PR triggers
 trigger:
@@ -35,6 +39,7 @@ jobs:
     enablePublishBuildArtifacts: true
     enablePublishTestResults: true
     enablePublishBuildAssets: true
+    enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     helixRepo: aspnet/Extensions
     jobs:
@@ -59,6 +64,8 @@ jobs:
                  /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                  /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json
                  /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                 /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                 /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                  /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       # else
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2443

Goal: mitigate `lock on the feed problem` and add further validations. [More details here.](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing_HowToUse.md)

Test build was here: https://dnceng.visualstudio.com/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/index?buildId=149743
Test release: https://dnceng.visualstudio.com/internal/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?_a=release-pipeline-progress&releaseId=4449