### PR TITLE
Expose property on CacheOptions to allow for access token authentication

### DIFF
--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -52,8 +52,13 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
         protected ISystemClock SystemClock { get; }
 
-        protected SqlConnection CreateSqlConnection() => new SqlConnection(ConnectionString)
-            {AccessToken = AccessTokenFunc?.Invoke()};
+        protected SqlConnection CreateSqlConnection()
+        {
+            return new SqlConnection(ConnectionString)
+            {
+                AccessToken = AccessTokenFunc?.Invoke()
+            };
+        }
 
         public void DeleteCacheItem(string key)
         {

--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -30,17 +30,17 @@ namespace Microsoft.Extensions.Caching.SqlServer
             "Connection string: {2}";
 
         public DatabaseOperations(
-            string connectionString, string schemaName, string tableName, Func<string> accessTokenFunc, ISystemClock systemClock)
+            string connectionString, string schemaName, string tableName, Func<string> accessTokenProvider, ISystemClock systemClock)
         {
             ConnectionString = connectionString;
             SchemaName = schemaName;
             TableName = tableName;
-            AccessTokenFunc = accessTokenFunc;
+            AccessTokenProvider = accessTokenProvider;
             SystemClock = systemClock;
             SqlQueries = new SqlQueries(schemaName, tableName);
         }
 
-        protected Func<string> AccessTokenFunc { get; }
+        protected Func<string> AccessTokenProvider { get; }
 
         protected SqlQueries SqlQueries { get; }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
         {
             return new SqlConnection(ConnectionString)
             {
-                AccessToken = AccessTokenFunc?.Invoke()
+                AccessToken = AccessTokenProvider?.Invoke()
             };
         }
 

--- a/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
     internal class MonoDatabaseOperations : DatabaseOperations
     {
         public MonoDatabaseOperations(
-            string connectionString, string schemaName, string tableName, ISystemClock systemClock)
-            : base(connectionString, schemaName, tableName, systemClock)
+            string connectionString, string schemaName, string tableName, Func<string> accessTokenFunc, ISystemClock systemClock)
+            : base(connectionString, schemaName, tableName, accessTokenFunc, systemClock)
         {
         }
 
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
             TimeSpan? slidingExpiration = null;
             DateTimeOffset? absoluteExpiration = null;
             DateTimeOffset expirationTime;
-            using (var connection = new SqlConnection(ConnectionString))
+            using (var connection = CreateSqlConnection())
             {
                 var command = new SqlCommand(query, connection);
                 command.Parameters
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
             TimeSpan? slidingExpiration = null;
             DateTimeOffset? absoluteExpiration = null;
             DateTimeOffset expirationTime;
-            using (var connection = new SqlConnection(ConnectionString))
+            using (var connection = CreateSqlConnection())
             {
                 var command = new SqlCommand(SqlQueries.GetCacheItem, connection);
                 command.Parameters
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
             var absoluteExpiration = GetAbsoluteExpiration(utcNow, options);
             ValidateOptions(options.SlidingExpiration, absoluteExpiration);
 
-            using (var connection = new SqlConnection(ConnectionString))
+            using (var connection = CreateSqlConnection())
             {
                 var upsertCommand = new SqlCommand(SqlQueries.SetCacheItem, connection);
                 upsertCommand.Parameters
@@ -192,7 +192,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
             var absoluteExpiration = GetAbsoluteExpiration(utcNow, options);
             ValidateOptions(options.SlidingExpiration, absoluteExpiration);
 
-            using (var connection = new SqlConnection(ConnectionString))
+            using (var connection = CreateSqlConnection())
             {
                 var upsertCommand = new SqlCommand(SqlQueries.SetCacheItem, connection);
                 upsertCommand.Parameters
@@ -227,7 +227,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
         {
             var utcNow = SystemClock.UtcNow;
 
-            using (var connection = new SqlConnection(ConnectionString))
+            using (var connection = CreateSqlConnection())
             {
                 var command = new SqlCommand(SqlQueries.DeleteExpiredCacheItems, connection);
                 command.Parameters.AddWithValue("UtcNow", SqlDbType.DateTime, utcNow.UtcDateTime);

--- a/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Extensions.Caching.SqlServer
     internal class MonoDatabaseOperations : DatabaseOperations
     {
         public MonoDatabaseOperations(
-            string connectionString, string schemaName, string tableName, Func<string> accessTokenFunc, ISystemClock systemClock)
-            : base(connectionString, schemaName, tableName, accessTokenFunc, systemClock)
+            string connectionString, string schemaName, string tableName, Func<string> accessTokenProvider, ISystemClock systemClock)
+            : base(connectionString, schemaName, tableName, accessTokenProvider, systemClock)
         {
         }
 

--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
                     cacheOptions.ConnectionString,
                     cacheOptions.SchemaName,
                     cacheOptions.TableName,
+                    cacheOptions.AccessTokenFunc,
                     _systemClock);
             }
             else
@@ -82,6 +83,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
                     cacheOptions.ConnectionString,
                     cacheOptions.SchemaName,
                     cacheOptions.TableName,
+                    cacheOptions.AccessTokenFunc,
                     _systemClock);
             }
         }

--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
                     cacheOptions.ConnectionString,
                     cacheOptions.SchemaName,
                     cacheOptions.TableName,
-                    cacheOptions.AccessTokenFunc,
+                    cacheOptions.AccessTokenProvider,
                     _systemClock);
             }
             else
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
                     cacheOptions.ConnectionString,
                     cacheOptions.SchemaName,
                     cacheOptions.TableName,
-                    cacheOptions.AccessTokenFunc,
+                    cacheOptions.AccessTokenProvider,
                     _systemClock);
             }
         }

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
         public TimeSpan DefaultSlidingExpiration { get; set; } = TimeSpan.FromMinutes(20);
 
         /// <summary>
-        /// A function, if provided, should return an access token for authentication
+        /// Gets or sets an access token provider that will be called to return a token for each SQL connection.
         /// </summary>
         public Func<string> AccessTokenFunc { get; set; }
 

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Extensions.Caching.SqlServer
         /// </summary>
         public TimeSpan DefaultSlidingExpiration { get; set; } = TimeSpan.FromMinutes(20);
 
+        /// <summary>
+        /// A function, if provided, should return an access token for authentication
+        /// </summary>
+        public Func<string> AccessTokenFunc { get; set; }
+
         SqlServerCacheOptions IOptions<SqlServerCacheOptions>.Value
         {
             get

--- a/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
+++ b/src/Caching/SqlServer/src/SqlServerCacheOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
         /// <summary>
         /// Gets or sets an access token provider that will be called to return a token for each SQL connection.
         /// </summary>
-        public Func<string> AccessTokenFunc { get; set; }
+        public Func<string> AccessTokenProvider { get; set; }
 
         SqlServerCacheOptions IOptions<SqlServerCacheOptions>.Value
         {


### PR DESCRIPTION
Summary of the changes
 - Add property to cache options to allow for access token authentication 
