### PR TITLE
[2.2] Fix for assembly version not matching package version

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,12 +18,15 @@
   <Import Project="eng\Baseline.Designer.props" />
 
   <PropertyGroup Condition=" '$(IsPackable)' != 'false' AND '$(IsServicingBuild)' == 'true' ">
-    <IsPackable>$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackable>
+    <IsPackageInThisPatch Condition="'$(IsPackageInThisPatch)' == ''">$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackageInThisPatch>
+    <!-- Suppress creation of .nupkg for servicing builds. -->
+    <IsPackable Condition=" '$(IsPackageInThisPatch)' != 'true' ">false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsPackable)' == 'true' AND '$(BaselinePackageVersion)' != '' AND '$(IsServicingBuild)' == 'true' ">
-    <!-- This keeps assembly versions consistent across patches. If a package is not included in a patch, its assembly version should stay at the baseline. -->
-    <AssemblyVersion>$(BaselinePackageVersion).0</AssemblyVersion>
+  <PropertyGroup Condition=" '$(IsPackageInThisPatch)' != 'true' AND '$(BaselinePackageVersion)' != '' AND '$(IsServicingBuild)' == 'true' ">
+    <!-- This keeps assembly and package versions consistent across patches. If a package is not included in a patch, its version should stay at the baseline. -->
+    <AssemblyVersion Condition="$(BaselinePackageVersion.Contains('-'))">$(BaselinePackageVersion.Substring(0, $(BaselinePackageVersion.IndexOf('-')))).0</AssemblyVersion>
+    <AssemblyVersion Condition="! $(BaselinePackageVersion.Contains('-'))">$(BaselinePackageVersion).0</AssemblyVersion>
     <!--
       Ideally, we would also set the project version to match the baseline in case NuGet turns a ProjectReference into a nuspec depenendency, but
       NuGet does not currently handle conflicts between packages and projects which have the same package id/version.

--- a/eng/NuGetPackageVerifier.json
+++ b/eng/NuGetPackageVerifier.json
@@ -24,37 +24,7 @@
             "*": "Props file intentionally targets any framework since the content is the same for both netstandard2.0 and net461."
           }
         }
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "Exclusions": {
-          "ASSEMBLY_FILE_VERSION_MISMATCH": {
-            "lib/netstandard2.0/Microsoft.Extensions.Configuration.Binder.dll": "Enter justification"
-          },
-          "ASSEMBLY_VERSION_MISMATCH": {
-            "lib/netstandard2.0/Microsoft.Extensions.Configuration.Binder.dll": "Enter justification"
-          }
-        }
-      },
-      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
-       "Exclusions": {
-          "ASSEMBLY_FILE_VERSION_MISMATCH": {
-            "lib/netstandard2.0/Microsoft.Extensions.Configuration.EnvironmentVariables.dll": "Enter justification"
-          },
-          "ASSEMBLY_VERSION_MISMATCH": {
-            "lib/netstandard2.0/Microsoft.Extensions.Configuration.EnvironmentVariables.dll": "Enter justification"
-          }
-        }
-      },
-      "Microsoft.Extensions.Configuration.KeyPerFile": {
-        "Exclusions": {
-          "ASSEMBLY_FILE_VERSION_MISMATCH": {
-            "lib/netstandard2.0/Microsoft.Extensions.Configuration.KeyPerFile.dll": "Enter justification"
-          },
-          "ASSEMBLY_VERSION_MISMATCH": {
-            "lib/netstandard2.0/Microsoft.Extensions.Configuration.KeyPerFile.dll": "Enter justification"
-          }
-        }
-      }      
+      }
     }
   }
 }

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -1,4 +1,18 @@
+<!--
+
+This file contains a list of the package IDs which are patching in a given release.
+
+CAUTION: due to limitations in MSBuild, the format of the PackagesInPatch property is picky.
+When adding a new package, make sure the new line ends with a semicolon and starts with a space.
+
+Later on, this will be checked using this condition:
+
+    <IsPackageInThisPatch>$(PackagesInPatch.Contains(' $(PackageId);'))</IsPackageInThisPatch>
+-->
 <Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(VersionPrefix)' == '2.2.1' ">
     <PackagesInPatch>


### PR DESCRIPTION
Revert exclusions added in https://github.com/aspnet/Extensions/pull/1259 to NuGet package verifier which suppresses errors that should not have been ignored.

For future reference, assembly version mismatch errors should be taken seriously and not ignored. If we get assembly versions wrong, we can end up with all sorts of nasty problems with binding redirects, forced downgrades, runtime errors, shared framework mismatches, etc.

Required to unblock @BrennanConroy's work.

## Description

Normally, ASP.NET Core packages have the assembly version match the NuGet package version (at least the first three parts, x.y.z). Each patch of should have incremented the assembly versions but didn't. For example, the 2.2.4 release of Microsoft.Extensions.Configuration.KeyPerFile contains an an assembly with version `2.2.0.0`, not `2.2.4.0`.

## Customer impact

This will prevent us from having problems in the future if we have to patch any assemblies for a 2nd time.

## Regression?

Yes.

## Risk

Low. This restores behavior we had in 2.1 which somehow went missing during source code reorganization. It should have been caught earlier, but devs started suppressing the errors instead of fixing them.