### PR TITLE
Remove target invocation exceptions

### DIFF
--- a/src/Shared/src/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/Shared/src/ActivatorUtilities/ActivatorUtilities.cs
@@ -403,16 +403,20 @@ namespace Microsoft.Extensions.Internal
                     }
                 }
 
+#if NETCOREAPP3_0
+                return _constructor.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters: _parameterValues, culture: null);
+#else
                 try
                 {
                     return _constructor.Invoke(_parameterValues);
                 }
-                catch (TargetInvocationException ex)
+                catch (TargetInvocationException ex) when (ex.InnerException != null)
                 {
                     ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                     // The above line will always throw, but the compiler requires we throw explicitly.
                     throw;
                 }
+#endif
             }
         }
 


### PR DESCRIPTION
- Use BindingFlags.DoNotWrapExceptions to invoke constructors

