### PR TITLE
KeyVault Config Provider ctor parameter validation

### DIFF
--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _vault = vault ?? throw new ArgumentNullException(nameof(vault));
             _manager = manager ?? throw new ArgumentNullException(nameof(manager));
-            if (_reloadInterval != null && _reloadInterval.Value <= TimeSpan.Zero)
+            if (reloadInterval != null && reloadInterval.Value <= TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException (nameof(reloadInterval), reloadInterval, nameof(reloadInterval) + " must be positive.");
             }

--- a/src/Configuration/Config.AzureKeyVault/test/AzureKeyVaultConfigurationTest.cs
+++ b/src/Configuration/Config.AzureKeyVault/test/AzureKeyVaultConfigurationTest.cs
@@ -442,6 +442,18 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
         }
 
         [Fact]
+        public void ConstructorThrowsForZeroRefreshPeriodValue()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(new MockKeyVaultClient(), VaultUri, new DefaultKeyVaultSecretManager(), TimeSpan.Zero));
+        }
+
+        [Fact]
+        public void ConstructorThrowsForNegativeRefreshPeriodValue()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(new MockKeyVaultClient(), VaultUri, new DefaultKeyVaultSecretManager(), TimeSpan.FromMilliseconds(-1)));
+        }
+
+        [Fact]
         public override void Null_values_are_included_in_the_config()
         {
             AssertConfig(BuildConfigRoot(LoadThroughProvider(TestSection.NullsTestConfig)), expectNulls: true);

--- a/src/Configuration/Config.AzureKeyVault/test/AzureKeyVaultConfigurationTest.cs
+++ b/src/Configuration/Config.AzureKeyVault/test/AzureKeyVaultConfigurationTest.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
     public class AzureKeyVaultConfigurationTest: ConfigurationProviderTestBase
     {
         private const string VaultUri = "https://vault";
+        private static readonly TimeSpan NoReloadDelay = TimeSpan.FromMilliseconds(1);
 
         [Fact]
         public void LoadsAllSecretsFromVault()
@@ -167,7 +168,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
             );
 
             // Act & Assert
-            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: TimeSpan.Zero))
+            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: NoReloadDelay))
             {
                 ChangeToken.OnChange(
                     () => provider.GetReloadToken(),
@@ -212,7 +213,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
             );
 
             // Act & Assert
-            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: TimeSpan.Zero))
+            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: NoReloadDelay))
             {
                 ChangeToken.OnChange(
                     () => provider.GetReloadToken(),
@@ -250,7 +251,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
             );
 
             // Act & Assert
-            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: TimeSpan.Zero))
+            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: NoReloadDelay))
             {
                 ChangeToken.OnChange(
                     () => provider.GetReloadToken(),
@@ -295,7 +296,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
             );
 
             // Act & Assert
-            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: TimeSpan.Zero))
+            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: NoReloadDelay))
             {
                 ChangeToken.OnChange(
                     () => provider.GetReloadToken(),
@@ -340,7 +341,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault.Test
             );
 
             // Act & Assert
-            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: TimeSpan.Zero))
+            using (var provider = new ReloadControlKeyVaultProvider(client, VaultUri, new DefaultKeyVaultSecretManager(), reloadPollDelay: NoReloadDelay))
             {
                 ChangeToken.OnChange(
                     () => provider.GetReloadToken(),


### PR DESCRIPTION
Summary:
 - Reload Interval: Private field was validated instead of ctor parameter.

Addresses #none
