### PR TITLE
Tags defined during health check registration are now available in th…

### DIFF
--- a/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netstandard2.0.cs
+++ b/src/HealthChecks/Abstractions/ref/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.netstandard2.0.cs
@@ -47,11 +47,13 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         private object _dummy;
         private int _dummyPrimitive;
         public HealthReportEntry(Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus status, string description, System.TimeSpan duration, System.Exception exception, System.Collections.Generic.IReadOnlyDictionary<string, object> data) { throw null; }
+        public HealthReportEntry(Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus status, string description, System.TimeSpan duration, System.Exception exception, System.Collections.Generic.IReadOnlyDictionary<string, object> data, System.Collections.Generic.IEnumerable<string> tags = null) { throw null; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object> Data { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.TimeSpan Duration { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Exception Exception { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus Status { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> Tags { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     public enum HealthStatus
     {

--- a/src/HealthChecks/Abstractions/src/HealthReportEntry.cs
+++ b/src/HealthChecks/Abstractions/src/HealthReportEntry.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Extensions.Diagnostics.HealthChecks
 {
@@ -22,13 +23,15 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// <param name="duration">A value indicating the health execution duration.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
         /// <param name="data">Additional key-value pairs describing the health of the component.</param>
-        public HealthReportEntry(HealthStatus status, string description, TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data)
+        /// <param name="tags">Tags associated with the health check that generated the report entry.</param>
+        public HealthReportEntry(HealthStatus status, string description, TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data, IEnumerable<string> tags = null)
         {
             Status = status;
             Description = description;
             Duration = duration;
             Exception = exception;
             Data = data ?? _emptyReadOnlyDictionary;
+            Tags = tags ?? Enumerable.Empty<string>();
         }
 
         /// <summary>
@@ -55,5 +58,10 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// Gets the health status of the component that was checked.
         /// </summary>
         public HealthStatus Status { get; }
+
+        /// <summary>
+        /// Gets the tags associated with the health check.
+        /// </summary>
+        public IEnumerable<string> Tags { get; }
     }
 }

--- a/src/HealthChecks/Abstractions/src/HealthReportEntry.cs
+++ b/src/HealthChecks/Abstractions/src/HealthReportEntry.cs
@@ -23,6 +23,20 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         /// <param name="duration">A value indicating the health execution duration.</param>
         /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
         /// <param name="data">Additional key-value pairs describing the health of the component.</param>
+        public HealthReportEntry(HealthStatus status, string description, TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data)
+            : this(status, description, duration, exception, data, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="HealthReportEntry"/> with the specified values for <paramref name="status"/>, <paramref name="exception"/>,
+        /// <paramref name="description"/>, and <paramref name="data"/>.
+        /// </summary>
+        /// <param name="status">A value indicating the health status of the component that was checked.</param>
+        /// <param name="description">A human-readable description of the status of the component that was checked.</param>
+        /// <param name="duration">A value indicating the health execution duration.</param>
+        /// <param name="exception">An <see cref="Exception"/> representing the exception that was thrown when checking for status (if any).</param>
+        /// <param name="data">Additional key-value pairs describing the health of the component.</param>
         /// <param name="tags">Tags associated with the health check that generated the report entry.</param>
         public HealthReportEntry(HealthStatus status, string description, TimeSpan duration, Exception exception, IReadOnlyDictionary<string, object> data, IEnumerable<string> tags = null)
         {
@@ -33,6 +47,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             Data = data ?? _emptyReadOnlyDictionary;
             Tags = tags ?? Enumerable.Empty<string>();
         }
+
 
         /// <summary>
         /// Gets additional key-value pairs describing the health of the component.

--- a/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
+++ b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         description: result.Description,
                         duration: duration,
                         exception: result.Exception,
-                        data: result.Data);
+                        data: result.Data,
+                        tags: registration.Tags);
 
                     Log.HealthCheckEnd(_logger, registration, entry, duration);
                     Log.HealthCheckData(_logger, registration, entry);

--- a/src/HealthChecks/HealthChecks/test/DefaultHealthCheckServiceTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DefaultHealthCheckServiceTest.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             const string UnhealthyMessage = "Halp!";
             const string HealthyMessage = "Everything is A-OK";
             var exception = new Exception("Things are pretty bad!");
-            IEnumerable<string> healthyCheckTags = new List<string> { "healthy-check-tag" };
-            IEnumerable<string> degradedCheckTags = new List<string> { "degraded-check-tag" };
-            IEnumerable<string> unhealthyCheckTags = new List<string> { "unhealthy-check-tag" };
+            var healthyCheckTags = new List<string> { "healthy-check-tag" };
+            var degradedCheckTags = new List<string> { "degraded-check-tag" };
+            var unhealthyCheckTags = new List<string> { "unhealthy-check-tag" };
 
             // Arrange
             var data = new Dictionary<string, object>()

--- a/src/HealthChecks/HealthChecks/test/DefaultHealthCheckServiceTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DefaultHealthCheckServiceTest.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             const string UnhealthyMessage = "Halp!";
             const string HealthyMessage = "Everything is A-OK";
             var exception = new Exception("Things are pretty bad!");
+            IEnumerable<string> healthyCheckTags = new List<string> { "healthy-check-tag" };
+            IEnumerable<string> degradedCheckTags = new List<string> { "degraded-check-tag" };
+            IEnumerable<string> unhealthyCheckTags = new List<string> { "unhealthy-check-tag" };
 
             // Arrange
             var data = new Dictionary<string, object>()
@@ -66,9 +69,9 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
 
             var service = CreateHealthChecksService(b =>
             {
-                b.AddAsyncCheck("HealthyCheck", _ => Task.FromResult(HealthCheckResult.Healthy(HealthyMessage, data)));
-                b.AddAsyncCheck("DegradedCheck", _ => Task.FromResult(HealthCheckResult.Degraded(DegradedMessage)));
-                b.AddAsyncCheck("UnhealthyCheck", _ => Task.FromResult(HealthCheckResult.Unhealthy(UnhealthyMessage, exception)));
+                b.AddAsyncCheck("HealthyCheck", _ => Task.FromResult(HealthCheckResult.Healthy(HealthyMessage, data)), healthyCheckTags);
+                b.AddAsyncCheck("DegradedCheck", _ => Task.FromResult(HealthCheckResult.Degraded(DegradedMessage)), degradedCheckTags);
+                b.AddAsyncCheck("UnhealthyCheck", _ => Task.FromResult(HealthCheckResult.Unhealthy(UnhealthyMessage, exception)), unhealthyCheckTags);
             });
 
             // Act
@@ -84,6 +87,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                     Assert.Equal(HealthStatus.Degraded, actual.Value.Status);
                     Assert.Null(actual.Value.Exception);
                     Assert.Empty(actual.Value.Data);
+                    Assert.Equal(actual.Value.Tags, degradedCheckTags);
                 },
                 actual =>
                 {
@@ -96,6 +100,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                         Assert.Equal(DataKey, item.Key);
                         Assert.Equal(DataValue, item.Value);
                     });
+                    Assert.Equal(actual.Value.Tags, healthyCheckTags);
                 },
                 actual =>
                 {
@@ -104,6 +109,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
                     Assert.Equal(HealthStatus.Unhealthy, actual.Value.Status);
                     Assert.Same(exception, actual.Value.Exception);
                     Assert.Empty(actual.Value.Data);
+                    Assert.Equal(actual.Value.Tags, unhealthyCheckTags);
                 });
         }
 


### PR DESCRIPTION
…e health report entries.

Summary of the changes (Less than 80 chars)
 - HealthReportEntry has tags defined in the HealthCheck registration. Updated unit test.

Addresses #9378.

@rynowak , please let me know if more unit tests are needed. 
