### PR TITLE
Fix for false-positive publish failures when tests fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
         condition: always()
       - task: PublishBuildArtifacts@1
         displayName: Upload package artifacts
-        condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+        condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         inputs:
           pathtoPublish: artifacts/packages/
           artifactName: artifacts


### PR DESCRIPTION
The PublishBuildArtifacts fails when artifacts/packages/ does not exist or is empty. This change will only publish packages if build.cmd succeeds (which means all tests, code signing, and compilation must pass)

