### PR TITLE
Enable ValidateOnBuild in CreateDefaultBuilder

### DIFF
--- a/src/Hosting/Hosting/src/Host.cs
+++ b/src/Hosting/Hosting/src/Host.cs
@@ -97,7 +97,9 @@ namespace Microsoft.Extensions.Hosting
             })
             .UseDefaultServiceProvider((context, options) =>
             {
-                options.ValidateScopes = context.HostingEnvironment.IsDevelopment();
+                var isDevelopment = context.HostingEnvironment.IsDevelopment();
+                options.ValidateScopes = isDevelopment;
+                options.ValidateOnBuild = isDevelopment;
             });
 
             return builder;

--- a/src/Hosting/Hosting/test/HostTests.cs
+++ b/src/Hosting/Hosting/test/HostTests.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Extensions.Hosting
         [Fact]
         public void CreateDefaultBuilder_EnablesScopeValidation()
         {
-            var listener = new TestEventListener();
             var host = Host.CreateDefaultBuilder()
                 .UseEnvironment(Environments.Development)
                 .ConfigureServices(serices =>
@@ -69,7 +68,30 @@ namespace Microsoft.Extensions.Hosting
             Assert.Throws<InvalidOperationException>(() => { host.Services.GetRequiredService<ServiceA>(); });
         }
 
+        [Fact]
+        public void CreateDefaultBuilder_EnablesValidateOnBuild()
+        {
+            var hostBuilder = Host.CreateDefaultBuilder()
+                .UseEnvironment(Environments.Development)
+                .ConfigureServices(serices =>
+                {
+                    serices.AddSingleton<ServiceB>();
+                });
+
+            Assert.Throws<AggregateException>(() => hostBuilder.Build());
+        }
+
         internal class ServiceA { }
+
+        internal class ServiceB
+        {
+            public ServiceB(ServiceC c)
+            {
+
+            }
+        }
+
+        internal class ServiceC { }
 
         private class TestEventListener : EventListener
         {


### PR DESCRIPTION
- This will allow developers to catch broken service graphs ahead of time.

Related to https://github.com/aspnet/AspNetCore/issues/7745