### PR TITLE
Fixes aspnet/Extensions#1503

### DIFF
--- a/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackOuterService.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/Fakes/FakeDisposableCallbackOuterService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
@@ -13,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
             FakeDisposeCallback callback) : base(callback)
         {
             SingleService = singleService;
-            MultipleServices = multipleServices;
+            MultipleServices = multipleServices.ToArray();
         }
 
         public IFakeService SingleService { get; }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Fixes an issue where dependencies are never instantiated due to lazy resolution of enumerable dependencies by the Unity container

Addresses #bugnumber (in this specific format)
aspnet/Extensions#1503 