### PR TITLE
Fix #519

### DIFF
--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -48,6 +48,10 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHttpMessageHandlerBuilderFilter, LoggingHttpMessageHandlerBuilderFilter>());
 
+            // This is used to track state and report errors **DURING** service registration. This has to be an instance
+            // because we access it by reaching into the service collection.
+            services.TryAddSingleton(new HttpClientMappingRegistry());
+
             return services;
         }
 

--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientMappingRegistry.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientMappingRegistry.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    // Internal tracking for HTTP Client configuration. This is used to prevent some common mistakes
+    // that are easy to make with HTTP Client registration.
+    //
+    // See: https://github.com/aspnet/Extensions/issues/519
+    // See: https://github.com/aspnet/Extensions/issues/960
+    internal class HttpClientMappingRegistry
+    {
+        public Dictionary<Type, string> TypedClientRegistrations { get; } = new Dictionary<Type, string>();
+
+        public Dictionary<string, Type> NamedClientRegistrations { get; } = new Dictionary<string, Type>();
+    }
+}

--- a/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -347,6 +347,78 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        public void AddHttpClient_AddSameTypedClientTwice_ThrowsError()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient<TestTypedClient>();
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => serviceCollection.AddHttpClient<TestTypedClient>("Test"));
+
+            // Assert
+            Assert.Equal(
+                "The HttpClient factory already has a registered client with the type 'Microsoft.Extensions.Http.TestTypedClient'. " +
+                "Client types must be unique. " +
+                "Consider using inheritance to create multiple unique types with the same API surface.",
+                ex.Message);
+        }
+
+        [Fact]
+        public void AddHttpClient_AddSameTypedClientTwice_WithAddTypedClient_ThrowsError()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient<TestTypedClient>();
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => serviceCollection.AddHttpClient("Test").AddTypedClient<TestTypedClient>());
+
+            // Assert
+            Assert.Equal(
+                "The HttpClient factory already has a registered client with the type 'Microsoft.Extensions.Http.TestTypedClient'. " +
+                "Client types must be unique. " +
+                "Consider using inheritance to create multiple unique types with the same API surface.",
+                ex.Message);
+        }
+
+        [Fact]
+        public void AddHttpClient_AddSameNameWithTypedClientTwice_ThrowsError()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient<TestTypedClient>();
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => serviceCollection.AddHttpClient<AnotherNamespace.TestTypedClient>());
+
+            // Assert
+            Assert.Equal(
+                "The HttpClient factory already has a registered client with the name 'TestTypedClient', bound to the type 'Microsoft.Extensions.Http.TestTypedClient'. " +
+                "Client names are computed based on the type name without considering the namespace ('TestTypedClient'). " +
+                "Use an overload of AddHttpClient that accepts a string and provide a unique name to resolve the conflict.",
+                ex.Message);
+        }
+
+        [Fact]
+        public void AddHttpClient_AddSameNameWithTypedClientTwice_WithAddTypedClient_ThrowsError()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient<TestTypedClient>();
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => serviceCollection.AddHttpClient("TestTypedClient").AddTypedClient<AnotherNamespace.TestTypedClient>());
+
+            // Assert
+            Assert.Equal(
+                "The HttpClient factory already has a registered client with the name 'TestTypedClient', bound to the type 'Microsoft.Extensions.Http.TestTypedClient'. " +
+                "Client names are computed based on the type name without considering the namespace ('TestTypedClient'). " +
+                "Use an overload of AddHttpClient that accepts a string and provide a unique name to resolve the conflict.",
+                ex.Message);
+        }
+
+        [Fact]
         public void AddHttpClient_AddTypedClient_WithServiceDelegate_ConfiguresNamedClient()
         {
             // Arrange
@@ -1044,6 +1116,16 @@ namespace Microsoft.Extensions.DependencyInjection
             public HttpClient HttpClient { get; }
 
             public TransientService Service { get; }
+        }
+    }
+}
+
+namespace AnotherNamespace
+{
+    public class TestTypedClient
+    {
+        public TestTypedClient(HttpClient httpClient)
+        {
         }
     }
 }


### PR DESCRIPTION
Adds tracking for the relationship between named clients and the types
that they are bound to.

This allows us to throw a better in common cases that won't work:

- using clients with the same type name but different FQNs
- using the came client type twice with different names