### PR TITLE
Move from Microsoft.Bcl.Json.Sources to System.Text.Json

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -18,7 +18,6 @@ and are generated based on the last package release.
   </ItemDefinitionGroup>
 
   <ItemGroup Label=".NET Core dependencies">
-    <LatestPackageReference Include="Microsoft.Bcl.Json.Sources" Version="$(MicrosoftBclJsonSourcesPackageVersion)" />
     <LatestPackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <LatestPackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsPackageVersion)" />
     <LatestPackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientPackageVersion)" />
@@ -34,6 +33,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
     <LatestPackageReference Include="System.ServiceProcess.ServiceController" Version="$(SystemServiceProcessServiceControllerPackageVersion)" />
     <LatestPackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPackageVersion)" />
+    <LatestPackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
     <LatestPackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsPackageVersion)" />
     <LatestPackageReference Include="System.ValueTuple" Version="$(SystemValueTuplePackageVersion)" />
   </ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,10 +10,6 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview6.19222.12" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a78bd0c13887e26372aafdffb8f06be26563c4a8</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview6.19227.7" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>4f27d0f84c17850ef02ea7b330908fddcdf73c86</Sha>
@@ -59,6 +55,10 @@
       <Sha>4f27d0f84c17850ef02ea7b330908fddcdf73c86</Sha>
     </Dependency>
     <Dependency Name="System.Text.Encodings.Web" Version="4.6.0-preview6.19227.7" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>4f27d0f84c17850ef02ea7b330908fddcdf73c86</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="4.6.0-preview6.19227.7" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>4f27d0f84c17850ef02ea7b330908fddcdf73c86</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,6 @@
     <!-- Packages from dotnet/core-setup -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview6-27628-12</MicrosoftNETCoreAppPackageVersion>
     <!-- Packages from dotnet/corefx -->
-    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview6.19222.12</MicrosoftBclJsonSourcesPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>4.6.0-preview6.19227.7</MicrosoftWin32RegistryPackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview6.19227.7</SystemComponentModelAnnotationsPackageVersion>
     <SystemDataSqlClientPackageVersion>4.7.0-preview6.19227.7</SystemDataSqlClientPackageVersion>
@@ -33,6 +32,7 @@
     <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview6.19227.7</SystemSecurityCryptographyXmlPackageVersion>
     <SystemServiceProcessServiceControllerPackageVersion>4.6.0-preview6.19227.7</SystemServiceProcessServiceControllerPackageVersion>
     <SystemTextEncodingsWebPackageVersion>4.6.0-preview6.19227.7</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>4.6.0-preview6.19227.7</SystemTextJsonPackageVersion>
     <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19227.7</MicrosoftNETCorePlatformsPackageVersion>
     <!-- Packages from dotnet/arcade -->

--- a/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.csproj
+++ b/src/Configuration/Config.Json/ref/Microsoft.Extensions.Configuration.Json.csproj
@@ -7,8 +7,8 @@
     <Compile Include="Microsoft.Extensions.Configuration.Json.netstandard2.0.cs" />
     <Reference Include="Microsoft.Extensions.Configuration"  />
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions"  />
+    <Reference Include="System.Text.Json"  />
     <Reference Include="System.Threading.Tasks.Extensions"  />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe"  />
   </ItemGroup>
 <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Microsoft.Extensions.Configuration.Json.netcoreapp3.0.cs" />

--- a/src/Configuration/Config.Json/src/Microsoft.Extensions.Configuration.Json.csproj
+++ b/src/Configuration/Config.Json/src/Microsoft.Extensions.Configuration.Json.csproj
@@ -17,11 +17,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <Reference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <Reference Include="Microsoft.Bcl.Json.Sources" Condition="'$(TargetFramework)' == 'netstandard2.0'">
-      <PrivateAssets>All</PrivateAssets>
-    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Reference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Reference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Json/src/Microsoft.Extensions.Configuration.Json.csproj
+++ b/src/Configuration/Config.Json/src/Microsoft.Extensions.Configuration.Json.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <Reference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <Reference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>

--- a/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/Logging/Logging.EventSource/ref/Microsoft.Extensions.Logging.EventSource.csproj
@@ -6,6 +6,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="Microsoft.Extensions.Logging.EventSource.netstandard2.0.cs" />
     <Reference Include="Microsoft.Extensions.Logging"  />
+    <Reference Include="System.Text.Json"  />
     <Reference Include="System.Threading.Tasks.Extensions"  />
   </ItemGroup>
 </Project>

--- a/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
@@ -220,7 +220,12 @@ namespace Microsoft.Extensions.Logging.EventSource
 
             writer.Flush();
 
-            return Encoding.UTF8.GetString(stream.ToArray());
+            if (!stream.TryGetBuffer(out var buffer))
+            {
+                buffer = new ArraySegment<byte>(stream.ToArray());
+            }
+
+            return Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
         }
     }
 }

--- a/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
+++ b/src/Logging/Logging.EventSource/src/EventSourceLogger.cs
@@ -208,8 +208,8 @@ namespace Microsoft.Extensions.Logging.EventSource
 
         private string ToJson(IReadOnlyList<KeyValuePair<string, string>> keyValues)
         {
-            var arrayBufferWriter = new ArrayBufferWriter<byte>();
-            var writer = new Utf8JsonWriter(arrayBufferWriter);
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream);
 
             writer.WriteStartObject();
             foreach (var keyValue in keyValues)
@@ -220,7 +220,7 @@ namespace Microsoft.Extensions.Logging.EventSource
 
             writer.Flush();
 
-            return Encoding.UTF8.GetString(arrayBufferWriter.WrittenMemory.ToArray());
+            return Encoding.UTF8.GetString(stream.ToArray());
         }
     }
 }

--- a/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
+++ b/src/Logging/Logging.EventSource/src/Microsoft.Extensions.Logging.EventSource.csproj
@@ -12,10 +12,8 @@
   <ItemGroup>
     <Compile Include="../../shared/*.cs" />
 
-    <Reference Include="Microsoft.Bcl.Json.Sources">
-      <PrivateAssets>All</PrivateAssets>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="System.Text.Json" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 


### PR DESCRIPTION
- fix downgrade of CoreFx packages in AspNetCore-Tooling and EntityFrameworkCore

details:
- CoreFx no longer produces the Microsoft.Bcl.Json.Sources package
- System.Text.Json is now .NET Standard 2.0-compatible