### PR TITLE
Add the event log logger provider by default

### DIFF
--- a/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.csproj
+++ b/src/Hosting/Hosting/ref/Microsoft.Extensions.Hosting.csproj
@@ -16,6 +16,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Console"  />
     <Reference Include="Microsoft.Extensions.Logging.Debug"  />
     <Reference Include="Microsoft.Extensions.Logging.EventSource"  />
+    <Reference Include="Microsoft.Extensions.Logging.EventLog"  />
   </ItemGroup>
 <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Microsoft.Extensions.Hosting.netcoreapp3.0.cs" />
@@ -30,5 +31,6 @@
     <Reference Include="Microsoft.Extensions.Logging.Console"  />
     <Reference Include="Microsoft.Extensions.Logging.Debug"  />
     <Reference Include="Microsoft.Extensions.Logging.EventSource"  />
+    <Reference Include="Microsoft.Extensions.Logging.EventLog"  />
   </ItemGroup>
 </Project>

--- a/src/Hosting/Hosting/src/Microsoft.Extensions.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.Extensions.Hosting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>.NET Core hosting and startup infrastructures for applications.</Description>
@@ -22,6 +22,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Microsoft.Extensions.Logging.Debug" />
     <Reference Include="Microsoft.Extensions.Logging.EventSource" />
+    <Reference Include="Microsoft.Extensions.Logging.EventLog" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/aspnet/Extensions/issues/1628

- This change turns on the event log logger provider by default if we're running on windows and sets a default filters for warning or above. We add the first so that it can be overridden by configuration.

This works when put in appsettings.json:

```JSON
{
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft": "Warning",
      "Microsoft.Hosting.Lifetime": "Information"
    },
    "EventLog": {
      "LogLevel": {
        "Default": "Information"
      }
    }
  },
  "AllowedHosts": "*"
}
```

cc @natemcmaster This needs to be added to the ASP.NET Core shared framework. Do I need to wait until that change flows in to do that?
