### PR TITLE
Shuffled guts of the EventLogLogger

### DIFF
--- a/src/Logging/Logging.EventLog/src/EventLogLoggerProvider.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogLoggerProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
         public EventLogLoggerProvider(EventLogSettings settings)
         {
-            _settings = settings;
+            _settings = settings ?? new EventLogSettings();
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// <inheritdoc />
         public ILogger CreateLogger(string name)
         {
-            return new EventLogLogger(name, _settings ?? new EventLogSettings(), _scopeProvider);
+            return new EventLogLogger(name, _settings, _scopeProvider);
         }
 
         public void Dispose()

--- a/src/Logging/Logging.EventLog/src/EventLogSettings.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogSettings.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Extensions.Logging.EventLog
     /// </summary>
     public class EventLogSettings
     {
+        private IEventLog _eventLog;
+
         /// <summary>
         /// Name of the event log. If <c>null</c> or not specified, "Application" is the default.
         /// </summary>
@@ -30,9 +32,28 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// </summary>
         public Func<string, LogLevel, bool> Filter { get; set; }
 
-        /// <summary>
-        /// For unit testing purposes only.
-        /// </summary>
-        internal IEventLog EventLog { get; set; }
+        internal IEventLog EventLog
+        {
+            get => _eventLog ??= CreateDefaultEventLog();
+
+            // For unit testing purposes only.
+            set => _eventLog = value;
+        }
+
+        private IEventLog CreateDefaultEventLog()
+        {
+            var logName = string.IsNullOrEmpty(LogName) ? "Application" : LogName;
+            var machineName = string.IsNullOrEmpty(MachineName) ? "." : MachineName;
+            var sourceName = string.IsNullOrEmpty(SourceName) ? ".NET Runtime" : SourceName;
+            int? defaultEventId = null;
+
+            if (string.IsNullOrEmpty(SourceName))
+            {
+                sourceName = ".NET Runtime";
+                defaultEventId = 1000;
+            }
+
+            return new WindowsEventLog(logName, machineName, sourceName) { DefaultEventId = defaultEventId };
+        }
     }
 }

--- a/src/Logging/Logging.EventLog/src/IEventLog.cs
+++ b/src/Logging/Logging.EventLog/src/IEventLog.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Extensions.Logging.EventLog
 {
     internal interface IEventLog
     {
+        int? DefaultEventId { get; }
+
         int MaxMessageSize { get; }
 
         void WriteEntry(string message, EventLogEntryType type, int eventID, short category);

--- a/src/Logging/Logging.EventLog/src/WindowsEventLog.cs
+++ b/src/Logging/Logging.EventLog/src/WindowsEventLog.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Extensions.Logging.EventLog
 
         public int MaxMessageSize => MaximumMessageSize;
 
+        public int? DefaultEventId { get; set; }
+
         public void WriteEntry(string message, EventLogEntryType type, int eventID, short category)
         {
             try

--- a/src/Logging/test/EventLogLoggerTest.cs
+++ b/src/Logging/test/EventLogLoggerTest.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Extensions.Logging
             var logger = new EventLogLogger("Test", new EventLogSettings()
             {
                 Filter = (s, level) => level >= LogLevel.Warning
-            });
+            },
+            new LoggerExternalScopeProvider());
 
             // Assert
             Assert.False(logger.IsEnabled(LogLevel.None));
@@ -39,7 +40,7 @@ namespace Microsoft.Extensions.Logging
         public void CallingBeginScopeOnLogger_ReturnsNonNullableInstance()
         {
             // Arrange
-            var logger = new EventLogLogger("Test", new EventLogSettings());
+            var logger = new EventLogLogger("Test", new EventLogSettings(), new LoggerExternalScopeProvider());
 
             // Act
             var disposable = logger.BeginScope("Scope1");
@@ -70,12 +71,12 @@ namespace Microsoft.Extensions.Logging
         public void Constructor_CreatesWindowsEventLog_WithExpectedInformation()
         {
             // Arrange & Act
-            var eventLogLogger = new EventLogLogger("Test", new EventLogSettings());
+            var eventLogLogger = new EventLogLogger("Test", new EventLogSettings(), new LoggerExternalScopeProvider());
 
             // Assert
             var windowsEventLog = Assert.IsType<WindowsEventLog>(eventLogLogger.EventLog);
             Assert.Equal("Application", windowsEventLog.DiagnosticsEventLog.Log);
-            Assert.Equal("Application", windowsEventLog.DiagnosticsEventLog.Source);
+            Assert.Equal(".NET Runtime", windowsEventLog.DiagnosticsEventLog.Source);
             Assert.Equal(".", windowsEventLog.DiagnosticsEventLog.MachineName);
         }
 
@@ -92,7 +93,7 @@ namespace Microsoft.Extensions.Logging
             };
 
             // Act
-            var eventLogLogger = new EventLogLogger("Test", settings);
+            var eventLogLogger = new EventLogLogger("Test", settings, new LoggerExternalScopeProvider());
 
             // Assert
             var windowsEventLog = Assert.IsType<WindowsEventLog>(eventLogLogger.EventLog);
@@ -128,13 +129,16 @@ namespace Microsoft.Extensions.Logging
         [InlineData(36)]
         public void MessageWithinMaxSize_WritesFullMessage(int messageSize)
         {
+            var headerLength = "EventId: 0".Length + "Category: ".Length;
             // Arrange
             var loggerName = "Test";
-            var maxMessageSize = 50 + loggerName.Length + Environment.NewLine.Length;
+            var maxMessageSize = 50 + headerLength + loggerName.Length + Environment.NewLine.Length * 4;
             var message = new string('a', messageSize);
-            var expectedMessage = loggerName + Environment.NewLine + message;
+            var expectedMessage = "Category: " + loggerName + Environment.NewLine +
+                                  "EventId: 0" + Environment.NewLine + Environment.NewLine +
+                                  message + Environment.NewLine;
             var testEventLog = new TestEventLog(maxMessageSize);
-            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog });
+            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
 
             // Act
             logger.LogInformation(message);
@@ -150,13 +154,13 @@ namespace Microsoft.Extensions.Logging
         {
             // Arrange
             var loggerName = "Test";
-            var maxMessageSize = 50 + loggerName.Length + Environment.NewLine.Length;
-            var expectedMessage = loggerName + Environment.NewLine +
-                                  "Message" + Environment.NewLine +
+            var expectedMessage = "Category: " + loggerName + Environment.NewLine +
+                                  "EventId: 0" + Environment.NewLine +
                                   "Outer Scope" + Environment.NewLine +
-                                  "Inner Scope";
-            var testEventLog = new TestEventLog(maxMessageSize);
-            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog });
+                                  "Inner Scope" + Environment.NewLine + Environment.NewLine +
+                                  "Message" + Environment.NewLine;
+            var testEventLog = new TestEventLog(expectedMessage.Length);
+            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
 
             // Act
             using (logger.BeginScope("Outer Scope"))
@@ -170,47 +174,102 @@ namespace Microsoft.Extensions.Logging
             Assert.Equal(expectedMessage, testEventLog.Messages[0]);
         }
 
+        [ConditionalFact]
+        public void MessageWrittenToEventLogContainsEventId()
+        {
+            // Arrange
+            var loggerName = "Test";
+            var expectedMessage = "Category: " + loggerName + Environment.NewLine +
+                                  "EventId: 1" + Environment.NewLine + Environment.NewLine +
+                                  "Message" + Environment.NewLine;
+
+            var testEventLog = new TestEventLog(expectedMessage.Length);
+            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
+
+            // Act
+            logger.LogInformation(new EventId(1, "FooEvent"), "Message");
+
+            // Assert
+            Assert.Single(testEventLog.Messages);
+            Assert.Equal(expectedMessage, testEventLog.Messages[0]);
+            Assert.Equal(1, testEventLog.Entries[0].EventId);
+        }
+
+        [ConditionalFact]
+        public void EventIdWrittenToEventLogUsesDefaultIfSpecified()
+        {
+            // Arrange
+            var loggerName = "Test";
+            var expectedMessage = "Category: " + loggerName + Environment.NewLine +
+                                  "EventId: 1" + Environment.NewLine + Environment.NewLine +
+                                  "Message" + Environment.NewLine;
+
+            var testEventLog = new TestEventLog(expectedMessage.Length)
+            {
+                DefaultEventId = 1034
+            };
+            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
+
+            // Act
+            logger.LogInformation(new EventId(1, "FooEvent"), "Message");
+
+            // Assert
+            Assert.Single(testEventLog.Messages);
+            Assert.Equal(expectedMessage, testEventLog.Messages[0]);
+            Assert.Equal(1034, testEventLog.Entries[0].EventId);
+        }
+
+        [ConditionalFact]
+        public void NullCategoryNameThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EventLogLogger(null, new EventLogSettings() { }, new LoggerExternalScopeProvider()));
+        }
+
+        [ConditionalFact]
+        public void NullEventSettingsThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EventLogLogger("Something", settings: null, new LoggerExternalScopeProvider()));
+        }
+
         public static TheoryData<int, string[]> WritesSplitMessagesData
         {
             get
             {
-                var loggerName = "Test";
-
                 return new TheoryData<int, string[]>
                 {
-                    // loggername + newline combined length is 7
                     {
-                        1,
-                        new[]
+                        10,
+                        new []
                         {
-                            loggerName + Environment.NewLine + "a"
+                            "Category: Test\r\nEventId: 0\r...",
+                            "...\n\r\naaaaaaaaaa\r\n",
                         }
                     },
                     {
-                        5,
-                        new[]
+                        20,
+                        new []
                         {
-                            loggerName + Environment.NewLine + "a...",
-                            "...aaaa"
+                            "Category: Test\r\nEventId: 0\r...",
+                            "...\n\r\naaaaaaaaaaaaaaaaaaaa\r\n",
                         }
                     },
                     {
-                        10, // equaling the max message size
-                        new[]
+                        30, // equaling the max message size
+                        new []
                         {
-                            loggerName + Environment.NewLine + "a...",
-                            "...aaaa...",
-                            "...aaaaa"
+                            "Category: Test\r\nEventId: 0\r...",
+                            "...\n\r\naaaaaaaaaaaaaaaaaaaaa...",
+                            "...aaaaaaaaa\r\n",
                         }
+
                     },
                     {
-                        15,
-                        new[]
+                        40,
+                        new []
                         {
-                            loggerName + Environment.NewLine + "a...",
-                            "...aaaa...",
-                            "...aaaa...",
-                            "...aaaaaa"
+                            "Category: Test\r\nEventId: 0\r...",
+                            "...\n\r\naaaaaaaaaaaaaaaaaaaaa...",
+                            "...aaaaaaaaaaaaaaaaaaa\r\n",
                         }
                     }
                 };
@@ -222,11 +281,12 @@ namespace Microsoft.Extensions.Logging
         public void MessageExceedingMaxSize_WritesSplitMessages(int messageSize, string[] expectedMessages)
         {
             // Arrange
+            var headerLength = "EventId: 0".Length + "Category: ".Length;
             var loggerName = "Test";
-            var maxMessageSize = 10;
+            var maxMessageSize = headerLength + loggerName.Length + Environment.NewLine.Length * 3;
             var message = new string('a', messageSize);
             var testEventLog = new TestEventLog(maxMessageSize);
-            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog });
+            var logger = new EventLogLogger(loggerName, new EventLogSettings() { EventLog = testEventLog }, new LoggerExternalScopeProvider());
 
             // Act
             logger.LogInformation(message);
@@ -242,15 +302,21 @@ namespace Microsoft.Extensions.Logging
             {
                 MaxMessageSize = maxMessageSize;
                 Messages = new List<string>();
+                Entries = new List<(string Message, EventLogEntryType Type, int EventId, short Category)>();
             }
 
             public int MaxMessageSize { get; }
 
             public List<string> Messages { get; }
 
+            public List<(string Message, EventLogEntryType Type, int EventId, short Category)> Entries { get; }
+
+            public int? DefaultEventId { get; set; }
+
             public void WriteEntry(string message, EventLogEntryType type, int eventID, short category)
             {
                 Messages.Add(message);
+                Entries.Add((message, type, eventID, category));
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/aspnet/Extensions/issues/1406

- Don't create a settings object or IEventLog per EventLogger
- Use a string builder internally instead of concating strings
- Clean up the formatting a bit
  - Added headings for various bits of info.
  - Added the event id to the message itself.
- Use .NET Runtime with a specific eventId as the default to avoid the warning about logging an unknown event id.
- Added more tests

PS: Somebackground on that Event Viewer issue we run into:

- https://www.jitbit.com/alexblog/266-writing-to-an-event-log-from-net-without-the-description-for-event-id-nonsense/
- https://stackoverflow.com/questions/3412463/description-for-event-id-from-source-cannot-be-found
- https://www.codeproject.com/Articles/4153/Getting-the-most-out-of-Event-Viewer


![image](https://user-images.githubusercontent.com/95136/56950604-b995bb00-6aea-11e9-8978-6b34948a592a.png)

![image](https://user-images.githubusercontent.com/95136/56950643-cfa37b80-6aea-11e9-80bd-6787b27e629a.png)

![image](https://user-images.githubusercontent.com/95136/56951020-9c152100-6aeb-11e9-9168-5042c1b8d61a.png)

