### PR TITLE
Log HTTP status codes as integers

### DIFF
--- a/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Http.Logging
                 EventIds.RequestStart,
                 "Sending HTTP request {HttpMethod} {Uri}");
 
-            private static readonly Action<ILogger, double, HttpStatusCode, Exception> _requestEnd = LoggerMessage.Define<double, HttpStatusCode>(
+            private static readonly Action<ILogger, double, int, Exception> _requestEnd = LoggerMessage.Define<double, int>(
                 LogLevel.Information,
                 EventIds.RequestEnd,
                 "Received HTTP response after {ElapsedMilliseconds}ms - {StatusCode}");
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Http.Logging
 
             public static void RequestEnd(ILogger logger, HttpResponseMessage response, TimeSpan duration)
             {
-                _requestEnd(logger, duration.TotalMilliseconds, response.StatusCode, null);
+                _requestEnd(logger, duration.TotalMilliseconds, (int)response.StatusCode, null);
 
                 if (logger.IsEnabled(LogLevel.Trace))
                 {

--- a/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Http.Logging
                 EventIds.PipelineStart, 
                 "Start processing HTTP request {HttpMethod} {Uri}");
 
-            private static readonly Action<ILogger, double, HttpStatusCode, Exception> _requestPipelineEnd = LoggerMessage.Define<double, HttpStatusCode>(
+            private static readonly Action<ILogger, double, int, Exception> _requestPipelineEnd = LoggerMessage.Define<double, int>(
                 LogLevel.Information,
                 EventIds.PipelineEnd,
                 "End processing HTTP request after {ElapsedMilliseconds}ms - {StatusCode}");
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Http.Logging
 
             public static void RequestPipelineEnd(ILogger logger, HttpResponseMessage response, TimeSpan duration)
             {
-                _requestPipelineEnd(logger, duration.TotalMilliseconds, response.StatusCode, null);
+                _requestPipelineEnd(logger, duration.TotalMilliseconds, (int)response.StatusCode, null);
 
                 if (logger.IsEnabled(LogLevel.Trace))
                 {


### PR DESCRIPTION
Modifies the `LoggingHttpMessageHandler` and `LoggingScopeHttpMessageHandler` to log status codes explicitly as integers in order to be consistent with [HostingRequestFinishedLog](https://github.com/aspnet/AspNetCore/blob/master/src/Hosting/Hosting/src/Internal/HostingRequestFinishedLog.cs).  

This is necessary for logging stores that require consistent types for properties with the same name (e.g. Elasticsearch).  More details on the problem with the current logs are in the linked issue.

Addresses #1549 
