### PR TITLE
StyleCop Returns?

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,6 +58,10 @@
     <Reference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+  </ItemGroup>
+
   <Import Project="eng\Dependencies.props" />
   <Import Project="eng\PatchConfig.props" />
   <Import Project="eng\ProjectReferences.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,6 +62,10 @@
     <Reference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)eng\StyleCop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
   <Import Project="eng\Dependencies.props" />
   <Import Project="eng\PatchConfig.props" />
   <Import Project="eng\ProjectReferences.props" />

--- a/Extensions.sln
+++ b/Extensions.sln
@@ -305,6 +305,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Config
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Configuration.NewtonsoftJson.Tests", "src\Configuration\Config.NewtonsoftJson\test\Microsoft.Extensions.Configuration.NewtonsoftJson.Tests.csproj", "{2FEE9416-E709-4EA7-82A3-4A34816F75FD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{E9C6F0EE-B104-4E82-8B21-4690F9083B08}"
+	ProjectSection(SolutionItems) = preProject
+		eng\StyleCop.ruleset = eng\StyleCop.ruleset
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -52,6 +52,7 @@ and are generated based on the last package release.
   </PropertyGroup>
 
   <ItemGroup Label="External dependencies">
+    <LatestPackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" />
     <LatestPackageReference Include="BenchmarkDotNet" Version="0.10.13" />
     <LatestPackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
     <LatestPackageReference Include="Microsoft.Azure.KeyVault" Version="2.3.2" />

--- a/eng/StyleCop.ruleset
+++ b/eng/StyleCop.ruleset
@@ -1,0 +1,217 @@
+﻿<?xml version="1.0"?>
+<RuleSet Name="StyleCop.Analyzers rules with default action" Description="StyleCop.Analyzers with default action. Rules with IsEnabledByDefault = false are disabled." ToolsVersion="14.0">
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.SpecialRules">
+        <Rule Id="SA0001"  Action="None" />          <!-- XML comment analysis disabled -->
+        <Rule Id="SA0002"  Action="None" />          <!-- Invalid settings file -->
+    </Rules>
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.SpacingRules">
+        <Rule Id="SA1000"  Action="Error" />          <!-- Keywords should be spaced correctly -->
+        <Rule Id="SA1001"  Action="None" />          <!-- Commas should be spaced correctly -->
+        <Rule Id="SA1002"  Action="None" />          <!-- Semicolons should be spaced correctly -->
+        <Rule Id="SA1003"  Action="None" />          <!-- Symbols should be spaced correctly -->
+        <Rule Id="SA1004"  Action="None" />          <!-- Documentation lines should begin with single space -->
+        <Rule Id="SA1005"  Action="None" />          <!-- Single line comments should begin with single space -->
+        <Rule Id="SA1006"  Action="None" />          <!-- Preprocessor keywords should not be preceded by space -->
+        <Rule Id="SA1007"  Action="None" />          <!-- Operator keyword should be followed by space -->
+        <Rule Id="SA1008"  Action="None" />          <!-- Opening parenthesis should be spaced correctly -->
+        <Rule Id="SA1009"  Action="None" />          <!-- Closing parenthesis should be spaced correctly -->
+        <Rule Id="SA1010"  Action="None" />          <!-- Opening square brackets should be spaced correctly -->
+        <Rule Id="SA1011"  Action="None" />          <!-- Closing square brackets should be spaced correctly -->
+        <Rule Id="SA1012"  Action="None" />          <!-- Opening braces should be spaced correctly -->
+        <Rule Id="SA1013"  Action="None" />          <!-- Closing braces should be spaced correctly -->
+        <Rule Id="SA1014"  Action="None" />          <!-- Opening generic brackets should be spaced correctly -->
+        <Rule Id="SA1015"  Action="None" />          <!-- Closing generic brackets should be spaced correctly -->
+        <Rule Id="SA1016"  Action="None" />          <!-- Opening attribute brackets should be spaced correctly -->
+        <Rule Id="SA1017"  Action="None" />          <!-- Closing attribute brackets should be spaced correctly -->
+        <Rule Id="SA1018"  Action="None" />          <!-- Nullable type symbols should be spaced correctly -->
+        <Rule Id="SA1019"  Action="None" />          <!-- Member access symbols should be spaced correctly -->
+        <Rule Id="SA1020"  Action="None" />          <!-- Increment decrement symbols should be spaced correctly -->
+        <Rule Id="SA1021"  Action="None" />          <!-- Negative signs should be spaced correctly -->
+        <Rule Id="SA1022"  Action="None" />          <!-- Positive signs should be spaced correctly -->
+        <Rule Id="SA1023"  Action="None" />          <!-- Dereference and access of symbols should be spaced correctly -->
+        <Rule Id="SA1024"  Action="None" />          <!-- Colons should be spaced correctly -->
+        <Rule Id="SA1025"  Action="None" />          <!-- Code should not contain multiple whitespace in a row -->
+        <Rule Id="SA1026"  Action="None" />          <!-- Code should not contain space after new or stackalloc keyword in implicitly typed array allocation -->
+        <Rule Id="SA1027"  Action="None" />          <!-- Use tabs correctly -->
+        <Rule Id="SA1028"  Action="None" />          <!-- Code should not contain trailing whitespace -->
+    </Rules>
+
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.ReadabilityRules">
+        <Rule Id="SA1100"  Action="None" />          <!-- Do not prefix calls with base unless local implementation exists -->
+        <Rule Id="SA1101"  Action="None" />          <!-- Prefix local calls with this -->
+        <Rule Id="SA1102"  Action="None" />          <!-- Query clause should follow previous clause -->
+        <Rule Id="SA1103"  Action="None" />          <!-- Query clauses should be on separate lines or all on one line -->
+        <Rule Id="SA1104"  Action="None" />          <!-- Query clause should begin on new line when previous clause spans multiple lines -->
+        <Rule Id="SA1105"  Action="None" />          <!-- Query clauses spanning multiple lines should begin on own line -->
+        <Rule Id="SA1106"  Action="None" />          <!-- Code should not contain empty statements -->
+        <Rule Id="SA1107"  Action="None" />          <!-- Code should not contain multiple statements on one line -->
+        <Rule Id="SA1108"  Action="None" />          <!-- Block statements should not contain embedded comments -->
+        <Rule Id="SA1109"  Action="None" />             <!-- Block statements should not contain embedded regions -->
+        <Rule Id="SA1110"  Action="None" />          <!-- Opening parenthesis or bracket should be on declaration line -->
+        <Rule Id="SA1111"  Action="None" />          <!-- Closing parenthesis should be on line of last parameter -->
+        <Rule Id="SA1112"  Action="None" />          <!-- Closing parenthesis should be on line of opening parenthesis -->
+        <Rule Id="SA1113"  Action="None" />          <!-- Comma should be on the same line as previous parameter -->
+        <Rule Id="SA1114"  Action="None" />          <!-- Parameter list should follow declaration -->
+        <Rule Id="SA1115"  Action="None" />          <!-- Parameter should follow comma -->
+        <Rule Id="SA1116"  Action="None" />          <!-- Split parameters should start on line after declaration -->
+        <Rule Id="SA1117"  Action="None" />          <!-- Parameters should be on same line or separate lines -->
+        <Rule Id="SA1118"  Action="None" />          <!-- Parameter should not span multiple lines -->
+        <Rule Id="SA1120"  Action="None" />          <!-- Comments should contain text -->
+        <Rule Id="SA1121"  Action="None" />          <!-- Use built-in type alias -->
+        <Rule Id="SA1122"  Action="None" />          <!-- Use string.Empty for empty strings -->
+        <Rule Id="SA1123"  Action="None" />          <!-- Do not place regions within elements -->
+        <Rule Id="SA1124"  Action="None" />          <!-- Do not use regions -->
+        <Rule Id="SA1125"  Action="None" />          <!-- Use shorthand for nullable types -->
+        <Rule Id="SA1126"  Action="None" />             <!-- Prefix calls correctly -->
+        <Rule Id="SA1127"  Action="None" />          <!-- Generic type constraints should be on their own line -->
+        <Rule Id="SA1128"  Action="None" />          <!-- Put constructor initializers on their own line -->
+        <Rule Id="SA1129"  Action="None" />          <!-- Do not use default value type constructor -->
+        <Rule Id="SA1130"  Action="None" />          <!-- Use lambda syntax -->
+        <Rule Id="SA1131"  Action="None" />          <!-- Use readable conditions -->
+        <Rule Id="SA1132"  Action="None" />          <!-- Do not combine fields -->
+        <Rule Id="SA1133"  Action="None" />          <!-- Do not combine attributes -->
+        <Rule Id="SA1134"  Action="None" />          <!-- Attributes should not share line -->
+        <Rule Id="SA1135"  Action="None" />          <!-- Using directives should be qualified -->
+        <Rule Id="SA1136"  Action="None" />          <!-- Enum values should be on separate lines -->
+        <Rule Id="SA1137"  Action="None" />          <!-- Elements should have the same indentation -->
+        <Rule Id="SA1139"  Action="None" />          <!-- Use literal suffix notation instead of casting -->
+        <Rule Id="SX1101"  Action="None" />             <!-- Do not prefix local calls with 'this.' -->
+    </Rules>
+
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.OrderingRules">
+        <Rule Id="SA1200"  Action="None" />          <!-- Using directives should be placed correctly -->
+        <Rule Id="SA1201"  Action="None" />          <!-- Elements should appear in the correct order -->
+        <Rule Id="SA1202"  Action="None" />          <!-- Elements should be ordered by access -->
+        <Rule Id="SA1203"  Action="None" />          <!-- Constants should appear before fields -->
+        <Rule Id="SA1204"  Action="None" />          <!-- Static elements should appear before instance elements -->
+        <Rule Id="SA1205"  Action="None" />          <!-- Partial elements should declare access -->
+        <Rule Id="SA1206"  Action="None" />          <!-- Declaration keywords should follow order -->
+        <Rule Id="SA1207"  Action="None" />          <!-- Protected should come before internal -->
+        <Rule Id="SA1208"  Action="None" />          <!-- System using directives should be placed before other using directives -->
+        <Rule Id="SA1209"  Action="None" />          <!-- Using alias directives should be placed after other using directives -->
+        <Rule Id="SA1210"  Action="None" />          <!-- Using directives should be ordered alphabetically by namespace -->
+        <Rule Id="SA1211"  Action="None" />          <!-- Using alias directives should be ordered alphabetically by alias name -->
+        <Rule Id="SA1212"  Action="None" />          <!-- Property accessors should follow order -->
+        <Rule Id="SA1213"  Action="None" />          <!-- Event accessors should follow order -->
+        <Rule Id="SA1214"  Action="None" />          <!-- Readonly fields should appear before non-readonly fields -->
+        <Rule Id="SA1216"  Action="None" />          <!-- Using static directives should be placed at the correct location -->
+        <Rule Id="SA1217"  Action="None" />          <!-- Using static directives should be ordered alphabetically -->
+    </Rules>
+
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.NamingRules">
+        <Rule Id="SA1300"  Action="None" />          <!-- Element should begin with upper-case letter -->
+        <Rule Id="SA1301"  Action="None" />             <!-- Element should begin with lower-case letter -->
+        <Rule Id="SA1302"  Action="None" />          <!-- Interface names should begin with I -->
+        <Rule Id="SA1303"  Action="None" />          <!-- Const field names should begin with upper-case letter -->
+        <Rule Id="SA1304"  Action="None" />          <!-- Non-private readonly fields should begin with upper-case letter -->
+        <Rule Id="SA1305"  Action="None" />             <!-- Field names should not use Hungarian notation -->
+        <Rule Id="SA1306"  Action="None" />          <!-- Field names should begin with lower-case letter -->
+        <Rule Id="SA1307"  Action="None" />          <!-- Accessible fields should begin with upper-case letter -->
+        <Rule Id="SA1308"  Action="None" />          <!-- Variable names should not be prefixed -->
+        <Rule Id="SA1309"  Action="None" />          <!-- Field names should not begin with underscore -->
+        <Rule Id="SA1310"  Action="None" />          <!-- Field names should not contain underscore -->
+        <Rule Id="SA1311"  Action="None" />          <!-- Static readonly fields should begin with upper-case letter -->
+        <Rule Id="SA1312"  Action="None" />          <!-- Variable names should begin with lower-case letter -->
+        <Rule Id="SA1313"  Action="None" />          <!-- Parameter names should begin with lower-case letter -->
+        <Rule Id="SA1314"  Action="None" />          <!-- Type parameter names should begin with T -->
+        <Rule Id="SX1309"  Action="None" />             <!-- Field names should begin with underscore -->
+        <Rule Id="SX1309S" Action="None" />             <!-- Static field names should begin with underscore -->
+    </Rules>
+
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.MaintainabilityRules">
+        <Rule Id="SA1119"  Action="None" />          <!-- Statement should not use unnecessary parenthesis -->
+        <Rule Id="SA1400"  Action="None" />          <!-- Access modifier should be declared -->
+        <Rule Id="SA1401"  Action="None" />          <!-- Fields should be private -->
+        <Rule Id="SA1402"  Action="None" />          <!-- File may only contain a single type -->
+        <Rule Id="SA1403"  Action="None" />          <!-- File may only contain a single namespace -->
+        <Rule Id="SA1404"  Action="None" />          <!-- Code analysis suppression should have justification -->
+        <Rule Id="SA1405"  Action="None" />          <!-- Debug.Assert should provide message text -->
+        <Rule Id="SA1406"  Action="None" />          <!-- Debug.Fail should provide message text -->
+        <Rule Id="SA1407"  Action="None" />          <!-- Arithmetic expressions should declare precedence -->
+        <Rule Id="SA1408"  Action="None" />          <!-- Conditional expressions should declare precedence -->
+        <Rule Id="SA1409"  Action="None"    />          <!-- Remove unnecessary code -->
+        <Rule Id="SA1410"  Action="None" />          <!-- Remove delegate parenthesis when possible -->
+        <Rule Id="SA1411"  Action="None" />          <!-- Attribute constructor should not use unnecessary parenthesis -->
+        <Rule Id="SA1412"  Action="None"    />          <!-- Store files as UTF-8 with byte order mark -->
+        <Rule Id="SA1413"  Action="None" />          <!-- Use trailing comma in multi-line initializers -->
+    </Rules>
+
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.LayoutRules">
+        <Rule Id="SA1500"  Action="None" />          <!-- Braces for multi-line statements should not share line -->
+        <Rule Id="SA1501"  Action="None" />          <!-- Statement should not be on a single line -->
+        <Rule Id="SA1502"  Action="None" />          <!-- Element should not be on a single line -->
+        <Rule Id="SA1503"  Action="None" />          <!-- Braces should not be omitted -->
+        <Rule Id="SA1504"  Action="None" />          <!-- All accessors should be single-line or multi-line -->
+        <Rule Id="SA1505"  Action="None" />          <!-- Opening braces should not be followed by blank line -->
+        <Rule Id="SA1506"  Action="None" />          <!-- Element documentation headers should not be followed by blank line -->
+        <Rule Id="SA1507"  Action="None" />          <!-- Code should not contain multiple blank lines in a row -->
+        <Rule Id="SA1508"  Action="None" />          <!-- Closing braces should not be preceded by blank line -->
+        <Rule Id="SA1509"  Action="None" />          <!-- Opening braces should not be preceded by blank line -->
+        <Rule Id="SA1510"  Action="None" />          <!-- Chained statement blocks should not be preceded by blank line -->
+        <Rule Id="SA1511"  Action="None" />          <!-- While-do footer should not be preceded by blank line -->
+        <Rule Id="SA1512"  Action="None" />          <!-- Single-line comments should not be followed by blank line -->
+        <Rule Id="SA1513"  Action="None" />          <!-- Closing brace should be followed by blank line -->
+        <Rule Id="SA1514"  Action="None" />          <!-- Element documentation header should be preceded by blank line -->
+        <Rule Id="SA1515"  Action="None" />          <!-- Single-line comment should be preceded by blank line -->
+        <Rule Id="SA1516"  Action="None" />          <!-- Elements should be separated by blank line -->
+        <Rule Id="SA1517"  Action="None" />          <!-- Code should not contain blank lines at start of file -->
+        <Rule Id="SA1518"  Action="None" />          <!-- Use line endings correctly at end of file -->
+        <Rule Id="SA1519"  Action="None" />          <!-- Braces should not be omitted from multi-line child statement -->
+        <Rule Id="SA1520"  Action="None" />          <!-- Use braces consistently -->
+    </Rules>
+
+    <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.DocumentationRules">
+        <Rule Id="SA1600"  Action="None" />          <!-- Elements should be documented -->
+        <Rule Id="SA1601"  Action="None" />          <!-- Partial elements should be documented -->
+        <Rule Id="SA1602"  Action="None" />          <!-- Enumeration items should be documented -->
+        <Rule Id="SA1603"  Action="None" />             <!-- Documentation should contain valid XML -->
+        <Rule Id="SA1604"  Action="None" />          <!-- Element documentation should have summary -->
+        <Rule Id="SA1605"  Action="None" />          <!-- Partial element documentation should have summary -->
+        <Rule Id="SA1606"  Action="None" />          <!-- Element documentation should have summary text -->
+        <Rule Id="SA1607"  Action="None" />          <!-- Partial element documentation should have summary text -->
+        <Rule Id="SA1608"  Action="None" />          <!-- Element documentation should not have default summary -->
+        <Rule Id="SA1609"  Action="None" />             <!-- Property documentation should have value -->
+        <Rule Id="SA1610"  Action="None" />          <!-- Property documentation should have value text -->
+        <Rule Id="SA1611"  Action="None" />          <!-- Element parameters should be documented -->
+        <Rule Id="SA1612"  Action="None" />          <!-- Element parameter documentation should match element parameters -->
+        <Rule Id="SA1613"  Action="None" />          <!-- Element parameter documentation should declare parameter name -->
+        <Rule Id="SA1614"  Action="None" />          <!-- Element parameter documentation should have text -->
+        <Rule Id="SA1615"  Action="None" />          <!-- Element return value should be documented -->
+        <Rule Id="SA1616"  Action="None" />          <!-- Element return value documentation should have text -->
+        <Rule Id="SA1617"  Action="None" />          <!-- Void return value should not be documented -->
+        <Rule Id="SA1618"  Action="None" />          <!-- Generic type parameters should be documented -->
+        <Rule Id="SA1619"  Action="None" />          <!-- Generic type parameters should be documented partial class -->
+        <Rule Id="SA1620"  Action="None" />          <!-- Generic type parameter documentation should match type parameters -->
+        <Rule Id="SA1621"  Action="None" />          <!-- Generic type parameter documentation should declare parameter name -->
+        <Rule Id="SA1622"  Action="None" />          <!-- Generic type parameter documentation should have text -->
+        <Rule Id="SA1623"  Action="None" />          <!-- Property summary documentation should match accessors -->
+        <Rule Id="SA1624"  Action="None" />          <!-- Property summary documentation should omit accessor with restricted access -->
+        <Rule Id="SA1625"  Action="None" />          <!-- Element documentation should not be copied and pasted -->
+        <Rule Id="SA1626"  Action="None" />          <!-- Single-line comments should not use documentation style slashes -->
+        <Rule Id="SA1627"  Action="None" />          <!-- Documentation text should not be empty -->
+        <Rule Id="SA1628"  Action="None" />             <!-- Documentation text should begin with a capital letter -->
+        <Rule Id="SA1629"  Action="None" />          <!-- Documentation text should end with a period -->
+        <Rule Id="SA1630"  Action="None" />             <!-- Documentation text should contain whitespace -->
+        <Rule Id="SA1631"  Action="None" />             <!-- Documentation should meet character percentage -->
+        <Rule Id="SA1632"  Action="None" />             <!-- Documentation text should meet minimum character length -->
+        <Rule Id="SA1633"  Action="None" />          <!-- File should have header -->
+        <Rule Id="SA1634"  Action="None" />          <!-- File header should show copyright -->
+        <Rule Id="SA1635"  Action="None" />          <!-- File header should have copyright text -->
+        <Rule Id="SA1636"  Action="None" />          <!-- File header copyright text should match -->
+        <Rule Id="SA1637"  Action="None" />          <!-- File header should contain file name -->
+        <Rule Id="SA1638"  Action="None" />          <!-- File header file name documentation should match file name -->
+        <Rule Id="SA1639"  Action="None" />          <!-- File header should have summary -->
+        <Rule Id="SA1640"  Action="None" />          <!-- File header should have valid company text -->
+        <Rule Id="SA1641"  Action="None" />          <!-- File header company name text should match -->
+        <Rule Id="SA1642"  Action="None" />          <!-- Constructor summary documentation should begin with standard text -->
+        <Rule Id="SA1643"  Action="None" />          <!-- Destructor summary documentation should begin with standard text -->
+        <Rule Id="SA1644"  Action="None" />             <!-- Documentation headers should not contain blank lines -->
+        <Rule Id="SA1645"  Action="None" />             <!-- Included documentation file does not exist -->
+        <Rule Id="SA1646"  Action="None" />             <!-- Included documentation XPath does not exist -->
+        <Rule Id="SA1647"  Action="None" />             <!-- Include node does not contain valid file and path -->
+        <Rule Id="SA1648"  Action="None" />          <!-- Inheritdoc should be used with inheriting class -->
+        <Rule Id="SA1649"  Action="None" />          <!-- File name should match first type name -->
+        <Rule Id="SA1650"  Action="None" />             <!-- Element documentation should be spelled correctly -->
+        <Rule Id="SA1651"  Action="None" />          <!-- Do not use placeholder elements -->
+    </Rules>
+</RuleSet>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,6 +37,8 @@
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19252.4</MicrosoftNETCorePlatformsPackageVersion>
     <!-- Packages from dotnet/arcade -->
     <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19251.6</MicrosoftDotNetGenAPIPackageVersion>
+    <!-- Analyzers -->
+    <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
   </PropertyGroup>
   <!--
 

--- a/src/Caching/Memory/src/CacheEntry.cs
+++ b/src/Caching/Memory/src/CacheEntry.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private void DetachTokens()
         {
-            lock(_lock)
+            lock (_lock)
             {
                 var registrations = _expirationTokenRegistrations;
                 if (registrations != null)

--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
             ValidateOptions(options.SlidingExpiration, absoluteExpiration);
 
             using (var connection = new SqlConnection(ConnectionString))
-            using(var upsertCommand = new SqlCommand(SqlQueries.SetCacheItem, connection))
+            using (var upsertCommand = new SqlCommand(SqlQueries.SetCacheItem, connection))
             {
                 upsertCommand.Parameters
                     .AddCacheItemId(key)

--- a/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
+++ b/src/Configuration/Config.Binder/src/ConfigurationBinder.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Extensions.Configuration
         private static Type FindOpenGenericInterface(Type expected, Type actual)
         {
             var actualTypeInfo = actual.GetTypeInfo();
-            if(actualTypeInfo.IsGenericType && 
+            if (actualTypeInfo.IsGenericType && 
                 actual.GetGenericTypeDefinition() == expected)
             {
                 return actual;

--- a/src/Configuration/Config.KeyPerFile/test/KeyPerFileTests.cs
+++ b/src/Configuration/Config.KeyPerFile/test/KeyPerFileTests.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile.Test
 
         public Stream CreateReadStream()
         {
-            if(IsDirectory)
+            if (IsDirectory)
             {
                 throw new InvalidOperationException("Cannot create stream from directory");
             }

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinear.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinear.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
                 throw new InvalidOperationException("Can't test file before entering a directory.");
             }
 
-            if(!Frame.IsNotApplicable && IsLastSegment() && TestMatchingSegment(file.Name))
+            if (!Frame.IsNotApplicable && IsLastSegment() && TestMatchingSegment(file.Name))
             {
                 return PatternTestResult.Success(CalculateStem(file));
             }

--- a/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRagged.cs
+++ b/src/FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRagged.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
                 throw new InvalidOperationException("Can't test file before entering a directory.");
             }
 
-            if(!Frame.IsNotApplicable && IsEndingGroup() && TestMatchingGroup(file))
+            if (!Frame.IsNotApplicable && IsEndingGroup() && TestMatchingGroup(file))
             {
                 return PatternTestResult.Success(CalculateStem(file));
             }

--- a/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
+++ b/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Logging.Testing
 
         public virtual void Dispose()
         {
-            if(_testLog == null)
+            if (_testLog == null)
             {
                 // It seems like sometimes the MSBuild goop that adds the test framework can end up in a bad state and not actually add it
                 // Not sure yet why that happens but the exception isn't clear so I'm adding this error so we can detect it better.

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/CollectingEventListener.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Tracing/CollectingEventListener.cs
@@ -17,10 +17,10 @@ namespace Microsoft.AspNetCore.Testing.Tracing
 
         public void CollectFrom(string eventSourceName)
         {
-            lock(_lock)
+            lock (_lock)
             {
                 // Check if it's already been created
-                if(_existingSources.TryGetValue(eventSourceName, out var existingSource))
+                if (_existingSources.TryGetValue(eventSourceName, out var existingSource))
                 {
                     // It has, so just enable it now
                     CollectFrom(existingSource);

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -72,12 +72,12 @@ namespace Microsoft.AspNetCore.Testing.xunit
         /// <param name="additionalFilters">A list of additional filters that define where this test is flaky. Use values in <see cref="FlakyOn"/>.</param>
         public FlakyAttribute(string gitHubIssueUrl, string firstFilter, params string[] additionalFilters)
         {
-            if(string.IsNullOrEmpty(gitHubIssueUrl))
+            if (string.IsNullOrEmpty(gitHubIssueUrl))
             {
                 throw new ArgumentNullException(nameof(gitHubIssueUrl));
             }
 
-            if(string.IsNullOrEmpty(firstFilter))
+            if (string.IsNullOrEmpty(firstFilter))
             {
                 throw new ArgumentNullException(nameof(firstFilter));
             }


### PR DESCRIPTION
Ok, so we've had our encounters with StyleCop in the past, but I think there may be some value in it. StyleCop is [now a set of Roslyn Analyzers **and Code Fixes**](https://github.com/DotNetAnalyzers/StyleCopAnalyzers). This is a (possibly crazy) PR that adds it to our repo and enables a **single rule**. @davidfowl 's favorite rule in fact, [`SA1000: KeywordsMustBeSpacedCorrectly`](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md).

If we believe this is a terrible idea, I'll go away, but I don't think it's the best use of our time to have code reviewers nit picking things like spacing, `var` usage, license headers, etc. If we want to try it further, I can enable a few more core rules and see where that takes us. I can also bring it to aspnet/AspNetCore.

StyleCop has [a **lot** of rules](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation) but it is also [very configurable](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md). If we are cautious and introduce rules that mostly already align with what we intend as style conventions, I think this will add value. The goal is not to reshape our code around some specific style guidance but to use robots to check style adherance instead of spending code review time and iterations on it.

These errors show up in command-line builds:

![image](https://user-images.githubusercontent.com/7574/57119999-1aa7d380-6d23-11e9-9ebd-5b8b4f1ae7ca.png)

And in VS (where they can also be `Ctrl-.`ed away):

![image](https://user-images.githubusercontent.com/7574/57120002-24313b80-6d23-11e9-89e6-ac704fb150e9.png)

![image](https://user-images.githubusercontent.com/7574/57119887-60b06780-6d22-11e9-92c9-f32a0ec693e2.png)

Thoughts? @davidfowl @rynowak @Eilon