### PR TITLE
Remove the exception filter that is problematic for wasm AOT

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -171,10 +171,15 @@ namespace Microsoft.JSInterop
             {
                 return methodInfo.Invoke(targetInstance, suppliedArgs);
             }
-            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            catch (TargetInvocationException tie)
             {
-                ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
-                throw null; // unreachable
+                if (tie.InnerException != null)
+                {
+                    ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+                    throw null; // unreached
+                }
+
+                throw;
             }
         }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -171,7 +171,7 @@ namespace Microsoft.JSInterop
             {
                 return methodInfo.Invoke(targetInstance, suppliedArgs);
             }
-            catch (TargetInvocationException tie)
+            catch (TargetInvocationException tie) // Avoid using exception filters for AOT runtime support
             {
                 if (tie.InnerException != null)
                 {
@@ -243,8 +243,8 @@ namespace Microsoft.JSInterop
             var invokableMethods = GetRequiredLoadedAssembly(assemblyName)
                 .GetExportedTypes()
                 .SelectMany(type => type.GetMethods(
-                    BindingFlags.Public | 
-                    BindingFlags.DeclaredOnly | 
+                    BindingFlags.Public |
+                    BindingFlags.DeclaredOnly |
                     BindingFlags.Instance |
                     BindingFlags.Static))
                 .Where(method => method.IsDefined(typeof(JSInvokableAttribute), inherit: false));


### PR DESCRIPTION
LLVM does not currently have IR to represent filter expressions and mono relies on LLVM IR when AOTing.  Removing the exception filter allows InvokeSynchronously to function properly in AOT and mixed (AOT+interpreter) modes for WebAssembly