### PR TITLE
Update SDK to 3.0 Preview 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,19 +23,16 @@
   <Import Project="eng\Workarounds.AfterArcade.props" />
   <Import Project="eng\FlakyTests.AfterArcade.props" />
 
-  <PropertyGroup Condition="'$(CopyrightMicrosoft)' != ''">
-    <Copyright>$(CopyrightMicrosoft)</Copyright>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-  </PropertyGroup>
-
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
     <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
-    <PackageLicenseUrl Condition="'$(PackageLicenseExpression)' == ''">https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageProjectUrl>https://asp.net</PackageProjectUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <LangVersion>8.0</LangVersion>
+
+    <DefaultNetCoreTargetFramework>netcoreapp$(MajorVersion).$(MinorVersion)</DefaultNetCoreTargetFramework>
 
     <Product>Microsoft .NET Extensions</Product>
     <RepositoryUrl>https://github.com/aspnet/Extensions</RepositoryUrl>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,5 @@
 <Project>
   <!-- Properties which should be set after the project has been evaluated -->
-  <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
-  </PropertyGroup>
-
-  <!-- Properties which should be set after the project has been evaluated -->
   <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <Description Condition=" '$(Description)' == ''">$(PackageId)</Description>

--- a/eng/Workarounds.AfterArcade.targets
+++ b/eng/Workarounds.AfterArcade.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <!-- Workaround https://github.com/dotnet/cli/issues/10528-->
+    <!-- Workaround https://github.com/dotnet/cli/issues/10528 -->
     <BundledNETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
 
     <!-- Workaround for the evaluation order in which Arcade assigns test properties. -->
@@ -8,8 +8,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Workaround https://github.com/dotnet/sdk/issues/2976 -->
-    <PackageReference Update="Microsoft.NETCore.Platforms" PrivateAssets="All" />
+    <!--
+      Workaround the cyclical nature of building .NET Core itself.
+
+      The SDK implies a default version of .NET Core to use, but that is typically too stale for this repo.
+      This sets the version of the NETCore.App shared framework which should be used
+    -->
+    <KnownFrameworkReference Update="Microsoft.NETCore.App">
+      <!-- Always update the 'latest version', whether the repo is servicing or not. -->
+      <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppPackageVersion)</LatestRuntimeFrameworkVersion>
+      <!-- Only update the default runtime version for preview builds. -->
+      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppPackageVersion)</DefaultRuntimeFrameworkVersion>
+      <!-- Only update the targeting pack version for preview builds. -->
+      <TargetingPackVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' and '$(IsServicingBuild)' != 'true'">$(MicrosoftNETCoreAppPackageVersion)</TargetingPackVersion>
+    </KnownFrameworkReference>
   </ItemGroup>
 
   <!-- Workaround for implicit references added by Arcade based on project name. Non-test projects should not reference these projects. -->

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "3.0.100-preview4-011136"
+    "version": "3.0.100-preview5-011568"
   },
   "tools": {
-    "dotnet": "3.0.100-preview4-011136"
+    "dotnet": "3.0.100-preview5-011568"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19256.12",


### PR DESCRIPTION
* Added workarounds to make the SDK build with the latest targeting pack from NETCore.App.
* Remove workarounds that were required for older versions of the Arcade SDK