### PR TITLE
I like trailing commas in config

### DIFF
--- a/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs
+++ b/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs
@@ -24,8 +24,14 @@ namespace Microsoft.Extensions.Configuration.Json
         {
             _data.Clear();
 
+            var jsonReaderOptions = new JsonReaderOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            };
+
             using (var reader = new StreamReader(input))
-            using (JsonDocument doc = JsonDocument.Parse(reader.ReadToEnd(), new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip }))
+            using (JsonDocument doc = JsonDocument.Parse(reader.ReadToEnd(), jsonReaderOptions))
             {
                 if (doc.RootElement.Type != JsonValueType.Object)
                 {

--- a/src/Configuration/Config.Json/test/ArrayTest.cs
+++ b/src/Configuration/Config.Json/test/ArrayTest.cs
@@ -229,5 +229,30 @@ namespace Microsoft.Extensions.Configuration.Json.Test
             Assert.Equal("bob", indexConfigurationSections[4].Key);
             Assert.Equal("hello", indexConfigurationSections[5].Key);
         }
+
+        [Fact]
+        public void TrailingCommas()
+        {
+            var json = @"{
+                ""ip"": [
+                    [ 
+                        ""1.2.3.4"",
+                        ""5.6.7.8"",
+                    ],
+                    [ 
+                        ""9.10.11.12"",
+                        ""13.14.15.16"",
+                    ],
+                ]
+            }";
+
+            var jsonConfigSource = new JsonConfigurationProvider(new JsonConfigurationSource());
+            jsonConfigSource.Load(TestStreamHelpers.StringToStream(json));
+
+            Assert.Equal("1.2.3.4", jsonConfigSource.Get("ip:0:0"));
+            Assert.Equal("5.6.7.8", jsonConfigSource.Get("ip:0:1"));
+            Assert.Equal("9.10.11.12", jsonConfigSource.Get("ip:1:0"));
+            Assert.Equal("13.14.15.16", jsonConfigSource.Get("ip:1:1"));
+        }
     }
 }

--- a/src/Configuration/Config.Json/test/JsonConfigurationTest.cs
+++ b/src/Configuration/Config.Json/test/JsonConfigurationTest.cs
@@ -101,6 +101,26 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Fact]
+        public void SupportAndIgnoreTrailingCommas()
+        {
+            var json = @"
+{
+    ""firstname"": ""test"",
+    ""test.last.name"": ""last.name"",
+        ""residential.address"": {
+            ""street.name"": ""Something street"",
+            ""zipcode"": ""12345"",
+        },
+}";
+            var jsonConfigSrc = LoadProvider(json);
+
+            Assert.Equal("test", jsonConfigSrc.Get("firstname"));
+            Assert.Equal("last.name", jsonConfigSrc.Get("test.last.name"));
+            Assert.Equal("Something street", jsonConfigSrc.Get("residential.address:STREET.name"));
+            Assert.Equal("12345", jsonConfigSrc.Get("residential.address:zipcode"));
+        }
+
+        [Fact]
         public void ThrowExceptionWhenUnexpectedEndFoundBeforeFinishParsing()
         {
             var json = @"{


### PR DESCRIPTION
I searched the Extensions repo to see if there was any discussion about removing support for trailing commas in json config. I found this from @HaoK:

> @ajcvickers tests now are all passing, the trailing comma was a big issue in the new common provider tests you added, smallest change was to run it thru JSON.NET to clean it up. Thoughts?

https://github.com/aspnet/Extensions/pull/1028#issuecomment-461177591

My thoughts are that allowing trailing commas in config is the obviously better choice. And even if it's a close call, shouldn't we lean towards not breaking people? This broke the Kestrel "SampleApp" for instance.

Was there any other discussion about removing support for trailing commas in json config when switching from JSON.NET to System.Json.Text?

