### PR TITLE
Validate pipeline logger without telemetry

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -15,7 +15,7 @@
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
 # This flag is meant as a temporary opt-opt for the feature while validate it across
 # our consumers. It will be deleted in the future.
-[bool]$pipelinesLog = $false
+[bool]$pipelinesLog = if (Test-Path variable:pipelinesLog) { $pipelinesLog } else { $ci }
 
 # Turns on machine preparation/clean up code that changes the machine state (e.g. kills build processes).
 [bool]$prepareMachine = if (Test-Path variable:prepareMachine) { $prepareMachine } else { $false }

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19260.1",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19267.3",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19260.1"
   }
 }


### PR DESCRIPTION
FYI @natemcmaster 

This is testing a version of the pipeline logger which has telemetry removed.