### PR TITLE
 Allow flaky attribute on class and assembly

### DIFF
--- a/src/ObjectPool/test/DefaultObjectPoolTest.cs
+++ b/src/ObjectPool/test/DefaultObjectPoolTest.cs
@@ -3,12 +3,15 @@
 
 using System.Collections.Generic;
 using Xunit;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.Extensions.ObjectPool
 {
+    [Flaky("asdf", FlakyOn.All)]
     public class DefaultObjectPoolTest
     {
-        [Fact]
+        [ConditionalFact]
         public void DefaultObjectPoolWithDefaultPolicy_GetAnd_ReturnObject_SameInstance()
         {
             // Arrange
@@ -24,7 +27,7 @@ namespace Microsoft.Extensions.ObjectPool
             Assert.Same(obj1, obj2);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void DefaultObjectPool_GetAndReturnObject_SameInstance()
         {
             // Arrange
@@ -40,12 +43,12 @@ namespace Microsoft.Extensions.ObjectPool
             Assert.Same(list1, list2);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void DefaultObjectPool_CreatedByPolicy()
         {
             // Arrange
             var pool = new DefaultObjectPool<List<int>>(new ListPolicy());
-            
+
             // Act
             var list = pool.Get();
 
@@ -53,7 +56,7 @@ namespace Microsoft.Extensions.ObjectPool
             Assert.Equal(17, list.Capacity);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void DefaultObjectPool_Return_RejectedByPolicy()
         {
             // Arrange

--- a/src/ObjectPool/test/DefaultObjectPoolTest.cs
+++ b/src/ObjectPool/test/DefaultObjectPoolTest.cs
@@ -3,15 +3,12 @@
 
 using System.Collections.Generic;
 using Xunit;
-using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.Extensions.ObjectPool
 {
-    [Flaky("asdf", FlakyOn.All)]
     public class DefaultObjectPoolTest
     {
-        [ConditionalFact]
+        [Fact]
         public void DefaultObjectPoolWithDefaultPolicy_GetAnd_ReturnObject_SameInstance()
         {
             // Arrange
@@ -27,7 +24,7 @@ namespace Microsoft.Extensions.ObjectPool
             Assert.Same(obj1, obj2);
         }
 
-        [ConditionalFact]
+        [Fact]
         public void DefaultObjectPool_GetAndReturnObject_SameInstance()
         {
             // Arrange
@@ -43,7 +40,7 @@ namespace Microsoft.Extensions.ObjectPool
             Assert.Same(list1, list2);
         }
 
-        [ConditionalFact]
+        [Fact]
         public void DefaultObjectPool_CreatedByPolicy()
         {
             // Arrange
@@ -56,7 +53,7 @@ namespace Microsoft.Extensions.ObjectPool
             Assert.Equal(17, list.Capacity);
         }
 
-        [ConditionalFact]
+        [Fact]
         public void DefaultObjectPool_Return_RejectedByPolicy()
         {
             // Arrange

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FlakyAttribute.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
     /// </para>
     /// </example>
     [TraitDiscoverer("Microsoft.AspNetCore.Testing.xunit.FlakyTestDiscoverer", "Microsoft.AspNetCore.Testing")]
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
     public sealed class FlakyAttribute : Attribute, ITraitAttribute
     {
         /// <summary>


### PR DESCRIPTION
Addresses https://github.com/aspnet/Extensions/issues/1568

Tested to ensure adding a flaky attribute on class prevents all tests in that class from running.