### PR TITLE
Allow options validation with dependencies

### DIFF
--- a/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
+++ b/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
@@ -160,6 +160,16 @@ namespace Microsoft.Extensions.Options
         public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> PostConfigure<TDep1, TDep2, TDep3, TDep4, TDep5>(System.Action<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> configureOptions) where TDep1 : class where TDep2 : class where TDep3 : class where TDep4 : class where TDep5 : class { throw null; }
         public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate(System.Func<TOptions, bool> validation) { throw null; }
         public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate(System.Func<TOptions, bool> validation, string failureMessage) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep>(System.Func<TOptions, TDep, bool> validation) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep>(System.Func<TOptions, TDep, bool> validation, string failureMessage) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2>(System.Func<TOptions, TDep1, TDep2, bool> validation) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2>(System.Func<TOptions, TDep1, TDep2, bool> validation, string failureMessage) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3>(System.Func<TOptions, TDep1, TDep2, TDep3, bool> validation) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3>(System.Func<TOptions, TDep1, TDep2, TDep3, bool> validation, string failureMessage) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4>(System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> validation) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4>(System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> validation, string failureMessage) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4, TDep5>(System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> validation) { throw null; }
+        public virtual Microsoft.Extensions.Options.OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4, TDep5>(System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> validation, string failureMessage) { throw null; }
     }
     public partial class OptionsCache<TOptions> : Microsoft.Extensions.Options.IOptionsMonitorCache<TOptions> where TOptions : class
     {
@@ -284,6 +294,61 @@ namespace Microsoft.Extensions.Options
         public string FailureMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Func<TOptions, bool> Validation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
+    }
+    public partial class ValidateOptions<TOptions, TDep> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
+    {
+        public ValidateOptions(string name, TDep dependency, System.Func<TOptions, TDep, bool> validation, string failureMessage) { }
+        public TDep Dependency { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FailureMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Func<TOptions, TDep, bool> Validation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
+    }
+    public partial class ValidateOptions<TOptions, TDep1, TDep2> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
+    {
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, System.Func<TOptions, TDep1, TDep2, bool> validation, string failureMessage) { }
+        public TDep1 Dependency1 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep2 Dependency2 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FailureMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Func<TOptions, TDep1, TDep2, bool> Validation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
+    }
+    public partial class ValidateOptions<TOptions, TDep1, TDep2, TDep3> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
+    {
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, System.Func<TOptions, TDep1, TDep2, TDep3, bool> validation, string failureMessage) { }
+        public TDep1 Dependency1 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep2 Dependency2 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep3 Dependency3 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FailureMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Func<TOptions, TDep1, TDep2, TDep3, bool> Validation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
+    }
+    public partial class ValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
+    {
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> validation, string failureMessage) { }
+        public TDep1 Dependency1 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep2 Dependency2 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep3 Dependency3 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep4 Dependency4 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FailureMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> Validation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
+    }
+    public partial class ValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class
+    {
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, TDep5 dependency5, System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> validation, string failureMessage) { }
+        public TDep1 Dependency1 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep2 Dependency2 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep3 Dependency3 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep4 Dependency4 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TDep5 Dependency5 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FailureMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> Validation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Extensions.Options.ValidateOptionsResult Validate(string name, TOptions options) { throw null; }
     }
 }

--- a/src/Options/Options/src/OptionsBuilder.cs
+++ b/src/Options/Options/src/OptionsBuilder.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
     public class OptionsBuilder<TOptions> where TOptions : class
     {
+        private const string DefaultValidationFailureMessage = "A validation error has occured.";
+
         /// <summary>
         /// The default name of the <typeparamref name="TOptions"/> instance.
         /// </summary>
@@ -353,7 +355,7 @@ namespace Microsoft.Extensions.Options
         /// <param name="validation">The validation function.</param>
         /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
         public virtual OptionsBuilder<TOptions> Validate(Func<TOptions, bool> validation)
-            => Validate(validation: validation, failureMessage: "A validation error has occured.");
+            => Validate(validation: validation, failureMessage: DefaultValidationFailureMessage);
 
         /// <summary>
         /// Register a validation action for an options type.
@@ -369,6 +371,188 @@ namespace Microsoft.Extensions.Options
             }
 
             Services.AddSingleton<IValidateOptions<TOptions>>(new ValidateOptions<TOptions>(Name, validation, failureMessage));
+            return this;
+        }
+
+        /// <summary>
+        /// Register a validation action for an options type using a default failure message.
+        /// </summary>
+        /// <typeparam name="TDep">The dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep>(Func<TOptions, TDep, bool> validation)
+            => Validate(validation: validation, failureMessage: DefaultValidationFailureMessage);
+
+        /// <summary>
+        /// Register a validation action for an options type.
+        /// </summary>
+        /// <typeparam name="TDep">The dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="failureMessage">The failure message to use when validation fails.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep>(Func<TOptions, TDep, bool> validation, string failureMessage)
+        {
+            if (validation == null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
+                new ValidateOptions<TOptions, TDep>(Name, sp.GetRequiredService<TDep>(), validation, failureMessage));
+            return this;
+        }
+
+        /// <summary>
+        /// Register a validation action for an options type using a default failure message.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2>(Func<TOptions, TDep1, TDep2, bool> validation)
+            => Validate(validation: validation, failureMessage: DefaultValidationFailureMessage);
+
+        /// <summary>
+        /// Register a validation action for an options type.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="failureMessage">The failure message to use when validation fails.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2>(Func<TOptions, TDep1, TDep2, bool> validation, string failureMessage)
+        {
+            if (validation == null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
+                new ValidateOptions<TOptions, TDep1, TDep2>(Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    validation,
+                    failureMessage));
+            return this;
+        }
+
+        /// <summary>
+        /// Register a validation action for an options type using a default failure message.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep3">The third dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3>(Func<TOptions, TDep1, TDep2, TDep3, bool> validation)
+            => Validate(validation: validation, failureMessage: DefaultValidationFailureMessage);
+
+        /// <summary>
+        /// Register a validation action for an options type.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep3">The third dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="failureMessage">The failure message to use when validation fails.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3>(Func<TOptions, TDep1, TDep2, TDep3, bool> validation, string failureMessage)
+        {
+            if (validation == null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
+                new ValidateOptions<TOptions, TDep1, TDep2, TDep3>(Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    validation,
+                    failureMessage));
+            return this;
+        }
+
+        /// <summary>
+        /// Register a validation action for an options type using a default failure message.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep3">The third dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep4">The fourth dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4>(Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> validation)
+            => Validate(validation: validation, failureMessage: DefaultValidationFailureMessage);
+
+        /// <summary>
+        /// Register a validation action for an options type.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep3">The third dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep4">The fourth dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="failureMessage">The failure message to use when validation fails.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4>(Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> validation, string failureMessage)
+        {
+            if (validation == null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
+                new ValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4>(Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    sp.GetRequiredService<TDep4>(),
+                    validation,
+                    failureMessage));
+            return this;
+        }
+
+        /// <summary>
+        /// Register a validation action for an options type using a default failure message.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep3">The third dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep4">The fourth dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep5">The fifth dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4, TDep5>(Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> validation)
+            => Validate(validation: validation, failureMessage: DefaultValidationFailureMessage);
+
+        /// <summary>
+        /// Register a validation action for an options type.
+        /// </summary>
+        /// <typeparam name="TDep1">The first dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep2">The second dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep3">The third dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep4">The fourth dependency used by the validation function.</typeparam>
+        /// <typeparam name="TDep5">The fifth dependency used by the validation function.</typeparam>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="failureMessage">The failure message to use when validation fails.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
+        public virtual OptionsBuilder<TOptions> Validate<TDep1, TDep2, TDep3, TDep4, TDep5>(Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> validation, string failureMessage)
+        {
+            if (validation == null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            Services.AddTransient<IValidateOptions<TOptions>>(sp =>
+                new ValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5>(Name,
+                    sp.GetRequiredService<TDep1>(),
+                    sp.GetRequiredService<TDep2>(),
+                    sp.GetRequiredService<TDep3>(),
+                    sp.GetRequiredService<TDep4>(),
+                    sp.GetRequiredService<TDep5>(),
+                    validation,
+                    failureMessage));
             return this;
         }
     }

--- a/src/Options/Options/src/ValidateOptions.cs
+++ b/src/Options/Options/src/ValidateOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Implementation of <see cref="IValidateOptions{TOptions}"/>
     /// </summary>
-    /// <typeparam name="TOptions">The instance being validated.</typeparam>
+    /// <typeparam name="TOptions">The options type to validate.</typeparam>
     public class ValidateOptions<TOptions> : IValidateOptions<TOptions> where TOptions : class
     {
         /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.Options
         /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
         public ValidateOptionsResult Validate(string name, TOptions options)
         {
-            // Null name is used to configure all named options.
+            // null name is used to configure all named options
             if (Name == null || name == Name)
             {
                 if ((Validation?.Invoke(options)).Value)
@@ -57,7 +57,412 @@ namespace Microsoft.Extensions.Options
                 return ValidateOptionsResult.Fail(FailureMessage);
             }
 
-            // Ignored if not validating this instance.
+            // ignored if not validating this instance
+            return ValidateOptionsResult.Skip;
+        }
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IValidateOptions{TOptions}"/>
+    /// </summary>
+        /// <typeparam name="TOptions">The options type to validate.</typeparam>
+    /// <typeparam name="TDep">Dependency type.</typeparam>
+    public class ValidateOptions<TOptions, TDep> : IValidateOptions<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Options name.</param>
+        /// <param name="dependency">The dependency.</param>
+        /// <param name="validation">Validation function.</param>
+        /// <param name="failureMessage">Validation failure message.</param>
+        public ValidateOptions(string name, TDep dependency, Func<TOptions, TDep, bool> validation, string failureMessage)
+        {
+            Name = name;
+            Validation = validation;
+            FailureMessage = failureMessage;
+            Dependency = dependency;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The validation function.
+        /// </summary>
+        public Func<TOptions, TDep, bool> Validation { get; }
+
+        /// <summary>
+        /// The error to return when validation fails.
+        /// </summary>
+        public string FailureMessage { get; }
+
+        /// <summary>
+        /// The dependency.
+        /// </summary>
+        public TDep Dependency { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string name, TOptions options)
+        {
+            // null name is used to configure all named options
+            if (Name == null || name == Name)
+            {
+                if ((Validation?.Invoke(options, Dependency)).Value)
+                {
+                    return ValidateOptionsResult.Success;
+                }
+                return ValidateOptionsResult.Fail(FailureMessage);
+            }
+
+            // ignored if not validating this instance
+            return ValidateOptionsResult.Skip;
+        }
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IValidateOptions{TOptions}"/>
+    /// </summary>
+        /// <typeparam name="TOptions">The options type to validate.</typeparam>
+    /// <typeparam name="TDep1">First dependency type.</typeparam>
+    /// <typeparam name="TDep2">Second dependency type.</typeparam>
+    public class ValidateOptions<TOptions, TDep1, TDep2> : IValidateOptions<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Options name.</param>
+        /// <param name="dependency1">The first dependency.</param>
+        /// <param name="dependency2">The second dependency.</param>
+        /// <param name="validation">Validation function.</param>
+        /// <param name="failureMessage">Validation failure message.</param>
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, Func<TOptions, TDep1, TDep2, bool> validation, string failureMessage)
+        {
+            Name = name;
+            Validation = validation;
+            FailureMessage = failureMessage;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The validation function.
+        /// </summary>
+        public Func<TOptions, TDep1, TDep2, bool> Validation { get; }
+
+        /// <summary>
+        /// The error to return when validation fails.
+        /// </summary>
+        public string FailureMessage { get; }
+
+        /// <summary>
+        /// The first dependency.
+        /// </summary>
+        public TDep1 Dependency1 { get; }
+
+        /// <summary>
+        /// The second dependency.
+        /// </summary>
+        public TDep2 Dependency2 { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string name, TOptions options)
+        {
+            // null name is used to configure all named options
+            if (Name == null || name == Name)
+            {
+                if ((Validation?.Invoke(options, Dependency1, Dependency2)).Value)
+                {
+                    return ValidateOptionsResult.Success;
+                }
+                return ValidateOptionsResult.Fail(FailureMessage);
+            }
+
+            // ignored if not validating this instance
+            return ValidateOptionsResult.Skip;
+        }
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IValidateOptions{TOptions}"/>
+    /// </summary>
+        /// <typeparam name="TOptions">The options type to validate.</typeparam>
+    /// <typeparam name="TDep1">First dependency type.</typeparam>
+    /// <typeparam name="TDep2">Second dependency type.</typeparam>
+    /// <typeparam name="TDep3">Third dependency type.</typeparam>
+    public class ValidateOptions<TOptions, TDep1, TDep2, TDep3> : IValidateOptions<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Options name.</param>
+        /// <param name="dependency1">The first dependency.</param>
+        /// <param name="dependency2">The second dependency.</param>
+        /// <param name="dependency3">The third dependency.</param>
+        /// <param name="validation">Validation function.</param>
+        /// <param name="failureMessage">Validation failure message.</param>
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, Func<TOptions, TDep1, TDep2, TDep3, bool> validation, string failureMessage)
+        {
+            Name = name;
+            Validation = validation;
+            FailureMessage = failureMessage;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The validation function.
+        /// </summary>
+        public Func<TOptions, TDep1, TDep2, TDep3, bool> Validation { get; }
+
+        /// <summary>
+        /// The error to return when validation fails.
+        /// </summary>
+        public string FailureMessage { get; }
+
+        /// <summary>
+        /// The first dependency.
+        /// </summary>
+        public TDep1 Dependency1 { get; }
+
+        /// <summary>
+        /// The second dependency.
+        /// </summary>
+        public TDep2 Dependency2 { get; }
+
+        /// <summary>
+        /// The third dependency.
+        /// </summary>
+        public TDep3 Dependency3 { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string name, TOptions options)
+        {
+            // null name is used to configure all named options
+            if (Name == null || name == Name)
+            {
+                if ((Validation?.Invoke(options, Dependency1, Dependency2, Dependency3)).Value)
+                {
+                    return ValidateOptionsResult.Success;
+                }
+                return ValidateOptionsResult.Fail(FailureMessage);
+            }
+
+            // ignored if not validating this instance
+            return ValidateOptionsResult.Skip;
+        }
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IValidateOptions{TOptions}"/>
+    /// </summary>
+        /// <typeparam name="TOptions">The options type to validate.</typeparam>
+    /// <typeparam name="TDep1">First dependency type.</typeparam>
+    /// <typeparam name="TDep2">Second dependency type.</typeparam>
+    /// <typeparam name="TDep3">Third dependency type.</typeparam>
+    /// <typeparam name="TDep4">Fourth dependency type.</typeparam>
+    public class ValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4> : IValidateOptions<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Options name.</param>
+        /// <param name="dependency1">The first dependency.</param>
+        /// <param name="dependency2">The second dependency.</param>
+        /// <param name="dependency3">The third dependency.</param>
+        /// <param name="dependency4">The fourth dependency.</param>
+        /// <param name="validation">Validation function.</param>
+        /// <param name="failureMessage">Validation failure message.</param>
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> validation, string failureMessage)
+        {
+            Name = name;
+            Validation = validation;
+            FailureMessage = failureMessage;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+            Dependency4 = dependency4;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The validation function.
+        /// </summary>
+        public Func<TOptions, TDep1, TDep2, TDep3, TDep4, bool> Validation { get; }
+
+        /// <summary>
+        /// The error to return when validation fails.
+        /// </summary>
+        public string FailureMessage { get; }
+
+        /// <summary>
+        /// The first dependency.
+        /// </summary>
+        public TDep1 Dependency1 { get; }
+
+        /// <summary>
+        /// The second dependency.
+        /// </summary>
+        public TDep2 Dependency2 { get; }
+
+        /// <summary>
+        /// The third dependency.
+        /// </summary>
+        public TDep3 Dependency3 { get; }
+
+        /// <summary>
+        /// The fourth dependency.
+        /// </summary>
+        public TDep4 Dependency4 { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string name, TOptions options)
+        {
+            // null name is used to configure all named options
+            if (Name == null || name == Name)
+            {
+                if ((Validation?.Invoke(options, Dependency1, Dependency2, Dependency3, Dependency4)).Value)
+                {
+                    return ValidateOptionsResult.Success;
+                }
+                return ValidateOptionsResult.Fail(FailureMessage);
+            }
+
+            // ignored if not validating this instance
+            return ValidateOptionsResult.Skip;
+        }
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IValidateOptions{TOptions}"/>
+    /// </summary>
+        /// <typeparam name="TOptions">The options type to validate.</typeparam>
+    /// <typeparam name="TDep1">First dependency type.</typeparam>
+    /// <typeparam name="TDep2">Second dependency type.</typeparam>
+    /// <typeparam name="TDep3">Third dependency type.</typeparam>
+    /// <typeparam name="TDep4">Fourth dependency type.</typeparam>
+    /// <typeparam name="TDep5">Fifth dependency type.</typeparam>
+    public class ValidateOptions<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5> : IValidateOptions<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Options name.</param>
+        /// <param name="dependency1">The first dependency.</param>
+        /// <param name="dependency2">The second dependency.</param>
+        /// <param name="dependency3">The third dependency.</param>
+        /// <param name="dependency4">The fourth dependency.</param>
+        /// <param name="dependency5">The fifth dependency.</param>
+        /// <param name="validation">Validation function.</param>
+        /// <param name="failureMessage">Validation failure message.</param>
+        public ValidateOptions(string name, TDep1 dependency1, TDep2 dependency2, TDep3 dependency3, TDep4 dependency4, TDep5 dependency5, Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> validation, string failureMessage)
+        {
+            Name = name;
+            Validation = validation;
+            FailureMessage = failureMessage;
+            Dependency1 = dependency1;
+            Dependency2 = dependency2;
+            Dependency3 = dependency3;
+            Dependency4 = dependency4;
+            Dependency5 = dependency5;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The validation function.
+        /// </summary>
+        public Func<TOptions, TDep1, TDep2, TDep3, TDep4, TDep5, bool> Validation { get; }
+
+        /// <summary>
+        /// The error to return when validation fails.
+        /// </summary>
+        public string FailureMessage { get; }
+
+        /// <summary>
+        /// The first dependency.
+        /// </summary>
+        public TDep1 Dependency1 { get; }
+
+        /// <summary>
+        /// The second dependency.
+        /// </summary>
+        public TDep2 Dependency2 { get; }
+
+        /// <summary>
+        /// The third dependency.
+        /// </summary>
+        public TDep3 Dependency3 { get; }
+
+        /// <summary>
+        /// The fourth dependency.
+        /// </summary>
+        public TDep4 Dependency4 { get; }
+
+        /// <summary>
+        /// The fifth dependency.
+        /// </summary>
+        public TDep5 Dependency5 { get; }
+
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+        public ValidateOptionsResult Validate(string name, TOptions options)
+        {
+            // null name is used to configure all named options
+            if (Name == null || name == Name)
+            {
+                if ((Validation?.Invoke(options, Dependency1, Dependency2, Dependency3, Dependency4, Dependency5)).Value)
+                {
+                    return ValidateOptionsResult.Success;
+                }
+                return ValidateOptionsResult.Fail(FailureMessage);
+            }
+
+            // ignored if not validating this instance
             return ValidateOptionsResult.Skip;
         }
     }


### PR DESCRIPTION
This adds generic overloads to `OptionBuilder.Validate` that allow validation functions with up to five service dependencies. This is analog to what was done in aspnet/Options#236 where this was added for `Configure` and `PostConfigure`.

Options validation was added with aspnet/Options#266 but no generic overloads were included there. But in the end, having dependencies for validation (e.g. to check against different configurations) can be useful.

/cc @HaoK, @tebeco