### PR TITLE
Include build number in NPM package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,6 +135,15 @@ jobs:
       displayName: 'Ubuntu 16.04'
       pool:
         vmImage: ubuntu-16.04
+      variables:
+      # Only enable publishing in official builds.
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - name: _OfficialBuildArgs
+          value: -p:OfficialBuildId=$(Build.BuildNumber)
+      # else
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        - name: _OfficialBuildArgs
+          value: ''
       strategy:
         matrix:
           ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
@@ -157,6 +166,7 @@ jobs:
           --configuration $(_BuildConfig)
           --prepareMachine
           -p:BuildNodeJS=true
+          $(_OfficialBuildArgs)
         displayName: Build
       - script: eng/scripts/ci-flaky-tests.sh --configuration $(_BuildConfig)
         displayName: Run Flaky Tests


### PR DESCRIPTION
Followup to #1748.

 NPM package is always building as 3.0.0-ci because I forget we need to pass in the OfficialBuildId property to Linux builds