### PR TITLE
Fix generic IEnumerable callsite building 

### DIFF
--- a/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/CallSiteFactory.cs
@@ -169,9 +169,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                             var descriptor = _descriptors[i];
                             var callSite = TryCreateExact(descriptor, itemType, callSiteChain, slot) ??
                                            TryCreateOpenGeneric(descriptor, itemType, callSiteChain, slot);
-                            slot++;
+
                             if (callSite != null)
                             {
+                                slot++;
+
                                 cacheLocation = GetCommonCacheLocation(cacheLocation, callSite.Cache.Location);
                                 callSites.Add(callSite);
                             }

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Fact]
-        public void SameSingletonResolvedThroughEnumerableAndIndividually()
+        public void GenericIEnumerableItemCachedInTheRightSlot()
         {
             var services = new ServiceCollection();
             services.AddSingleton<IFakeOpenGenericService<PocoClass>, FakeService>();

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var services = new ServiceCollection();
             // It's important that this service is generic, it hits a different codepath when resolved inside IEnumerable
             services.AddSingleton<IFakeOpenGenericService<PocoClass>, FakeService>();
-            // Doesn't matter what this services is, we just something in the collection after generic registration
+            // Doesn't matter what this services is, we just want something in the collection after generic registration
             services.AddSingleton<FakeService>();
 
             var serviceProvider = services.BuildServiceProvider();

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -228,7 +228,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.Same(serviceRef1, servicesRef1);
         }
 
-
         private class FakeMultipleServiceWithIEnumerableDependency: IFakeMultipleService
         {
             public FakeMultipleServiceWithIEnumerableDependency(IEnumerable<IFakeService> fakeServices)

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.Fakes;
 using Microsoft.Extensions.DependencyInjection.Specification;
@@ -209,6 +210,23 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var service = CreateServiceProvider(serviceCollection).GetService<IEnumerable<IFakeOuterService>>();
         }
+
+        [Fact]
+        public void SameSingletonResolvedThroughEnumerableAndIndividually()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IFakeOpenGenericService<PocoClass>, FakeService>();
+            // Doesn't matter what this services is, we just need something generic and not IFakeOpenGenericService
+            services.AddSingleton<IComparable<string>>("");
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var serviceRef1 = serviceProvider.GetRequiredService<IFakeOpenGenericService<PocoClass>>();
+            var servicesRef1 = serviceProvider.GetServices<IFakeOpenGenericService<PocoClass>>().Single();
+
+            Assert.Same(serviceRef1, servicesRef1);
+        }
+
 
         private class FakeMultipleServiceWithIEnumerableDependency: IFakeMultipleService
         {

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -215,9 +215,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void GenericIEnumerableItemCachedInTheRightSlot()
         {
             var services = new ServiceCollection();
+            // It's important that this service is generic, it hits a different codepath when resolved inside IEnumerable
             services.AddSingleton<IFakeOpenGenericService<PocoClass>, FakeService>();
-            // Doesn't matter what this services is, we just need something generic and not IFakeOpenGenericService
-            services.AddSingleton<IComparable<string>>("");
+            // Doesn't matter what this services is, we just something in the collection after generic registration
+            services.AddSingleton<FakeService>();
 
             var serviceProvider = services.BuildServiceProvider();
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/Extensions/issues/1775

When we build call site for generic service inside IEnumerable (i.e. `IEnumerable<IFakeService<Something>>`) we have to iterate over all descriptors to try to find all applicable open-generic closures (in case there are registrations for `IFakeService<>`). 

The bug is that we incremented the index of cache location every time even if descriptor didn't represent a closure of requested type resulting in item inside IEnumerable being cached with a different key than standalone resolution.