### PR TITLE
[Preview6] Set AssemblyVersion and prevent hosting tests from rebuilding the product code

### DIFF
--- a/src/Hosting/IntegrationTesting/src/ApplicationPublisher.cs
+++ b/src/Hosting/IntegrationTesting/src/ApplicationPublisher.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Extensions.Hosting.IntegrationTesting
                                  + $" --output \"{publishDirectory.FullName}\""
                                  + $" --framework {deploymentParameters.TargetFramework}"
                                  + $" --configuration {deploymentParameters.Configuration}"
+                                 // avoids triggering builds of dependencies of the test app which could cause issues like https://github.com/dotnet/arcade/issues/2941
+                                 + $" --no-dependencies"
                                  + $" /p:TargetArchitecture={deploymentParameters.RuntimeArchitecture}"
                                  + " --no-restore";
 

--- a/version.props
+++ b/version.props
@@ -5,6 +5,13 @@
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview6</PreReleaseVersionLabel>
+    <AssemblyVersion Condition="'$(IsReferenceAssemblyProject)' != 'true'">$(VersionPrefix).0</AssemblyVersion>
+    <!--
+      We do not support changing reference assemblies in a patch. This ignores
+      the patch version number to ensure assembly version of ref assemblies stays constant
+      throughout major.minor.
+    -->
+    <AssemblyVersion Condition="'$(IsReferenceAssemblyProject)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Addresses https://github.com/dotnet/arcade/issues/2941

/cc @Pilchie @wtgodby @mmitche  - this should unblock Preview6 builds 