### PR TITLE
Add retries to HttpClientSlim on macOS.

### DIFF
--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
@@ -121,7 +121,9 @@ namespace Microsoft.AspNetCore.Testing
                     }
                 }
             }
-            throw new OperationCanceledException("Failed to connect, retry limit exceeded");
+
+            // This will never be hit.
+            throw new OperationCanceledException();
         }
 
         private static HttpStatusCode GetStatus(string response)

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Testing
                 {
                     return await retryBlock().ConfigureAwait(false);
                 }
-                catch (Exception)
+                catch (InvalidDataException)
                 {
                     if (retry == retryCount - 1)
                     {

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
@@ -102,11 +103,12 @@ namespace Microsoft.AspNetCore.Testing
 
         private static async Task<string> RetryRequest(Func<Task<string>> retryBlock)
         {
-#if MACOS
-            var retryCount = 3;
-#else
             var retryCount = 1;
-#endif
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                retryCount = 3;
+            }
+
             for (var retry = 0; retry < retryCount; retry++)
             {
                 try
@@ -123,7 +125,7 @@ namespace Microsoft.AspNetCore.Testing
             }
 
             // This will never be hit.
-            throw new OperationCanceledException();
+            throw new NotSupportedException();
         }
 
         private static HttpStatusCode GetStatus(string response)

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/HttpClientSlim.cs
@@ -24,17 +24,20 @@ namespace Microsoft.AspNetCore.Testing
 
         public static async Task<string> GetStringAsync(Uri requestUri, bool validateCertificate = true)
         {
-            using (var stream = await GetStream(requestUri, validateCertificate).ConfigureAwait(false))
+            return await RetryRequest(async () =>
             {
-                using (var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true))
+                using (var stream = await GetStream(requestUri, validateCertificate).ConfigureAwait(false))
                 {
-                    await writer.WriteAsync($"GET {requestUri.PathAndQuery} HTTP/1.0\r\n").ConfigureAwait(false);
-                    await writer.WriteAsync($"Host: {GetHost(requestUri)}\r\n").ConfigureAwait(false);
-                    await writer.WriteAsync("\r\n").ConfigureAwait(false);
-                }
+                    using (var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true))
+                    {
+                        await writer.WriteAsync($"GET {requestUri.PathAndQuery} HTTP/1.0\r\n").ConfigureAwait(false);
+                        await writer.WriteAsync($"Host: {GetHost(requestUri)}\r\n").ConfigureAwait(false);
+                        await writer.WriteAsync("\r\n").ConfigureAwait(false);
+                    }
 
-                return await ReadResponse(stream).ConfigureAwait(false);
-            }
+                    return await ReadResponse(stream).ConfigureAwait(false);
+                }
+            });
         }
 
         internal static string GetHost(Uri requestUri)
@@ -62,21 +65,24 @@ namespace Microsoft.AspNetCore.Testing
 
         public static async Task<string> PostAsync(Uri requestUri, HttpContent content, bool validateCertificate = true)
         {
-            using (var stream = await GetStream(requestUri, validateCertificate))
+            return await RetryRequest(async () =>
             {
-                using (var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true))
+                using (var stream = await GetStream(requestUri, validateCertificate))
                 {
-                    await writer.WriteAsync($"POST {requestUri.PathAndQuery} HTTP/1.0\r\n").ConfigureAwait(false);
-                    await writer.WriteAsync($"Host: {requestUri.Authority}\r\n").ConfigureAwait(false);
-                    await writer.WriteAsync($"Content-Type: {content.Headers.ContentType}\r\n").ConfigureAwait(false);
-                    await writer.WriteAsync($"Content-Length: {content.Headers.ContentLength}\r\n").ConfigureAwait(false);
-                    await writer.WriteAsync("\r\n").ConfigureAwait(false);
+                    using (var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true))
+                    {
+                        await writer.WriteAsync($"POST {requestUri.PathAndQuery} HTTP/1.0\r\n").ConfigureAwait(false);
+                        await writer.WriteAsync($"Host: {requestUri.Authority}\r\n").ConfigureAwait(false);
+                        await writer.WriteAsync($"Content-Type: {content.Headers.ContentType}\r\n").ConfigureAwait(false);
+                        await writer.WriteAsync($"Content-Length: {content.Headers.ContentLength}\r\n").ConfigureAwait(false);
+                        await writer.WriteAsync("\r\n").ConfigureAwait(false);
+                    }
+
+                    await content.CopyToAsync(stream).ConfigureAwait(false);
+
+                    return await ReadResponse(stream).ConfigureAwait(false);
                 }
-
-                await content.CopyToAsync(stream).ConfigureAwait(false);
-
-                return await ReadResponse(stream).ConfigureAwait(false);
-            }
+            });
         }
 
         private static async Task<string> ReadResponse(Stream stream)
@@ -92,6 +98,30 @@ namespace Microsoft.AspNetCore.Testing
                 var body = response.Substring(response.IndexOf("\r\n\r\n") + 4);
                 return body;
             }
+        }
+
+        private static async Task<string> RetryRequest(Func<Task<string>> retryBlock)
+        {
+#if MACOS
+            var retryCount = 3;
+#else
+            var retryCount = 1;
+#endif
+            for (var retry = 0; retry < retryCount; retry++)
+            {
+                try
+                {
+                    return await retryBlock().ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    if (retry == retryCount - 1)
+                    {
+                        throw;
+                    }
+                }
+            }
+            throw new OperationCanceledException("Failed to connect, retry limit exceeded");
         }
 
         private static HttpStatusCode GetStatus(string response)

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -12,6 +12,7 @@
     <IsShipping>false</IsShipping>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(DefineConstants);MACOS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/2637. If you need a backstory, see https://github.com/aspnet/KestrelHttpServer/issues/2635