### PR TITLE
Force StringValues.ToArray to copy the underlying array

### DIFF
--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -225,11 +225,7 @@ namespace Microsoft.Extensions.Primitives
             switch (value)
             {
                 case string[] values:
-#if NETCOREAPP
-                    return values.AsSpan().ToArray();
-#else
-                    return (string[])values.Clone();
-#endif
+                    return new ReadOnlySpan<string>(values).ToArray();
                 case null:
                     return Array.Empty<string>();
                 default:

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -225,7 +225,11 @@ namespace Microsoft.Extensions.Primitives
             switch (value)
             {
                 case string[] values:
-                    return (string[]) values.Clone();
+#if NETCOREAPP
+                    return (string[]) values.AsSpan().ToArray();
+#else
+                    return (string[])values.Clone();
+#endif
                 case null:
                     return Array.Empty<string>();
                 default:

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 case string[] values:
 #if NETCOREAPP
-                    return (string[]) values.AsSpan().ToArray();
+                    return values.AsSpan().ToArray();
 #else
                     return (string[])values.Clone();
 #endif

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Internal;
 
@@ -218,7 +219,20 @@ namespace Microsoft.Extensions.Primitives
 
         public string[] ToArray()
         {
-            return GetArrayValue() ?? Array.Empty<string>();
+            // The same idea as GetArrayValue with slightly different semantics: This method always returns a copy of the array (just like the IEnumerable.ToArray extension method).
+
+            // Take local copy of _values so type checks remain valid even if the StringValues is overwritten in memory.
+            var value = _values;
+            switch (value)
+            {
+                case string[] values:
+                    return (string[]) values.Clone();
+                case null:
+                    return Array.Empty<string>();
+                default:
+                    // value not array, can only be string
+                    return new[] { Unsafe.As<string>(value) };
+            }
         }
 
         private string[] GetArrayValue()

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Internal;
 

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -237,20 +237,19 @@ namespace Microsoft.Extensions.Primitives
 
         private string[] GetArrayValue()
         {
+            // The same idea as ToArray with slightly different semantics: This method reuses the existing array if possible.
+
             // Take local copy of _values so type checks remain valid even if the StringValues is overwritten in memory
             var value = _values;
-            if (value is string[] values)
+            switch (value)
             {
-                return values;
-            }
-            else if (value != null)
-            {
-                // value not array, can only be string
-                return new[] { Unsafe.As<string>(value) };
-            }
-            else
-            {
-                return null;
+                case string[] values:
+                    return values;
+                case null:
+                    return null;
+                default:
+                    // value not array, can only be string
+                    return new[] { Unsafe.As<string>(value) };
             }
         }
 

--- a/src/Primitives/test/StringValuesTests.cs
+++ b/src/Primitives/test/StringValuesTests.cs
@@ -522,5 +522,27 @@ namespace Microsoft.Extensions.Primitives
             Assert.True(StringValues.Equals(stringValues, expected));
             Assert.False(StringValues.Equals(stringValues, notEqual));
         }
+
+        [Fact]
+        public void ToArray_ConstructedFromString_CopiesValues()
+        {
+            var singleStringValue = new StringValues("abc");
+
+            var array = singleStringValue.ToArray();
+            array[0] = "bcd";
+
+            Assert.Equal("abc", singleStringValue[0]);
+        }
+
+        [Fact]
+        public void ToArray_ConstructedFromArray_CopiesValues()
+        {
+            var singleStringValue = new StringValues(new [] {"abc"});
+
+            var array = singleStringValue.ToArray();
+            array[0] = "bcd";
+
+            Assert.Equal("abc", singleStringValue[0]);
+        }
     }
 }


### PR DESCRIPTION
### Summary of the changes
 - Added test demonstrating the problem
 - Reimplemented `ToArray` to be independent from `GetArrayValue`
 - Cleaned up `GetArrayValue` to look syntactically like the new `ToArray`. (I added comments to highlight the differences.)

Addresses #1813 
