### PR TITLE
Set ReferenceAssemblyAttribute in reference assemblies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,6 +37,10 @@
     <HasReferenceAssembly Condition="'$(HasReferenceAssembly)' == ''">false</HasReferenceAssembly>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(Language)' == 'C#' AND '$(IsReferenceAssemblyProject)' == 'true'">
+    <Compile Include="$(SharedSourceRoot)ReferenceAssemblyInfo.cs" LinkBase="Properties" />
+  </ItemGroup>
+
   <Import Project="eng\targets\Packaging.targets" Condition=" '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="eng\targets\ResolveReferences.targets" Condition=" '$(DisableReferenceRestrictions)' != 'true' AND '$(MSBuildProjectExtension)' == '.csproj' " />
   <Import Project="eng\targets\ReferenceAssembly.targets" Condition=" '$(HasReferenceAssembly)' == 'true' " />

--- a/src/Shared/src/ReferenceAssemblyInfo.cs
+++ b/src/Shared/src/ReferenceAssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// All reference assemblies should have the 0x70 flag which prevents them from loading
+// and the ReferenceAssemblyAttribute.
+[assembly:System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly:System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]

--- a/src/Shared/src/ReferenceAssemblyInfo.cs
+++ b/src/Shared/src/ReferenceAssemblyInfo.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-// All reference assemblies should have the 0x70 flag which prevents them from loading
-// and the ReferenceAssemblyAttribute.
+// Reference assemblies should have the ReferenceAssemblyAttribute. 
 [assembly:System.Runtime.CompilerServices.ReferenceAssembly]
+
+// Reference assemblies should have the 0x70 flag which prevents them from loading.
+// This flag sets AssemblyName.ProcessorArchitecture to None. There is no public API for this.
+// Cref https://github.com/dotnet/coreclr/blob/64ca544ecf55490675e72b853e98ebc8cc75a4fe/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs#L74
 [assembly:System.Reflection.AssemblyFlags((System.Reflection.AssemblyNameFlags)0x70)]

--- a/src/Shared/test/Microsoft.Extensions.Sources.Tests.csproj
+++ b/src/Shared/test/Microsoft.Extensions.Sources.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="..\src\**\*.cs"
              Exclude="
+              ..\src\ReferenceAssemblyInfo.cs;
               ..\src\BenchmarkRunner\**\*.cs;
               ..\src\StackTrace\ExceptionDetails\**\*.cs;
               " />


### PR DESCRIPTION
Reference assemblies in .NET are supposed to have these two attributes, which prevent the runtime from loading and executing them.

For other examples of this, see https://github.com/dotnet/corefx/blob/41489a93acf3f36abcaaaea2003a8fdbb577cf35/eng/ReferenceAssemblies.props#L23-L28
and https://github.com/dotnet/standard/blob/14b6385e8640328e33883a919eca11594e22f21c/eng/versioning.targets#L48-L53