### PR TITLE
LogValues structs from LoggerMessage now implement IReadonlyDictionary<string, object>

### DIFF
--- a/src/Logging/Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/Logging/Logging.Abstractions/src/LoggerMessage.cs
@@ -264,7 +264,9 @@ namespace Microsoft.Extensions.Logging
             return logValuesFormatter;
         }
 
-        private readonly struct LogValues : IReadOnlyList<KeyValuePair<string, object>>
+        const string OriginalFormatKey = "{OriginalFormat}";
+
+        private readonly struct LogValues : IReadOnlyList<KeyValuePair<string, object>>, IReadOnlyDictionary<string, object>
         {
             public static readonly Func<LogValues, Exception, string> Callback = (state, exception) => state.ToString();
 
@@ -281,7 +283,7 @@ namespace Microsoft.Extensions.Logging
                 {
                     if (index == 0)
                     {
-                        return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
+                        return new KeyValuePair<string, object>(OriginalFormatKey, _formatter.OriginalFormat);
                     }
                     throw new IndexOutOfRangeException(nameof(index));
                 }
@@ -300,9 +302,46 @@ namespace Microsoft.Extensions.Logging
             {
                 return GetEnumerator();
             }
+
+            public bool ContainsKey(string key) => key == OriginalFormatKey;
+
+            public bool TryGetValue(string key, out object value)
+            {
+                if (key == OriginalFormatKey)
+                {
+                    value = _formatter.OriginalFormat;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public object this[string key]
+            {
+                get
+                {
+                    if (TryGetValue(key, out var value))
+                    {
+                        return value;
+                    }
+
+                    throw new KeyNotFoundException($"The key '{key}' was not found");
+                }
+            }
+
+            public IEnumerable<string> Keys
+            {
+                get { yield return OriginalFormatKey; }
+            }
+
+            public IEnumerable<object> Values
+            {
+                get { yield return _formatter.OriginalFormat; }
+            }
         }
 
-        private readonly struct LogValues<T0> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0> : IReadOnlyList<KeyValuePair<string, object>>, IReadOnlyDictionary<string, object>
         {
             public static readonly Func<LogValues<T0>, Exception, string> Callback = (state, exception) => state.ToString();
 
@@ -324,7 +363,7 @@ namespace Microsoft.Extensions.Logging
                         case 0:
                             return new KeyValuePair<string, object>(_formatter.ValueNames[0], _value0);
                         case 1:
-                            return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
+                            return new KeyValuePair<string, object>(OriginalFormatKey, _formatter.OriginalFormat);
                         default:
                             throw new IndexOutOfRangeException(nameof(index));
                     }
@@ -341,16 +380,70 @@ namespace Microsoft.Extensions.Logging
                 }
             }
 
-
             public override string ToString() => _formatter.Format(_value0);
 
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
+
+            public bool ContainsKey(string key)
+            {
+                return key == _formatter.ValueNames[0] ||
+                       key == OriginalFormatKey;
+            }
+
+            public bool TryGetValue(string key, out object value)
+            {
+                if (key == _formatter.ValueNames[0])
+                {
+                    value = _value0;
+                    return true;
+                }
+
+                if (key == OriginalFormatKey)
+                {
+                    value = _formatter.OriginalFormat;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public object this[string key]
+            {
+                get
+                {
+                    if (TryGetValue(key, out var value))
+                    {
+                        return value;
+                    }
+
+                    throw new KeyNotFoundException($"The key '{key}' was not found");
+                }
+            }
+
+            public IEnumerable<string> Keys
+            {
+                get
+                {
+                    yield return _formatter.ValueNames[0];
+                    yield return OriginalFormatKey;
+                }
+            }
+
+            public IEnumerable<object> Values
+            {
+                get
+                {
+                    yield return _value0;
+                    yield return _formatter.OriginalFormat;
+                }
+            }
         }
 
-        private readonly struct LogValues<T0, T1> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1> : IReadOnlyList<KeyValuePair<string, object>>, IReadOnlyDictionary<string, object>
         {
             public static readonly Func<LogValues<T0, T1>, Exception, string> Callback = (state, exception) => state.ToString();
 
@@ -399,9 +492,73 @@ namespace Microsoft.Extensions.Logging
             {
                 return GetEnumerator();
             }
+
+            public bool ContainsKey(string key)
+            {
+                return key == _formatter.ValueNames[0] ||
+                       key == _formatter.ValueNames[1] ||
+                       key == OriginalFormatKey;
+            }
+
+            public bool TryGetValue(string key, out object value)
+            {
+                if (key == _formatter.ValueNames[0])
+                {
+                    value = _value0;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[1])
+                {
+                    value = _value1;
+                    return true;
+                }
+
+                if (key == OriginalFormatKey)
+                {
+                    value = _formatter.OriginalFormat;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public object this[string key]
+            {
+                get
+                {
+                    if (TryGetValue(key, out var value))
+                    {
+                        return value;
+                    }
+
+                    throw new KeyNotFoundException($"The key '{key}' was not found");
+                }
+            }
+
+            public IEnumerable<string> Keys
+            {
+                get
+                {
+                    yield return _formatter.ValueNames[0];
+                    yield return _formatter.ValueNames[1];
+                    yield return OriginalFormatKey;
+                }
+            }
+
+            public IEnumerable<object> Values
+            {
+                get
+                {
+                    yield return _value0;
+                    yield return _value1;
+                    yield return _formatter.OriginalFormat;
+                }
+            }
         }
 
-        private readonly struct LogValues<T0, T1, T2> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2> : IReadOnlyList<KeyValuePair<string, object>>, IReadOnlyDictionary<string, object>
         {
             public static readonly Func<LogValues<T0, T1, T2>, Exception, string> Callback = (state, exception) => state.ToString();
 
@@ -454,9 +611,82 @@ namespace Microsoft.Extensions.Logging
             {
                 return GetEnumerator();
             }
+
+            public bool ContainsKey(string key)
+            {
+                return key == _formatter.ValueNames[0] ||
+                       key == _formatter.ValueNames[1] ||
+                       key == _formatter.ValueNames[2] ||
+                       key == OriginalFormatKey;
+            }
+
+            public bool TryGetValue(string key, out object value)
+            {
+                if (key == _formatter.ValueNames[0])
+                {
+                    value = _value0;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[1])
+                {
+                    value = _value1;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[2])
+                {
+                    value = _value2;
+                    return true;
+                }
+
+                if (key == OriginalFormatKey)
+                {
+                    value = _formatter.OriginalFormat;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public object this[string key]
+            {
+                get
+                {
+                    if (TryGetValue(key, out var value))
+                    {
+                        return value;
+                    }
+
+                    throw new KeyNotFoundException($"The key '{key}' was not found");
+                }
+            }
+
+            public IEnumerable<string> Keys
+            {
+                get
+                {
+                    yield return _formatter.ValueNames[0];
+                    yield return _formatter.ValueNames[1];
+                    yield return _formatter.ValueNames[2];
+                    yield return OriginalFormatKey;
+                }
+            }
+
+            public IEnumerable<object> Values
+            {
+                get
+                {
+                    yield return _value0;
+                    yield return _value1;
+                    yield return _value2;
+                    yield return _formatter.OriginalFormat;
+                }
+            }
         }
 
-        private readonly struct LogValues<T0, T1, T2, T3> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2, T3> : IReadOnlyList<KeyValuePair<string, object>>, IReadOnlyDictionary<string, object>
         {
             public static readonly Func<LogValues<T0, T1, T2, T3>, Exception, string> Callback = (state, exception) => state.ToString();
 
@@ -515,9 +745,91 @@ namespace Microsoft.Extensions.Logging
             {
                 return GetEnumerator();
             }
+
+            public bool ContainsKey(string key)
+            {
+                return key == _formatter.ValueNames[0] ||
+                       key == _formatter.ValueNames[1] ||
+                       key == _formatter.ValueNames[2] ||
+                       key == _formatter.ValueNames[3] ||
+                       key == OriginalFormatKey;
+            }
+
+            public bool TryGetValue(string key, out object value)
+            {
+                if (key == _formatter.ValueNames[0])
+                {
+                    value = _value0;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[1])
+                {
+                    value = _value1;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[2])
+                {
+                    value = _value2;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[3])
+                {
+                    value = _value3;
+                    return true;
+                }
+
+                if (key == OriginalFormatKey)
+                {
+                    value = _formatter.OriginalFormat;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public object this[string key]
+            {
+                get
+                {
+                    if (TryGetValue(key, out var value))
+                    {
+                        return value;
+                    }
+
+                    throw new KeyNotFoundException($"The key '{key}' was not found");
+                }
+            }
+
+            public IEnumerable<string> Keys
+            {
+                get
+                {
+                    yield return _formatter.ValueNames[0];
+                    yield return _formatter.ValueNames[1];
+                    yield return _formatter.ValueNames[2];
+                    yield return _formatter.ValueNames[3];
+                    yield return OriginalFormatKey;
+                }
+            }
+
+            public IEnumerable<object> Values
+            {
+                get
+                {
+                    yield return _value0;
+                    yield return _value1;
+                    yield return _value2;
+                    yield return _value3;
+                    yield return _formatter.OriginalFormat;
+                }
+            }
         }
 
-        private readonly struct LogValues<T0, T1, T2, T3, T4> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2, T3, T4> : IReadOnlyList<KeyValuePair<string, object>>, IReadOnlyDictionary<string, object>
         {
             public static readonly Func<LogValues<T0, T1, T2, T3, T4>, Exception, string> Callback = (state, exception) => state.ToString();
 
@@ -579,6 +891,97 @@ namespace Microsoft.Extensions.Logging
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
+            }
+
+            public bool ContainsKey(string key)
+            {
+                return key == _formatter.ValueNames[0] ||
+                       key == _formatter.ValueNames[1] ||
+                       key == _formatter.ValueNames[2] ||
+                       key == _formatter.ValueNames[3] ||
+                       key == _formatter.ValueNames[4] ||
+                       key == OriginalFormatKey;
+            }
+
+            public bool TryGetValue(string key, out object value)
+            {
+                if (key == _formatter.ValueNames[0])
+                {
+                    value = _value0;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[1])
+                {
+                    value = _value1;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[2])
+                {
+                    value = _value2;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[3])
+                {
+                    value = _value3;
+                    return true;
+                }
+
+                if (key == _formatter.ValueNames[4])
+                {
+                    value = _value4;
+                    return true;
+                }
+
+                if (key == OriginalFormatKey)
+                {
+                    value = _formatter.OriginalFormat;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public object this[string key]
+            {
+                get
+                {
+                    if (TryGetValue(key, out var value))
+                    {
+                        return value;
+                    }
+
+                    throw new KeyNotFoundException($"The key '{key}' was not found");
+                }
+            }
+
+            public IEnumerable<string> Keys
+            {
+                get
+                {
+                    yield return _formatter.ValueNames[0];
+                    yield return _formatter.ValueNames[1];
+                    yield return _formatter.ValueNames[2];
+                    yield return _formatter.ValueNames[3];
+                    yield return _formatter.ValueNames[4];
+                    yield return OriginalFormatKey;
+                }
+            }
+
+            public IEnumerable<object> Values
+            {
+                get
+                {
+                    yield return _value0;
+                    yield return _value1;
+                    yield return _value2;
+                    yield return _value3;
+                    yield return _value4;
+                    yield return _formatter.OriginalFormat;
+                }
             }
         }
 


### PR DESCRIPTION
This PR introduces an additional interface implementation for structs used for high-performance logging. The additional interface is `IReadonlyDictionary<string, object>` which should allow slightly faster querying of the state/scope object by `ILogger` implementations, especially taking into consideration that `Log<TState>` is a generic method, and there's some awesome work related to deviritualizing calls to structs implementing interfaces.

### Usages

With a change like this, there's potential to replace some allocations in various libraries, without creating specific types (they can be inferred from the parsed format & values) and replacing the allocated dictionaries. For example:
- Azure Functions/Webjobs function executor: https://github.com/Azure/azure-webjobs-sdk/blob/77234d6aef493788cfa25c02467fe31e1db265d6/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs#L525-L529
- Azure Functions/Webjobs logger extensions: https://github.com/Azure/azure-webjobs-sdk/blob/b798412ad74ba97cf2d85487ae8479f277bdd85c/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs

### Benchmarks

To benchmark potential gains I used the following benchmark, trying to compare finding a value via LINQ over `IReadOnlyList` and a direct access to a dictionary API. Maybe there's a better way, but my assumption is that this is the way one would access it in the implementation.

```csharp
[Benchmark]
public object ReadonlyList()
{
    return ((IReadOnlyList<KeyValuePair<string, object>>)values).FirstOrDefault(kvp => kvp.Key == Key).Value;
}

[Benchmark]
public object Dictionary()
{
    ((IReadOnlyDictionary<string, object>)values).TryGetValue(Key, out var value);
    return value;
}
```

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.829 (1803/April2018Update/Redstone4)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=2531248 Hz, Resolution=395.0620 ns, Timer=TSC
.NET Core SDK=2.2.203
  [Host] : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT
  Core   : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT

Job=Core  Runtime=Core  

```
|       Method |     Mean |     Error |   StdDev |   Median |
|------------- |---------:|----------:|---------:|---------:|
| ReadonlyList | 92.16 ns | 1.9167 ns | 4.629 ns | 91.18 ns |
|   Dictionary | 21.70 ns | 0.7151 ns | 1.993 ns | 21.05 ns |
