### PR TITLE
fix #1723 by converting sql cache to new sqlclient

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -72,6 +72,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
     <LatestPackageReference Include="xunit.extensibility.core" Version="$(XUnitVersion)" />
     <LatestPackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
+    <LatestPackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19128.1-Preview" />
 
     <!-- External DI container references -->
     <LatestPackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -20,7 +20,6 @@ and are generated based on the last package release.
   <ItemGroup Label=".NET team dependencies">
     <LatestPackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <LatestPackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsPackageVersion)" />
-    <LatestPackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientPackageVersion)" />
     <LatestPackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourcePackageVersion)" />
     <LatestPackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogPackageVersion)" />
     <LatestPackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,10 +18,6 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>edc88b0fe55278ee43c821ab05707d8bb0befded</Sha>
     </Dependency>
-    <Dependency Name="System.Data.SqlClient" Version="4.7.0-preview7.19319.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>edc88b0fe55278ee43c821ab05707d8bb0befded</Sha>
-    </Dependency>
     <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview7.19319.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>edc88b0fe55278ee43c821ab05707d8bb0befded</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,6 @@
     <!-- Packages from dotnet/corefx -->
     <MicrosoftWin32RegistryPackageVersion>4.6.0-preview7.19319.4</MicrosoftWin32RegistryPackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>4.6.0-preview7.19319.4</SystemComponentModelAnnotationsPackageVersion>
-    <SystemDataSqlClientPackageVersion>4.7.0-preview7.19319.4</SystemDataSqlClientPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.6.0-preview7.19319.4</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview7.19319.4</SystemDiagnosticsEventLogPackageVersion>
     <SystemIOPipelinesPackageVersion>4.6.0-preview7.19319.4</SystemIOPipelinesPackageVersion>

--- a/eng/tools/BaselineGenerator/Program.cs
+++ b/eng/tools/BaselineGenerator/Program.cs
@@ -152,6 +152,7 @@ namespace PackageBaselineGenerator
                 OmitXmlDeclaration = true,
                 Encoding = Encoding.UTF8,
                 Indent = true,
+                NewLineChars = "\n", // The files use LF, not CRLF.
             };
 
             using (var writer = XmlWriter.Create(output, settings))
@@ -212,6 +213,7 @@ namespace PackageBaselineGenerator
                     NewLineOnAttributes = false,
                     OmitXmlDeclaration = true,
                     WriteEndDocumentOnClose = true,
+                    NewLineChars = "\n", // The file uses LF, not CRLF!
                 };
 
                 using (var stream = File.OpenWrite(documentPath))

--- a/src/Caching/SqlServer/Directory.Build.props
+++ b/src/Caching/SqlServer/Directory.Build.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <!-- These projects depend on code which is not open source. -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <NoWarn>$(NoWarn);PKG0001</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Caching/SqlServer/ref/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/ref/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -7,6 +7,6 @@
     <Compile Include="Microsoft.Extensions.Caching.SqlServer.netstandard2.0.cs" />
     <Reference Include="Microsoft.Extensions.Caching.Abstractions"  />
     <Reference Include="Microsoft.Extensions.Options"  />
-    <Reference Include="System.Data.SqlClient"  />
+    <Reference Include="Microsoft.Data.SqlClient"  />
   </ItemGroup>
 </Project>

--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Data;
-using System.Data.SqlClient;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Internal;
-using System.Threading;
 
 namespace Microsoft.Extensions.Caching.SqlServer
 {

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Distributed cache implementation of Microsoft.Extensions.Caching.Distributed.IDistributedCache using Microsoft SQL Server.</Description>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="System.Data.SqlClient" />
+    <Reference Include="Microsoft.Data.SqlClient" />
   </ItemGroup>
 
 </Project>

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Distributed cache implementation of Microsoft.Extensions.Caching.Distributed.IDistributedCache using Microsoft SQL Server.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;PKG0001</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cache;distributedcache;sqlserver</PackageTags>
     <IsPackable>true</IsPackable>

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Distributed cache implementation of Microsoft.Extensions.Caching.Distributed.IDistributedCache using Microsoft SQL Server.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591;PKG0001</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>cache;distributedcache;sqlserver</PackageTags>
     <IsPackable>true</IsPackable>

--- a/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/MonoDatabaseOperations.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Internal;
 

--- a/src/Caching/SqlServer/src/MonoSqlParameterCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/MonoSqlParameterCollectionExtensions.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Extensions.Caching.SqlServer
 {

--- a/src/Caching/SqlServer/src/SqlParameterCollectionExtensions.cs
+++ b/src/Caching/SqlServer/src/SqlParameterCollectionExtensions.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Extensions.Caching.SqlServer
 {

--- a/src/Caching/SqlServer/test/Microsoft.Extensions.Caching.SqlServer.Tests.csproj
+++ b/src/Caching/SqlServer/test/Microsoft.Extensions.Caching.SqlServer.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>

--- a/src/Caching/SqlServer/test/README.md
+++ b/src/Caching/SqlServer/test/README.md
@@ -1,0 +1,17 @@
+# Microsoft.Extensions.Caching.SqlServer Tests
+
+These tests include functional tests that run against a real SQL Server. Since these are flaky on CI, they should be run manually when changing this code.
+
+## Pre-requisites
+
+1. A functional SQL Server, Local DB included with VS is sufficient
+1. An empty database named `CacheTestDb` in that SQL Server
+
+## Running the tests
+
+1. Install the latest version of the `dotnet-sql-cache` too: `dotnet tool install --global dotnet-sql-cache` (make sure to specify a version if it's a pre-release tool you want!)
+1. Run `dotnet sql-cache [connectionstring] dbo CacheTest`
+    * `[connectionstring]` must be a SQL Connection String **for an empty database named `CacheTestDb` that already exists**
+    * If using Local DB, this string should work: `"Server=(localdb)\MSSQLLocalDB;Database=CacheTestDb;Trusted_Connection=True;"`
+1. Unskip the tests by changing the `SqlServerCacheWithDatabaseTest.SkipReason` field to `null`.
+1. Run the tests.

--- a/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Internal;
@@ -16,7 +18,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
 {
     public class SqlServerCacheWithDatabaseTest
     {
-        private const string SkipReason = "This requires SQL Server database to be setup";
+        private const string SkipReason = "This requires SQL Server database to be set up";
 
         private const string ConnectionStringKey = "ConnectionString";
         private const string SchemaNameKey = "SchemaName";
@@ -33,7 +35,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
 
             var memoryConfigurationData = new Dictionary<string, string>
             {
-                { ConnectionStringKey, "Server=localhost;Database=CacheTestDb;Trusted_Connection=True;" },
+                { ConnectionStringKey, @"Server=(localdb)\MSSQLLocalDB;Database=CacheTestDb;Trusted_Connection=True;" },
                 { SchemaNameKey, "dbo" },
                 { TableNameKey, "CacheTest" },
             };

--- a/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
 {
     public class SqlServerCacheWithDatabaseTest
     {
-        private const string SkipReason = "This requires SQL Server database to be set up";
+        private const string SkipReason = null; //"This requires SQL Server database to be set up";
 
         private const string ConnectionStringKey = "ConnectionString";
         private const string SchemaNameKey = "SchemaName";

--- a/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
+++ b/src/Caching/SqlServer/test/SqlServerCacheWithDatabaseTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Caching.SqlServer
 {
     public class SqlServerCacheWithDatabaseTest
     {
-        private const string SkipReason = null; //"This requires SQL Server database to be set up";
+        private const string SkipReason = "This requires SQL Server database to be set up";
 
         private const string ConnectionStringKey = "ConnectionString";
         private const string SchemaNameKey = "SchemaName";


### PR DESCRIPTION
This changes the `Microsoft.Extensions.Caching.SqlServer` package to use `Microsoft.Data.SqlClient`.

There is a big open question to be resolved though: The `Microsoft.Data.SqlClient` package does not currently support **.NET Framework 32-bit**. The tests run fine if forced to use 64-bit but if your app runs in 32-bit you **will** get `BadImageFormatException`s from `Microsoft.Data.SqlClient`

According to [the README](https://github.com/dotnet/SqlClient/blob/master/README.md) for the new SQL client, the plan is to support both 32 and 64 bit, so maybe this is OK, but I want Important People:tm: to know and be OK with this :).

**To be clear**: This is the support matrix:

| Arch \ Framework | **.NET Framework** | **.NET Core** |
| - | - | - |
| **x86** | `BadImageFormatException` | _Works_ |
| **x64** | _Works_ | _Works_ |

Fixes #1723 