### PR TITLE
Allow sanitation of dotnet interop exceptions

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
@@ -59,7 +59,6 @@ namespace Microsoft.JSInterop
     public abstract partial class JSRuntimeBase : Microsoft.JSInterop.IJSRuntime
     {
         protected JSRuntimeBase() { }
-        protected System.TimeSpan? DefaultAsyncCallTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         protected abstract void BeginInvokeJS(long asyncHandle, string identifier, string argsJson);
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, params object[] args) { throw null; }
         protected virtual object OnDotNetInvocationException(System.Exception exception, string assemblyName, string methodIdentifier) { throw null; }

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
@@ -59,8 +59,10 @@ namespace Microsoft.JSInterop
     public abstract partial class JSRuntimeBase : Microsoft.JSInterop.IJSRuntime
     {
         protected JSRuntimeBase() { }
+        protected System.TimeSpan? DefaultAsyncCallTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         protected abstract void BeginInvokeJS(long asyncHandle, string identifier, string argsJson);
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, params object[] args) { throw null; }
+        protected virtual object OnDotNetInvocationException(System.Exception exception, string assemblyName, string methodIdentifier) { throw null; }
     }
 }
 namespace Microsoft.JSInterop.Internal

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -93,8 +93,6 @@ namespace Microsoft.JSInterop
             catch (Exception ex)
             {
                 syncException = ExceptionDispatchInfo.Capture(ex);
-                syncException.SourceException.Data.Add(JSRuntimeBase.AssemblyNameKey, assemblyName);
-                syncException.SourceException.Data.Add(JSRuntimeBase.MethodKey, methodIdentifier);
             }
 
             // If there was no callId, the caller does not want to be notified about the result
@@ -116,8 +114,6 @@ namespace Microsoft.JSInterop
                     if (t.Exception != null)
                     {
                         var exception = t.Exception.GetBaseException();
-                        exception.Data.Add(JSRuntimeBase.AssemblyNameKey, assemblyName);
-                        exception.Data.Add(JSRuntimeBase.MethodKey, methodIdentifier);
 
                         jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, ExceptionDispatchInfo.Capture(exception), assemblyName, methodIdentifier);
                     }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -105,7 +105,7 @@ namespace Microsoft.JSInterop
             else if (syncException != null)
             {
                 // Threw synchronously, let's respond.
-                jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, syncException);
+                jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, syncException, assemblyName, methodIdentifier);
             }
             else if (syncResult is Task task)
             {
@@ -119,16 +119,16 @@ namespace Microsoft.JSInterop
                         exception.Data.Add(JSRuntimeBase.AssemblyNameKey, assemblyName);
                         exception.Data.Add(JSRuntimeBase.MethodKey, methodIdentifier);
 
-                        jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, ExceptionDispatchInfo.Capture(exception));
+                        jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, ExceptionDispatchInfo.Capture(exception), assemblyName, methodIdentifier);
                     }
 
                     var result = TaskGenericsUtil.GetTaskResult(task);
-                    jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, result);
+                    jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, result, assemblyName, methodIdentifier);
                 }, TaskScheduler.Current);
             }
             else
             {
-                jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, syncResult);
+                jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, syncResult, assemblyName, methodIdentifier);
             }
         }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -93,6 +93,8 @@ namespace Microsoft.JSInterop
             catch (Exception ex)
             {
                 syncException = ExceptionDispatchInfo.Capture(ex);
+                syncException.SourceException.Data.Add(JSRuntimeBase.AssemblyNameKey, assemblyName);
+                syncException.SourceException.Data.Add(JSRuntimeBase.MethodKey, methodIdentifier);
             }
 
             // If there was no callId, the caller does not want to be notified about the result
@@ -114,6 +116,9 @@ namespace Microsoft.JSInterop
                     if (t.Exception != null)
                     {
                         var exception = t.Exception.GetBaseException();
+                        exception.Data.Add(JSRuntimeBase.AssemblyNameKey, assemblyName);
+                        exception.Data.Add(JSRuntimeBase.MethodKey, methodIdentifier);
+
                         jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, ExceptionDispatchInfo.Capture(exception));
                     }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -21,9 +21,6 @@ namespace Microsoft.JSInterop
         private readonly ConcurrentDictionary<long, object> _pendingTasks
             = new ConcurrentDictionary<long, object>();
 
-        internal static readonly object AssemblyNameKey = new object();
-        internal static readonly object MethodKey = new object();
-
         internal DotNetObjectRefManager ObjectRefManager { get; } = new DotNetObjectRefManager();
 
         /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.ComponentModel;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Threading;

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -62,18 +62,29 @@ namespace Microsoft.JSInterop
         /// <param name="argsJson">A JSON representation of the arguments.</param>
         protected abstract void BeginInvokeJS(long asyncHandle, string identifier, string argsJson);
 
+        /// <summary>
+        /// Allows derived classes to configure the information about an exception in a JS interop call that gets sent to JavaScript.
+        /// </summary>
+        /// <remarks>
+        /// This callback can be used in remote JS interop scenarios to sanitize exceptions that happen on the server to avoid disclosing
+        /// sensitive information to remote browser clients.
+        /// </remarks>
+        /// <param name="exception">The exception that occurred.</param>
+        /// <returns>An object containing information about the exception.</returns>
+        protected virtual object OnDotNetInteropException(Exception exception) => exception;
+
         internal void EndInvokeDotNet(string callId, bool success, object resultOrException)
         {
             // For failures, the common case is to call EndInvokeDotNet with the Exception object.
             // For these we'll serialize as something that's useful to receive on the JS side.
             // If the value is not an Exception, we'll just rely on it being directly JSON-serializable.
-            if (!success && resultOrException is Exception)
+            if (!success && resultOrException is Exception ex)
             {
-                resultOrException = resultOrException.ToString();
+                resultOrException = OnDotNetInteropException(ex);
             }
             else if (!success && resultOrException is ExceptionDispatchInfo edi)
             {
-                resultOrException = edi.SourceException.ToString();
+                resultOrException = OnDotNetInteropException(edi.SourceException);
             }
 
             // We pass 0 as the async handle because we don't want the JS-side code to

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.JSInterop.Internal;

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
@@ -185,11 +185,9 @@ namespace Microsoft.JSInterop.Tests
             };
 
             var exception = new Exception("Some really sensitive data in here");
-            exception.Data.Add(JSRuntimeBase.AssemblyNameKey, "Assembly");
-            exception.Data.Add(JSRuntimeBase.MethodKey, "Method");
 
             // Act
-            runtime.EndInvokeDotNet("0", false, exception);
+            runtime.EndInvokeDotNet("0", false, exception, "Assembly", "Method");
 
             // Assert
             var call = runtime.BeginInvokeCalls.Single();

--- a/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
+++ b/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Extensions.Options
         public System.Collections.Generic.IEnumerable<string> Failures { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public bool Skipped { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public bool Succeeded { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
-        public static Microsoft.Extensions.Options.ValidateOptionsResult Fail(System.Collections.Generic.IEnumerable<string> failures) { throw null; }        
+        public static Microsoft.Extensions.Options.ValidateOptionsResult Fail(System.Collections.Generic.IEnumerable<string> failures) { throw null; }
         public static Microsoft.Extensions.Options.ValidateOptionsResult Fail(string failureMessage) { throw null; }
     }
     public partial class ValidateOptions<TOptions> : Microsoft.Extensions.Options.IValidateOptions<TOptions> where TOptions : class


### PR DESCRIPTION
Adds a hook that gets called before serializing a .NET exception and that allows implementations to customize the object that gets sent to the client.