### PR TITLE
Improve systemd detection for pre-232 systemd

### DIFF
--- a/src/Hosting/Systemd/src/SystemdHelpers.cs
+++ b/src/Hosting/Systemd/src/SystemdHelpers.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
                 return false;
             }
 
-            // We've got invocation id, it's systemd >= 232 running a unit
+            // We've got invocation id, it's systemd >= 232 running a unit (either directly or through a child process)
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(INVOCATION_ID)))
             {
                 return true;
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
             // Either it's not a unit, or systemd is < 232, do a bit more digging
             try
             {
-                // Test parent process
+                // Test parent process (this matches only direct parents, walking all the way up to the PID 1 is probably not what we would want)
                 var parentPid = GetParentPid();
                 var ppidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
 

--- a/src/Hosting/Systemd/src/SystemdHelpers.cs
+++ b/src/Hosting/Systemd/src/SystemdHelpers.cs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Microsoft.Extensions.Hosting.Systemd
 {
@@ -12,14 +16,55 @@ namespace Microsoft.Extensions.Hosting.Systemd
     {
         private const string INVOCATION_ID = "INVOCATION_ID";
 
+        private static bool? _isSystemdService;
+
         /// <summary>
         /// Check if the current process is hosted as a systemd Service.
         /// </summary>
         /// <returns><c>True</c> if the current process is hosted as a systemd Service, otherwise <c>false</c>.</returns>
         public static bool IsSystemdService()
+            => _isSystemdService ?? (bool)(_isSystemdService = CheckSystemdUnit());
+
+        private static bool CheckSystemdUnit()
         {
-            // We use the INVOCATION_ID envirionment variable that was introduced in systemd 232 (released 2016-11-03).
-            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(INVOCATION_ID));
+            // No point in testing anything unless it's Unix
+            if (Environment.OSVersion.Platform != PlatformID.Unix)
+            {
+                return false;
+            }
+
+            // We've got invocation id, it's systemd >= 232 running a unit
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(INVOCATION_ID)))
+            {
+                return true;
+            }
+
+            // Either it's not a unit, or systemd is < 232, do a bit more digging
+            try
+            {
+                // Test parent process
+                var parentPid = GetParentPid();
+                var ppidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
+
+                // If parent PID is not 1, this may be a user unit, in this case it must match MANAGERPID envvar
+                if (parentPid != 1
+                    && Environment.GetEnvironmentVariable("MANAGERPID") != ppidString)
+                {
+                    return false;
+                }
+
+                // Check parent process name to match "systemd\n"
+                var comm = File.ReadAllBytes("/proc/" + ppidString + "/comm");
+                return comm.AsSpan().SequenceEqual(Encoding.ASCII.GetBytes("systemd\n"));
+            }
+            catch
+            {
+            }
+
+            return false;
         }
+
+        [DllImport("libc", EntryPoint = "getppid", SetLastError = true)]
+        private static extern int GetParentPid();
     }
 }

--- a/src/Hosting/Systemd/src/SystemdHelpers.cs
+++ b/src/Hosting/Systemd/src/SystemdHelpers.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
             return false;
         }
 
-        [DllImport("libc", EntryPoint = "getppid", SetLastError = true)]
+        [DllImport("libc", EntryPoint = "getppid")]
         private static extern int GetParentPid();
     }
 }


### PR DESCRIPTION
Older _systemd_ versions (for example the Ubuntu 16.04 has _systemd_ 229) have no direct method of determining if the process is run as a unit, since the `$INVOCATION_ID` envvar [was introduced](https://lists.freedesktop.org/archives/systemd-devel/2016-November/037698.html) in _systemd_ 232. To work around this limitation, I had to expand the `SystemdHelpers.IsSystemdService()` method to cover older versions. It still performs the check via the `$INVOCATION_ID` envvar, and then, if it's not present, follows up with checking the parent process command using the `getppid(2)` and access to the _/proc/\<pid\>/comm_ file to check if the parent process is, in fact, an instance of _systemd_, along with doing some extra checks for user units via [`$MANAGERPID`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment%20variables%20in%20spawned%20processes) envvar.

This is a partial application of the [tmds/Tmds.Systemd#43](https://github.com/tmds/Tmds.Systemd/pull/43), mentioning @tmds as per [his request](https://github.com/tmds/Tmds.Systemd/pull/43#issuecomment-506385507).