### PR TITLE
Invoking a method with an invalid dotnetobjectref bubbles up through the wrong path

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -75,19 +75,20 @@ namespace Microsoft.JSInterop
             // code has to implement its own way of returning async results.
             var jsRuntimeBaseInstance = (JSRuntimeBase)JSRuntime.Current;
 
-            var targetInstance = (object)null;
-            if (dotNetObjectId != default)
-            {
-                targetInstance = DotNetObjectRefManager.Current.FindDotNetObject(dotNetObjectId);
-            }
 
             // Using ExceptionDispatchInfo here throughout because we want to always preserve
             // original stack traces.
             object syncResult = null;
             ExceptionDispatchInfo syncException = null;
+            object targetInstance = null;
 
             try
             {
+                if (dotNetObjectId != default)
+                {
+                    targetInstance = DotNetObjectRefManager.Current.FindDotNetObject(dotNetObjectId);
+                }
+
                 syncResult = InvokeSynchronously(assemblyName, methodIdentifier, targetInstance, argsJson);
             }
             catch (Exception ex)

--- a/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
@@ -381,6 +381,23 @@ namespace Microsoft.JSInterop.Tests
             Assert.Contains("JsonReaderException: '<' is an invalid start of a value.", result[2].GetString());
         });
 
+        [Fact]
+        public Task BeginInvoke_ThrowsWithInvalid_DotNetObjectRef() => WithJSRuntime(jsRuntime =>
+        {
+            // Arrange
+            var callId = "123";
+            var resultTask = jsRuntime.NextInvocationTask;
+            DotNetDispatcher.BeginInvoke(callId, null, "InvokableInstanceVoid", 1, null);
+
+            // Assert
+            using var jsonDocument = JsonDocument.Parse(jsRuntime.LastInvocationArgsJson);
+            var result = jsonDocument.RootElement;
+            Assert.Equal(callId, result[0].GetString());
+            Assert.False(result[1].GetBoolean()); // Fails
+
+            Assert.StartsWith("System.ArgumentException: There is no tracked object with id '1'. Perhaps the DotNetObjectRef instance was already disposed.", result[2].GetString());
+        });
+
         Task WithJSRuntime(Action<TestJSRuntime> testCode)
         {
             return WithJSRuntime(jsRuntime =>


### PR DESCRIPTION
* You want it to flow through `DotNetDispatcher.endInvokeDotnet` in the same way as any other similar exception
  * Not finding the assembly.
  * Not finding the method name.
  * etc.
* In the case of blazor server-side it ends up being handled by the circuit error handler and producing a warning, which is not something we want.