### PR TITLE
Fix memory leak

### DIFF
--- a/src/Logging/Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.Logging.Console
             _options = options;
             _loggers = new ConcurrentDictionary<string, ConsoleLogger>();
 
+            _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
             ReloadLoggerOptions(options.CurrentValue);
 
             _messageQueue = new ConsoleLoggerProcessor();
@@ -44,8 +45,6 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 logger.Value.Options = options;
             }
-
-            _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
         }
 
         /// <inheritdoc />

--- a/src/Logging/Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/Logging/Logging.Console/src/ConsoleLoggerProvider.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Extensions.Logging.Console
             _options = options;
             _loggers = new ConcurrentDictionary<string, ConsoleLogger>();
 
-            _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
             ReloadLoggerOptions(options.CurrentValue);
+            _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
 
             _messageQueue = new ConsoleLoggerProcessor();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Logging/test/ConsoleLoggerTest.cs
+++ b/src/Logging/test/ConsoleLoggerTest.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
-        public void ConsoleLoggerOptions_DisableColors_IsReloaded()
+        public void ConsoleLoggerOptions_TimeStampFormat_IsReloaded()
         {
             // Arrange
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
@@ -1029,6 +1029,20 @@ namespace Microsoft.Extensions.Logging.Test
 
             var consoleLoggerProvider = Assert.IsType<ConsoleLoggerProvider>(loggerProvider);
             var logger = (ConsoleLogger)consoleLoggerProvider.CreateLogger("Category");
+            Assert.Equal("yyyyMMddHHmmss", logger.Options.TimestampFormat);
+        }
+
+        [Fact]
+        public void ConsoleLoggerOptions_TimeStampFormat_MultipleReloads()
+        {
+            var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
+            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
+
+            Assert.Null(logger.Options.TimestampFormat);
+            monitor.Set(new ConsoleLoggerOptions() { TimestampFormat = "yyyyMMdd" });
+            Assert.Equal("yyyyMMdd", logger.Options.TimestampFormat);
+            monitor.Set(new ConsoleLoggerOptions() { TimestampFormat = "yyyyMMddHHmmss" });
             Assert.Equal("yyyyMMddHHmmss", logger.Options.TimestampFormat);
         }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Move event registration out of event callback to avoid memory leak(recursive event registration)

Addresses #bugnumber (in this specific format)
