### PR TITLE
In JSInterop calls, use expected value for 'this'. Fixes #1477

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -142,14 +142,6 @@ module DotNet {
    */
   export const jsCallDispatcher = {
     /**
-     * Finds the JavaScript function matching the specified identifier.
-     *
-     * @param identifier Identifies the globally-reachable function to be returned.
-     * @returns A Function instance.
-     */
-    findJSFunction,
-
-    /**
      * Invokes the specified synchronous JavaScript function.
      *
      * @param identifier Identifies the globally-reachable function to invoke.
@@ -227,8 +219,10 @@ module DotNet {
 
     let result: any = window;
     let resultIdentifier = 'window';
+    let lastSegmentValue: any;
     identifier.split('.').forEach(segment => {
       if (segment in result) {
+        lastSegmentValue = result;
         result = result[segment];
         resultIdentifier += '.' + segment;
       } else {
@@ -237,6 +231,8 @@ module DotNet {
     });
 
     if (result instanceof Function) {
+      result = result.bind(lastSegmentValue);
+      cachedJSFunctions[identifier] = result;
       return result;
     } else {
       throw new Error(`The value '${resultIdentifier}' is not a function.`);


### PR DESCRIPTION
Previously, if you did this:

```cs
jsInterop.InvokeAsync<string>("a.b", arg1, arg2)
```

it would be equivalent to `window.a.b.apply(null, [arg1, arg2])`. That's OK as long as the function doesn't require any particular value for `this`. But unfortunately some static functions do expect a `this` value.

After this PR, the same call becomes equivalent to `window.a.b.apply(window.a.b, [arg1, arg2])`, or more simply `a.b(arg1, arg2)`, which is much more likely to match the developer's intent.

As a realistic example, it means you can do things like:

```cs
jsInterop.InvokeAsync<string>("localStorage.getItem", "myKey")
```

... and it will just work without needing any JS wrapper library.