### PR TITLE
Use TimeSpan value for reload interval

### DIFF
--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
 
         protected virtual async Task WaitForReload()
         {
-            await Task.Delay(_reloadInterval.Value.Milliseconds, _cancellationToken.Token);
+            await Task.Delay(_reloadInterval.Value.TotalMilliseconds, _cancellationToken.Token);
         }
 
         private async Task LoadAsync()

--- a/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
+++ b/src/Configuration/Config.AzureKeyVault/src/AzureKeyVaultConfigurationProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Configuration.AzureKeyVault
 
         protected virtual async Task WaitForReload()
         {
-            await Task.Delay(_reloadInterval.Value.TotalMilliseconds, _cancellationToken.Token);
+            await Task.Delay(_reloadInterval.Value, _cancellationToken.Token);
         }
 
         private async Task LoadAsync()


### PR DESCRIPTION
`Milliseconds` returns the wrong, `TotalMilliseconds` should be used. But we can pass in the `TimeSpan` value directly as well.