### PR TITLE
Bring back required export jsCallDispatcher.findJSFunction

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -142,6 +142,14 @@ module DotNet {
    */
   export const jsCallDispatcher = {
     /**
+     * Finds the JavaScript function matching the specified identifier.
+     *
+     * @param identifier Identifies the globally-reachable function to be returned.
+     * @returns A Function instance.
+     */
+    findJSFunction, // Note that this is used by the JS interop code inside Mono WebAssembly itself
+
+    /**
      * Invokes the specified synchronous JavaScript function.
      *
      * @param identifier Identifies the globally-reachable function to invoke.


### PR DESCRIPTION
I got this wrong yesterday. I removed this export because I thought it was unused. In fact, it's not used from any code in the `extensions` or `aspnetcore` repos, but it *is* used by Mono WebAssembly itself.

I've added a comment now to clarify why this is required.