### PR TITLE
[JSInterop] Updates the JSInterop abstractions to better support logging and diagnostics.

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -19,7 +19,24 @@ module DotNet {
    * @param dispatcher An object that can dispatch calls from JavaScript to a .NET runtime.
    */
   export function attachDispatcher(dispatcher: DotNetCallDispatcher) {
+    if (!dispatcher) {
+      throw new Error("dispatcher can't be null or undefined.");
+    }
+
     dotNetDispatcher = dispatcher;
+    if (!(dotNetDispatcher.endInvokeDotNetFromJS)) {
+      // We didn't get a concrete implementation, so provide a default one
+      dotNetDispatcher.endInvokeDotNetFromJS = (asyncHandle: number, succeeded: boolean, resultOrError: any) => {
+        return getRequiredDispatcher().beginInvokeDotNetFromJS(
+          0,
+          'Microsoft.JSInterop',
+          'DotNetDispatcher.EndInvoke',
+          null,
+          succeeded ?
+            JSON.stringify([asyncHandle, succeeded, resultOrError], argReplacer) :
+            JSON.stringify([asyncHandle, succeeded, resultOrError]));
+      };
+    }
   }
 
   /**
@@ -75,7 +92,7 @@ module DotNet {
     try {
       const argsJson = JSON.stringify(args, argReplacer);
       getRequiredDispatcher().beginInvokeDotNetFromJS(asyncCallId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
-    } catch(ex) {
+    } catch (ex) {
       // Synchronous failure
       completePendingCall(asyncCallId, false, ex);
     }
@@ -116,7 +133,7 @@ module DotNet {
   export interface DotNetCallDispatcher {
     /**
      * Optional. If implemented, invoked by the runtime to perform a synchronous call to a .NET method.
-     * 
+     *
      * @param assemblyName The short name (without key/version or .dll extension) of the .NET assembly holding the method to invoke. The value may be null when invoking instance methods.
      * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
      * @param dotNetObjectId If given, the call will be to an instance method on the specified DotNetObject. Pass null or undefined to call static methods.
@@ -135,6 +152,15 @@ module DotNet {
      * @param argsJson JSON representation of arguments to pass to the method.
      */
     beginInvokeDotNetFromJS(callId: number, assemblyName: string | null, methodIdentifier: string, dotNetObjectId: number | null, argsJson: string): void;
+
+    /**
+     * Invoked by the runtime to begin an asynchronous call to a .NET method.
+     *
+     * @param callId A value identifying the asynchronous operation. This value should be passed back in a later call from .NET to JS.
+     * @param succeded Whether the operation succeeded or not.
+     * @param resultOrError The result or the error from the async operation.
+     */
+    endInvokeDotNetFromJS?(callId: number, succeeded: boolean, resultOrError: any): void;
   }
 
   /**
@@ -183,8 +209,8 @@ module DotNet {
         // On completion, dispatch result back to .NET
         // Not using "await" because it codegens a lot of boilerplate
         promise.then(
-          result => getRequiredDispatcher().beginInvokeDotNetFromJS(0, 'Microsoft.JSInterop', 'DotNetDispatcher.EndInvoke', null, JSON.stringify([asyncHandle, true, result], argReplacer)),
-          error => getRequiredDispatcher().beginInvokeDotNetFromJS(0, 'Microsoft.JSInterop', 'DotNetDispatcher.EndInvoke', null, JSON.stringify([asyncHandle, false, formatError(error)]))
+          result => getRequiredDispatcher().endInvokeDotNetFromJS!(asyncHandle, true, result),
+          error => getRequiredDispatcher().endInvokeDotNetFromJS!(asyncHandle, false, formatError(error))
         );
       }
     },
@@ -219,7 +245,7 @@ module DotNet {
       return error ? error.toString() : 'null';
     }
   }
-  
+
   function findJSFunction(identifier: string): Function {
     if (cachedJSFunctions.hasOwnProperty(identifier)) {
       return cachedJSFunctions[identifier];
@@ -247,7 +273,7 @@ module DotNet {
     }
   }
 
-  class DotNetObject {    
+  class DotNetObject {
     constructor(private _id: number) {
     }
 
@@ -268,14 +294,14 @@ module DotNet {
     }
 
     public serializeAsArg() {
-      return {__dotNetObject: this._id};
+      return { __dotNetObject: this._id };
     }
   }
 
   const dotNetObjectRefKey = '__dotNetObject';
   attachReviver(function reviveDotNetObject(key: any, value: any) {
     if (value && typeof value === 'object' && value.hasOwnProperty(dotNetObjectRefKey)) {
-        return new DotNetObject(value.__dotNetObject);
+      return new DotNetObject(value.__dotNetObject);
     }
 
     // Unrecognized - let another reviver handle it

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -139,7 +139,7 @@ module DotNet {
     /**
      * Invoked by the runtime to complete an asynchronous JavaScript function call started from .NET
      *
-     * @param callId A value identifying the asynchronous operation. This value should be passed back in a later call from .NET to JS.
+     * @param callId A value identifying the asynchronous operation.
      * @param succeded Whether the operation succeeded or not.
      * @param resultOrError The serialized result or the serialized error from the async operation.
      */

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -193,7 +193,7 @@ module DotNet {
         // Not using "await" because it codegens a lot of boilerplate
         promise.then(
           result => getRequiredDispatcher().endInvokeJSFromDotNet(asyncHandle, true, JSON.stringify([asyncHandle, true, result], argReplacer)),
-          error => getRequiredDispatcher().endInvokeJSFromDotNet(asyncHandle, false, JSON.stringify([asyncHandle, true, formatError(error)]))
+          error => getRequiredDispatcher().endInvokeJSFromDotNet(asyncHandle, false, JSON.stringify([asyncHandle, false, formatError(error)]))
         );
       }
     },

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -24,7 +24,7 @@ module DotNet {
     }
 
     dotNetDispatcher = dispatcher;
-    if (!(dotNetDispatcher.endInvokeDotNetFromJS)) {
+    if (!dotNetDispatcher.endInvokeDotNetFromJS) {
       // We didn't get a concrete implementation, so provide a default one
       dotNetDispatcher.endInvokeDotNetFromJS = (asyncHandle, succeeded, resultOrError, replacer) => {
         return getRequiredDispatcher().beginInvokeDotNetFromJS(

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -26,14 +26,14 @@ module DotNet {
     dotNetDispatcher = dispatcher;
     if (!(dotNetDispatcher.endInvokeDotNetFromJS)) {
       // We didn't get a concrete implementation, so provide a default one
-      dotNetDispatcher.endInvokeDotNetFromJS = (asyncHandle: number, succeeded: boolean, resultOrError: any) => {
+      dotNetDispatcher.endInvokeDotNetFromJS = (asyncHandle, succeeded, resultOrError, replacer) => {
         return getRequiredDispatcher().beginInvokeDotNetFromJS(
           0,
           'Microsoft.JSInterop',
           'DotNetDispatcher.EndInvoke',
           null,
           succeeded ?
-            JSON.stringify([asyncHandle, succeeded, resultOrError], argReplacer) :
+            JSON.stringify([asyncHandle, succeeded, resultOrError], replacer) :
             JSON.stringify([asyncHandle, succeeded, resultOrError]));
       };
     }
@@ -159,8 +159,9 @@ module DotNet {
      * @param callId A value identifying the asynchronous operation. This value should be passed back in a later call from .NET to JS.
      * @param succeded Whether the operation succeeded or not.
      * @param resultOrError The result or the error from the async operation.
+     * @param argReplacer A function that replaces [DotNetObject] references with the appropriate value during serialization.
      */
-    endInvokeDotNetFromJS?(callId: number, succeeded: boolean, resultOrError: any): void;
+    endInvokeDotNetFromJS?(callId: number, succeeded: boolean, resultOrError: any, argReplacer: (key: string, value: any) => any): void;
   }
 
   /**
@@ -209,8 +210,8 @@ module DotNet {
         // On completion, dispatch result back to .NET
         // Not using "await" because it codegens a lot of boilerplate
         promise.then(
-          result => getRequiredDispatcher().endInvokeDotNetFromJS!(asyncHandle, true, result),
-          error => getRequiredDispatcher().endInvokeDotNetFromJS!(asyncHandle, false, formatError(error))
+          result => getRequiredDispatcher().endInvokeDotNetFromJS!(asyncHandle, true, result, argReplacer),
+          error => getRequiredDispatcher().endInvokeDotNetFromJS!(asyncHandle, false, formatError(error), argReplacer)
         );
       }
     },

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -19,10 +19,6 @@ module DotNet {
    * @param dispatcher An object that can dispatch calls from JavaScript to a .NET runtime.
    */
   export function attachDispatcher(dispatcher: DotNetCallDispatcher) {
-    if (!dispatcher) {
-      throw new Error("dispatcher can't be null or undefined.");
-    }
-
     dotNetDispatcher = dispatcher;
   }
 

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
@@ -6,8 +6,7 @@ namespace Microsoft.JSInterop
     public static partial class DotNetDispatcher
     {
         public static void BeginInvoke(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson) { }
-        [Microsoft.JSInterop.JSInvokableAttribute("DotNetDispatcher.EndInvoke")]
-        public static void EndInvoke(long asyncHandle, bool succeeded, Microsoft.JSInterop.Internal.JSAsyncCallResult result) { }
+        public static void EndInvoke(string arguments) { }
         public static string Invoke(string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson) { throw null; }
         [Microsoft.JSInterop.JSInvokableAttribute("DotNetDispatcher.ReleaseDotNetObject")]
         public static void ReleaseDotNetObject(long dotNetObjectId) { }
@@ -62,9 +61,9 @@ namespace Microsoft.JSInterop
         protected JSRuntimeBase() { }
         protected System.TimeSpan? DefaultAsyncTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         protected abstract void BeginInvokeJS(long taskId, string identifier, string argsJson);
+        protected internal virtual void EndInvokeDotNet(string callId, bool success, object resultOrError, string assemblyName, string methodIdentifier, long dotNetObjectId) { }
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, System.Collections.Generic.IEnumerable<object> args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, params object[] args) { throw null; }
-        protected virtual object OnDotNetInvocationException(System.Exception exception, string assemblyName, string methodIdentifier) { throw null; }
     }
 }
 namespace Microsoft.JSInterop.Internal

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
@@ -66,11 +66,3 @@ namespace Microsoft.JSInterop
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, params object[] args) { throw null; }
     }
 }
-namespace Microsoft.JSInterop.Internal
-{
-    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    public sealed partial class JSAsyncCallResult
-    {
-        internal JSAsyncCallResult() { }
-    }
-}

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
@@ -61,7 +61,7 @@ namespace Microsoft.JSInterop
         protected JSRuntimeBase() { }
         protected System.TimeSpan? DefaultAsyncTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         protected abstract void BeginInvokeJS(long taskId, string identifier, string argsJson);
-        protected internal virtual void EndInvokeDotNet(string callId, bool success, object resultOrError, string assemblyName, string methodIdentifier, long dotNetObjectId) { }
+        protected internal abstract void EndInvokeDotNet(string callId, bool success, object resultOrError, string assemblyName, string methodIdentifier, long dotNetObjectId);
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, System.Collections.Generic.IEnumerable<object> args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.Task<T> InvokeAsync<T>(string identifier, params object[] args) { throw null; }
     }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -20,6 +20,7 @@ namespace Microsoft.JSInterop
     public static class DotNetDispatcher
     {
         internal const string DotNetObjectRefKey = nameof(DotNetObjectRef<object>.__dotNetObject);
+        private static readonly Type[] EndInvokeParameterTypes = new Type[] { typeof(long), typeof(bool), typeof(JSAsyncCallResult) };
 
         private static readonly ConcurrentDictionary<AssemblyKey, IReadOnlyDictionary<string, (MethodInfo, Type[])>> _cachedMethodsByAssembly
             = new ConcurrentDictionary<AssemblyKey, IReadOnlyDictionary<string, (MethodInfo, Type[])>>();
@@ -242,6 +243,19 @@ namespace Microsoft.JSInterop
                     item.TryGetProperty(DotNetObjectRefKey, out _) &&
                      !typeof(IDotNetObjectRef).IsAssignableFrom(parameterType);
             }
+        }
+
+        public static void EndInvoke(string arguments)
+        {
+            // We don't need to notify the client if a JS interop call fails to be processed on the server.
+            // The client needs to catch potential exceptions. We do it this way so that we can log errors
+            // processing the callback completion.
+            var parsedArgs = ParseArguments(
+                nameof(EndInvoke),
+                arguments,
+                EndInvokeParameterTypes);
+
+            EndInvoke((long)parsedArgs[0], (bool)parsedArgs[1], (JSAsyncCallResult)parsedArgs[2]);
         }
 
         /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -273,14 +273,6 @@ namespace Microsoft.JSInterop
             EndInvoke((long)parsedArgs[0], (bool)parsedArgs[1], (JSAsyncCallResult)parsedArgs[2]);
         }
 
-        /// <summary>
-        /// Receives notification that a call from .NET to JS has finished, marking the
-        /// associated <see cref="Task"/> as completed.
-        /// </summary>
-        /// <param name="asyncHandle">The identifier for the function invocation.</param>
-        /// <param name="succeeded">A flag to indicate whether the invocation succeeded.</param>
-        /// <param name="result">If <paramref name="succeeded"/> is <c>true</c>, specifies the invocation result. If <paramref name="succeeded"/> is <c>false</c>, gives the <see cref="Exception"/> corresponding to the invocation failure.</param>
-        [JSInvokable(nameof(DotNetDispatcher) + "." + nameof(EndInvoke))]
         private static void EndInvoke(long asyncHandle, bool succeeded, JSAsyncCallResult result)
             => ((JSRuntimeBase)JSRuntime.Current).EndInvokeJS(asyncHandle, succeeded, result);
 

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -245,6 +245,11 @@ namespace Microsoft.JSInterop
             }
         }
 
+        /// <summary>
+        /// Receives notification that a call from .NET to JS has finished, marking the
+        /// associated <see cref="Task"/> as completed.
+        /// </summary>
+        /// <param name="arguments">The serialized arguments for the callback completion.</param>
         public static void EndInvoke(string arguments)
         {
             // We don't need to notify the client if a JS interop call fails to be processed on the server.

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -105,7 +105,7 @@ namespace Microsoft.JSInterop
             else if (syncException != null)
             {
                 // Threw synchronously, let's respond.
-                jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, syncException, assemblyName, methodIdentifier);
+                jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, syncException, assemblyName, methodIdentifier, dotNetObjectId);
             }
             else if (syncResult is Task task)
             {
@@ -117,16 +117,16 @@ namespace Microsoft.JSInterop
                     {
                         var exception = t.Exception.GetBaseException();
 
-                        jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, ExceptionDispatchInfo.Capture(exception), assemblyName, methodIdentifier);
+                        jsRuntimeBaseInstance.EndInvokeDotNet(callId, false, ExceptionDispatchInfo.Capture(exception), assemblyName, methodIdentifier, dotNetObjectId);
                     }
 
                     var result = TaskGenericsUtil.GetTaskResult(task);
-                    jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, result, assemblyName, methodIdentifier);
+                    jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, result, assemblyName, methodIdentifier, dotNetObjectId);
                 }, TaskScheduler.Current);
             }
             else
             {
-                jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, syncResult, assemblyName, methodIdentifier);
+                jsRuntimeBaseInstance.EndInvokeDotNet(callId, true, syncResult, assemblyName, methodIdentifier, dotNetObjectId);
             }
         }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -8,9 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Microsoft.JSInterop.Internal;
 
 namespace Microsoft.JSInterop
 {

--- a/src/JSInterop/Microsoft.JSInterop/src/JSAsyncCallResult.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSAsyncCallResult.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.ComponentModel;
 using System.Text.Json;
 
-namespace Microsoft.JSInterop.Internal
+namespace Microsoft.JSInterop
 {
     // This type takes care of a special case in handling the result of an async call from
     // .NET to JS. The information about what type the result should be exists only on the
@@ -23,8 +22,7 @@ namespace Microsoft.JSInterop.Internal
     /// <summary>
     /// Intended for framework use only.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed class JSAsyncCallResult
+    internal sealed class JSAsyncCallResult
     {
         internal JSAsyncCallResult(JsonDocument document, JsonElement jsonElement)
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -9,7 +9,6 @@ using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.JSInterop.Internal;
 
 namespace Microsoft.JSInterop
 {

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -124,35 +124,37 @@ namespace Microsoft.JSInterop
         protected abstract void BeginInvokeJS(long taskId, string identifier, string argsJson);
 
         /// <summary>
-        /// Allows derived classes to configure the information about an exception in a JS interop call that gets sent to JavaScript.
+        /// Completes an async JS interop call from JavaScript to DotNet.
         /// </summary>
-        /// <remarks>
-        /// This callback can be used in remote JS interop scenarios to sanitize exceptions that happen on the server to avoid disclosing
-        /// sensitive information to remote browser clients.
-        /// </remarks>
-        /// <param name="exception">The exception that occurred.</param>
-        /// <param name="assemblyName">The assembly for the invoked .NET method.</param>
-        /// <param name="methodIdentifier">The identifier for the invoked .NET method.</param>
-        /// <returns>An object containing information about the exception.</returns>
-        protected virtual object OnDotNetInvocationException(Exception exception, string assemblyName, string methodIdentifier) => exception.ToString();
-
-        internal void EndInvokeDotNet(string callId, bool success, object resultOrException, string assemblyName, string methodIdentifier)
+        /// <param name="callId">The id of the JavaScript callback to execute on completion.</param>
+        /// <param name="success">Whether the operation succeeded or not.</param>
+        /// <param name="resultOrError">The result of the operation or an object containing error details.</param>
+        /// <param name="assemblyName">The name of the method assembly if the invocation was for a static method.</param>
+        /// <param name="methodIdentifier">The identifier for the method within the assembly.</param>
+        /// <param name="dotNetObjectId">The tracking id of the dotnet object if the invocation was for an instance method.</param>
+        protected internal virtual void EndInvokeDotNet(
+            string callId,
+            bool success,
+            object resultOrError,
+            string assemblyName,
+            string methodIdentifier,
+            long dotNetObjectId)
         {
             // For failures, the common case is to call EndInvokeDotNet with the Exception object.
             // For these we'll serialize as something that's useful to receive on the JS side.
             // If the value is not an Exception, we'll just rely on it being directly JSON-serializable.
-            if (!success && resultOrException is Exception ex)
+            if (!success && resultOrError is Exception ex)
             {
-                resultOrException = OnDotNetInvocationException(ex, assemblyName, methodIdentifier);
+                resultOrError = ex.ToString();
             }
-            else if (!success && resultOrException is ExceptionDispatchInfo edi)
+            else if (!success && resultOrError is ExceptionDispatchInfo edi)
             {
-                resultOrException = OnDotNetInvocationException(edi.SourceException, assemblyName, methodIdentifier);
+                resultOrError = edi.SourceException.ToString();
             }
 
             // We pass 0 as the async handle because we don't want the JS-side code to
             // send back any notification (we're just providing a result for an existing async call)
-            var args = JsonSerializer.Serialize(new[] { callId, success, resultOrException }, JsonSerializerOptionsProvider.Options);
+            var args = JsonSerializer.Serialize(new[] { callId, success, resultOrError }, JsonSerializerOptionsProvider.Options);
             BeginInvokeJS(0, "DotNet.jsCallDispatcher.endInvokeDotNetFromJS", args);
         }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -131,31 +131,13 @@ namespace Microsoft.JSInterop
         /// <param name="assemblyName">The name of the method assembly if the invocation was for a static method.</param>
         /// <param name="methodIdentifier">The identifier for the method within the assembly.</param>
         /// <param name="dotNetObjectId">The tracking id of the dotnet object if the invocation was for an instance method.</param>
-        protected internal virtual void EndInvokeDotNet(
+        protected internal abstract void EndInvokeDotNet(
             string callId,
             bool success,
             object resultOrError,
             string assemblyName,
             string methodIdentifier,
-            long dotNetObjectId)
-        {
-            // For failures, the common case is to call EndInvokeDotNet with the Exception object.
-            // For these we'll serialize as something that's useful to receive on the JS side.
-            // If the value is not an Exception, we'll just rely on it being directly JSON-serializable.
-            if (!success && resultOrError is Exception ex)
-            {
-                resultOrError = ex.ToString();
-            }
-            else if (!success && resultOrError is ExceptionDispatchInfo edi)
-            {
-                resultOrError = edi.SourceException.ToString();
-            }
-
-            // We pass 0 as the async handle because we don't want the JS-side code to
-            // send back any notification (we're just providing a result for an existing async call)
-            var args = JsonSerializer.Serialize(new[] { callId, success, resultOrError }, JsonSerializerOptionsProvider.Options);
-            BeginInvokeJS(0, "DotNet.jsCallDispatcher.endInvokeDotNetFromJS", args);
-        }
+            long dotNetObjectId);
 
         internal void EndInvokeJS(long taskId, bool succeeded, JSAsyncCallResult asyncCallResult)
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntimeBase.cs
@@ -124,7 +124,7 @@ namespace Microsoft.JSInterop
         protected abstract void BeginInvokeJS(long taskId, string identifier, string argsJson);
 
         /// <summary>
-        /// Completes an async JS interop call from JavaScript to DotNet.
+        /// Completes an async JS interop call from JavaScript to .NET
         /// </summary>
         /// <param name="callId">The id of the JavaScript callback to execute on completion.</param>
         /// <param name="success">Whether the operation succeeded or not.</param>

--- a/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
@@ -296,23 +297,18 @@ namespace Microsoft.JSInterop.Tests
             var resultTask = jsRuntime.NextInvocationTask;
             DotNetDispatcher.BeginInvoke(callId, null, "InvokableAsyncMethod", 1, argsJson);
             await resultTask;
-            var result = JsonDocument.Parse(jsRuntime.LastInvocationArgsJson).RootElement;
-            var resultValue = result[2];
 
-            // Assert: Correct info to complete the async call
-            Assert.Equal(0, jsRuntime.LastInvocationAsyncHandle); // 0 because it doesn't want a further callback from JS to .NET
-            Assert.Equal("DotNet.jsCallDispatcher.endInvokeDotNetFromJS", jsRuntime.LastInvocationIdentifier);
-            Assert.Equal(3, result.GetArrayLength());
-            Assert.Equal(callId, result[0].GetString());
-            Assert.True(result[1].GetBoolean()); // Success flag
+            // Assert: Correct completion information
+            Assert.Equal(callId, jsRuntime.LastCompletionCallId);
+            Assert.True(jsRuntime.LastCompletionStatus);
+            var result = Assert.IsType<object []>(jsRuntime.LastCompletionResult);
+            var resultDto1 = Assert.IsType<TestDTO>(result[0]);
 
-            // Assert: First result value marshalled via JSON
-            var resultDto1 = JsonSerializer.Deserialize<TestDTO>(resultValue[0].GetRawText(), JsonSerializerOptionsProvider.Options);
             Assert.Equal("STRING VIA JSON", resultDto1.StringVal);
             Assert.Equal(2000, resultDto1.IntVal);
 
             // Assert: Second result value marshalled by ref
-            var resultDto2Ref = JsonSerializer.Deserialize<DotNetObjectRef<TestDTO>>(resultValue[1].GetRawText(), JsonSerializerOptionsProvider.Options);
+            var resultDto2Ref = Assert.IsType<DotNetObjectRef<TestDTO>>(result[1]);
             var resultDto2 = resultDto2Ref.Value;
             Assert.Equal("MY STRING", resultDto2.StringVal);
             Assert.Equal(2468, resultDto2.IntVal);
@@ -331,13 +327,12 @@ namespace Microsoft.JSInterop.Tests
             await resultTask; // This won't throw, it sets properties on the jsRuntime.
 
             // Assert
-            var result = JsonDocument.Parse(jsRuntime.LastInvocationArgsJson).RootElement;
-            Assert.Equal(callId, result[0].GetString());
-            Assert.False(result[1].GetBoolean()); // Fails
+            Assert.Equal(callId, jsRuntime.LastCompletionCallId);
+            Assert.False(jsRuntime.LastCompletionStatus); // Fails
 
             // Make sure the method that threw the exception shows up in the call stack
             // https://github.com/aspnet/AspNetCore/issues/8612
-            var exception = result[2].GetString();
+            var exception = jsRuntime.LastCompletionResult is ExceptionDispatchInfo edi ? edi.SourceException.ToString() : null;
             Assert.Contains(nameof(ThrowingClass.ThrowingMethod), exception);
         });
 
@@ -354,13 +349,12 @@ namespace Microsoft.JSInterop.Tests
             await resultTask; // This won't throw, it sets properties on the jsRuntime.
 
             // Assert
-            var result = JsonDocument.Parse(jsRuntime.LastInvocationArgsJson).RootElement;
-            Assert.Equal(callId, result[0].GetString());
-            Assert.False(result[1].GetBoolean()); // Fails
+            Assert.Equal(callId, jsRuntime.LastCompletionCallId);
+            Assert.False(jsRuntime.LastCompletionStatus); // Fails
 
             // Make sure the method that threw the exception shows up in the call stack
             // https://github.com/aspnet/AspNetCore/issues/8612
-            var exception = result[2].GetString();
+            var exception = jsRuntime.LastCompletionResult is ExceptionDispatchInfo edi ? edi.SourceException.ToString() : null;
             Assert.Contains(nameof(ThrowingClass.AsyncThrowingMethod), exception);
         });
 
@@ -375,11 +369,10 @@ namespace Microsoft.JSInterop.Tests
             await resultTask; // This won't throw, it sets properties on the jsRuntime.
 
             // Assert
-            using var jsonDocument = JsonDocument.Parse(jsRuntime.LastInvocationArgsJson);
-            var result = jsonDocument.RootElement;
-            Assert.Equal(callId, result[0].GetString());
-            Assert.False(result[1].GetBoolean()); // Fails
-            Assert.Contains("JsonReaderException: '<' is an invalid start of a value.", result[2].GetString());
+            Assert.Equal(callId, jsRuntime.LastCompletionCallId);
+            Assert.False(jsRuntime.LastCompletionStatus); // Fails
+            var result = Assert.IsType<ExceptionDispatchInfo>(jsRuntime.LastCompletionResult);
+            Assert.Contains("JsonReaderException: '<' is an invalid start of a value.", result.SourceException.ToString());
         });
 
         [Fact]
@@ -391,12 +384,10 @@ namespace Microsoft.JSInterop.Tests
             DotNetDispatcher.BeginInvoke(callId, null, "InvokableInstanceVoid", 1, null);
 
             // Assert
-            using var jsonDocument = JsonDocument.Parse(jsRuntime.LastInvocationArgsJson);
-            var result = jsonDocument.RootElement;
-            Assert.Equal(callId, result[0].GetString());
-            Assert.False(result[1].GetBoolean()); // Fails
-
-            Assert.StartsWith("System.ArgumentException: There is no tracked object with id '1'. Perhaps the DotNetObjectRef instance was already disposed.", result[2].GetString());
+            Assert.Equal(callId, jsRuntime.LastCompletionCallId);
+            Assert.False(jsRuntime.LastCompletionStatus); // Fails
+            var result = Assert.IsType<ExceptionDispatchInfo>(jsRuntime.LastCompletionResult);
+            Assert.StartsWith("System.ArgumentException: There is no tracked object with id '1'. Perhaps the DotNetObjectRef instance was already disposed.", result.SourceException.ToString());
         });
 
         Task WithJSRuntime(Action<TestJSRuntime> testCode)
@@ -557,6 +548,10 @@ namespace Microsoft.JSInterop.Tests
             public string LastInvocationIdentifier { get; private set; }
             public string LastInvocationArgsJson { get; private set; }
 
+            public string LastCompletionCallId { get; private set; }
+            public bool LastCompletionStatus { get; private set; }
+            public object LastCompletionResult { get; private set; }
+
             protected override void BeginInvokeJS(long asyncHandle, string identifier, string argsJson)
             {
                 LastInvocationAsyncHandle = asyncHandle;
@@ -584,17 +579,11 @@ namespace Microsoft.JSInterop.Tests
                 string methodIdentifier,
                 long dotNetObjectId)
             {
-                if (!success && resultOrError is Exception ex)
-                {
-                    resultOrError = ex.ToString();
-                }
-                else if (!success && resultOrError is ExceptionDispatchInfo edi)
-                {
-                    resultOrError = edi.SourceException.ToString();
-                }
-
-                var args = JsonSerializer.Serialize(new[] { callId, success, resultOrError }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-                BeginInvokeJS(0, "DotNet.jsCallDispatcher.endInvokeDotNetFromJS", args);
+                LastCompletionCallId = callId;
+                LastCompletionStatus = success;
+                LastCompletionResult = resultOrError;
+                _nextInvocationTcs.SetResult(null);
+                _nextInvocationTcs = new TaskCompletionSource<object>();
             }
         }
     }

--- a/src/JSInterop/Microsoft.JSInterop/test/DotNetObjectRefTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/DotNetObjectRefTest.cs
@@ -37,6 +37,11 @@ namespace Microsoft.JSInterop.Tests
             {
                 throw new NotImplementedException();
             }
+
+            protected internal override void EndInvokeDotNet(string callId, bool success, object resultOrError, string assemblyName, string methodIdentifier, long dotNetObjectId)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         async Task WithJSRuntime(Action<JSRuntimeBase> testCode)

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessRuntimeBaseTest.cs
@@ -115,6 +115,9 @@ namespace Microsoft.JSInterop.Tests
 
             protected override void BeginInvokeJS(long asyncHandle, string identifier, string argsJson)
                 => throw new NotImplementedException("This test only covers sync calls");
+
+            protected internal override void EndInvokeDotNet(string callId, bool success, object resultOrError, string assemblyName, string methodIdentifier, long dotNetObjectId) =>
+                throw new NotImplementedException("This test only covers sync calls");
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.JSInterop.Internal;
 using Xunit;
 
 namespace Microsoft.JSInterop.Tests

--- a/src/JSInterop/Mono.WebAssembly.Interop/ref/Mono.WebAssembly.Interop.netstandard2.0.cs
+++ b/src/JSInterop/Mono.WebAssembly.Interop/ref/Mono.WebAssembly.Interop.netstandard2.0.cs
@@ -7,6 +7,7 @@ namespace Mono.WebAssembly.Interop
     {
         public MonoWebAssemblyJSRuntime() { }
         protected override void BeginInvokeJS(long asyncHandle, string identifier, string argsJson) { }
+        protected override void EndInvokeDotNet(string callId, bool success, object resultOrError, string assemblyName, string methodIdentifier, long dotNetObjectId) { }
         protected override string InvokeJS(string identifier, string argsJson) { throw null; }
         public TRes InvokeUnmarshalled<TRes>(string identifier) { throw null; }
         public TRes InvokeUnmarshalled<T0, TRes>(string identifier, T0 arg0) { throw null; }

--- a/src/JSInterop/Mono.WebAssembly.Interop/src/MonoWebAssemblyJSRuntime.cs
+++ b/src/JSInterop/Mono.WebAssembly.Interop/src/MonoWebAssemblyJSRuntime.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Runtime.ExceptionServices;
+using System.Text.Json;
 using Microsoft.JSInterop;
 using WebAssembly.JSInterop;
 
@@ -56,6 +59,32 @@ namespace Mono.WebAssembly.Interop
             }
 
             DotNetDispatcher.BeginInvoke(callId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
+        }
+
+        protected override void EndInvokeDotNet(
+            string callId,
+            bool success,
+            object resultOrError,
+            string assemblyName,
+            string methodIdentifier,
+            long dotNetObjectId)
+        {
+            // For failures, the common case is to call EndInvokeDotNet with the Exception object.
+            // For these we'll serialize as something that's useful to receive on the JS side.
+            // If the value is not an Exception, we'll just rely on it being directly JSON-serializable.
+            if (!success && resultOrError is Exception ex)
+            {
+                resultOrError = ex.ToString();
+            }
+            else if (!success && resultOrError is ExceptionDispatchInfo edi)
+            {
+                resultOrError = edi.SourceException.ToString();
+            }
+
+            // We pass 0 as the async handle because we don't want the JS-side code to
+            // send back any notification (we're just providing a result for an existing async call)
+            var args = JsonSerializer.Serialize(new[] { callId, success, resultOrError }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            BeginInvokeJS(0, "DotNet.jsCallDispatcher.endInvokeDotNetFromJS", args);
         }
 
         #region Custom MonoWebAssemblyJSRuntime methods

--- a/src/JSInterop/Mono.WebAssembly.Interop/src/MonoWebAssemblyJSRuntime.cs
+++ b/src/JSInterop/Mono.WebAssembly.Interop/src/MonoWebAssemblyJSRuntime.cs
@@ -33,6 +33,10 @@ namespace Mono.WebAssembly.Interop
             => DotNetDispatcher.Invoke(assemblyName, methodIdentifier, dotNetObjectId == null ? default : long.Parse(dotNetObjectId), argsJson);
 
         // Invoked via Mono's JS interop mechanism (invoke_method)
+        private static void EndInvokeJS(string argsJson)
+            => DotNetDispatcher.EndInvoke(argsJson);
+
+        // Invoked via Mono's JS interop mechanism (invoke_method)
         private static void BeginInvokeDotNet(string callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
         {
             // Figure out whether 'assemblyNameOrDotNetObjectId' is the assembly name or the instance ID


### PR DESCRIPTION
This PR is related to https://github.com/aspnet/AspNetCore/pull/12182. See that PR for more context on the practical applications of these changes.

* Allows the server to directly dispatch completions from a method hub by calling EndInvoke directly.
  * The client is responsible for handling exceptions thrown by this method.
  * We do it this way so that the server can log issues delivering the exception.
* Allows the server to better log completions for JS -> .NET async calls by overriding EndInvokeDotNet.
  * Removes the need for a specific endpoint to sanitize .NET exceptions.