### PR TITLE
Wait for host to shutdown before marking service stopped

### DIFF
--- a/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs
+++ b/src/Hosting/WindowsServices/ref/Microsoft.Extensions.Hosting.WindowsServices.netstandard2.0.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
     }
     public partial class WindowsServiceLifetime : System.ServiceProcess.ServiceBase, Microsoft.Extensions.Hosting.IHostLifetime
     {
-        public WindowsServiceLifetime(Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public WindowsServiceLifetime(Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Hosting.HostOptions> optionsAccessor) { }
+        protected override void Dispose(bool disposing) { }
         protected override void OnStart(string[] args) { }
         protected override void OnStop() { }
         public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/src/Hosting/WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceLifetime.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
 {
     public class WindowsServiceLifetime : ServiceBase, IHostLifetime
     {
-        private readonly TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ManualResetEventSlim _delayStop = new ManualResetEventSlim();
 
         public WindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory)

--- a/src/Hosting/WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/Hosting/WindowsServices/src/WindowsServiceLifetime.cs
@@ -87,14 +87,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         {
             ApplicationLifetime.StopApplication();
             // Wait for the host to shutdown before marking service as stopped.
-            if (_hostOptions == null)
-            {
-                _delayStop.Wait();
-            }
-            else
-            {
-                _delayStop.Wait(_hostOptions.ShutdownTimeout);
-            }
+            _delayStop.Wait(_hostOptions.ShutdownTimeout);
             base.OnStop();
         }
 


### PR DESCRIPTION
When the ApplicationStopping event is fired (either by SCM or the application), transition the service to StopPending. Then, wait in OnStop() until ApplicationStopped is fired, to keep the service in the StopPending state.

Task.Run is used in ApplicationStopping to avoid a deadlock because it waits for ApplicationStopped.

Addresses #1323 
