### PR TITLE
Correct GetHashCode behavior for StringValues

### DIFF
--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 if (Count == 1)
                 {
-                    return values[0].GetHashCode();
+                    return Unsafe.As<string>(this[0])?.GetHashCode() ?? 0;
                 }
                 var hcc = new HashCodeCombiner();
                 for (var i = 0; i < values.Length; i++)

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Extensions.Primitives
             {
                 if (Count == 1)
                 {
-                    return Unsafe.As<string>(this[0])?.GetHashCode() ?? 0;
+                    return Unsafe.As<string>(this[0])?.GetHashCode() ?? Count.GetHashCode();
                 }
                 var hcc = new HashCodeCombiner();
                 for (var i = 0; i < values.Length; i++)
@@ -600,7 +600,7 @@ namespace Microsoft.Extensions.Primitives
             }
             else
             {
-                return Unsafe.As<string>(value)?.GetHashCode() ?? 0;
+                return Unsafe.As<string>(value)?.GetHashCode() ?? Count.GetHashCode();
             }
         }
 

--- a/src/Primitives/src/StringValues.cs
+++ b/src/Primitives/src/StringValues.cs
@@ -587,6 +587,10 @@ namespace Microsoft.Extensions.Primitives
             var value = _values;
             if (value is string[] values)
             {
+                if (Count == 1)
+                {
+                    return values[0].GetHashCode();
+                }
                 var hcc = new HashCodeCombiner();
                 for (var i = 0; i < values.Length; i++)
                 {

--- a/src/Primitives/test/StringValuesTests.cs
+++ b/src/Primitives/test/StringValuesTests.cs
@@ -231,12 +231,16 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        public void GetHashCode_NullVsArrayWithNullItem_DifferentHashCodes()
+        public void GetHashCode_NullCases_DifferentHashCodes()
         {
             var sv1 = new StringValues((string)null);
             var sv2 = new StringValues(new[] { (string)null });
             Assert.NotEqual(sv1, sv2);
-            Assert.Equal(sv1.GetHashCode(), sv2.GetHashCode());
+            Assert.NotEqual(sv1.GetHashCode(), sv2.GetHashCode());
+
+            var sv3 = new StringValues((string[])null);
+            Assert.Equal(sv1, sv3);
+            Assert.Equal(sv1.GetHashCode(), sv3.GetHashCode());
         }
 
         [Fact]

--- a/src/Primitives/test/StringValuesTests.cs
+++ b/src/Primitives/test/StringValuesTests.cs
@@ -222,6 +222,24 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        public void GetHashCode_SingleValueVsArrayWithOneItem_SameHashCode()
+        {
+            var sv1 = new StringValues("value");
+            var sv2 = new StringValues(new[] { "value" });
+            Assert.True(sv1.Equals(sv2));
+            Assert.Equal(sv1.GetHashCode(), sv2.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_SingleValueVsArrayWithTwoItems_DifferentHashCodes()
+        {
+            var sv1 = new StringValues("value");
+            var sv2 = new StringValues(new[] { "value", "value" });
+            Assert.False(sv1.Equals(sv2));
+            Assert.NotEqual(sv1.GetHashCode(), sv2.GetHashCode());
+        }
+
+        [Fact]
         public void ImplicitStringArrayConverter_Works()
         {
             string[] nullStringArray = null;

--- a/src/Primitives/test/StringValuesTests.cs
+++ b/src/Primitives/test/StringValuesTests.cs
@@ -542,6 +542,9 @@ namespace Microsoft.Extensions.Primitives
 
             Assert.True(StringValues.Equals(stringValues, expected));
             Assert.False(StringValues.Equals(stringValues, notEqual));
+
+            Assert.True(StringValues.Equals(stringValues, new StringValues(expected)));
+            Assert.Equal(stringValues.GetHashCode(), new StringValues(expected).GetHashCode());
         }
 
         [Theory]
@@ -552,6 +555,9 @@ namespace Microsoft.Extensions.Primitives
 
             Assert.True(StringValues.Equals(stringValues, expected));
             Assert.False(StringValues.Equals(stringValues, notEqual));
+
+            Assert.True(StringValues.Equals(stringValues, new StringValues(expected)));
+            Assert.Equal(stringValues.GetHashCode(), new StringValues(expected).GetHashCode());
         }
     }
 }

--- a/src/Primitives/test/StringValuesTests.cs
+++ b/src/Primitives/test/StringValuesTests.cs
@@ -226,7 +226,16 @@ namespace Microsoft.Extensions.Primitives
         {
             var sv1 = new StringValues("value");
             var sv2 = new StringValues(new[] { "value" });
-            Assert.True(sv1.Equals(sv2));
+            Assert.Equal(sv1, sv2);
+            Assert.Equal(sv1.GetHashCode(), sv2.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_NullVsArrayWithNullItem_DifferentHashCodes()
+        {
+            var sv1 = new StringValues((string)null);
+            var sv2 = new StringValues(new[] { (string)null });
+            Assert.NotEqual(sv1, sv2);
             Assert.Equal(sv1.GetHashCode(), sv2.GetHashCode());
         }
 
@@ -235,7 +244,7 @@ namespace Microsoft.Extensions.Primitives
         {
             var sv1 = new StringValues("value");
             var sv2 = new StringValues(new[] { "value", "value" });
-            Assert.False(sv1.Equals(sv2));
+            Assert.NotEqual(sv1, sv2);
             Assert.NotEqual(sv1.GetHashCode(), sv2.GetHashCode());
         }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Single value hashcode should return same value as
a Single item array with that same value

Addresses #953

cc: @anurse 