### PR TITLE
Fix #2044 by updating doc comment

### DIFF
--- a/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
+++ b/src/Hosting/Abstractions/src/IHostApplicationLifetime.cs
@@ -6,7 +6,7 @@ using System.Threading;
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
-    /// Allows consumers to be notified of application lifetime events.
+    /// Allows consumers to be notified of application lifetime events. This interface is not intended to be user-replaceable.
     /// </summary>
     public interface IHostApplicationLifetime
     {


### PR DESCRIPTION
Fixes #2044.

On that thread, the conclusion was that the interface isn't really intended to be user-replaceable, so we should update docs to show that.

cc @davidmatson