### PR TITLE
Move exception to setter for UsePollingFileWatcher

### DIFF
--- a/src/FileProviders/Physical/src/PhysicalFileProvider.cs
+++ b/src/FileProviders/Physical/src/PhysicalFileProvider.cs
@@ -84,16 +84,19 @@ namespace Microsoft.Extensions.FileProviders
         /// </value>
         public bool UsePollingFileWatcher
         {
-            get => _usePollingFileWatcher ?? false;
+            get
+            {
+                if (_usePollingFileWatcher == null)
+                {
+                    ReadPollingEnvironmentVariables();
+                }
+                return _usePollingFileWatcher ?? false;;
+            }
             set
             {
                 if (_fileWatcher != null)
                 {
                     throw new InvalidOperationException($"Cannot modify {nameof(UsePollingFileWatcher)} once file watcher has been initialized.");
-                }
-                if (_usePollingFileWatcher == null)
-                {
-                    ReadPollingEnvironmentVariables();
                 }
                 _usePollingFileWatcher = value;
             }

--- a/src/FileProviders/Physical/src/PhysicalFileProvider.cs
+++ b/src/FileProviders/Physical/src/PhysicalFileProvider.cs
@@ -84,21 +84,19 @@ namespace Microsoft.Extensions.FileProviders
         /// </value>
         public bool UsePollingFileWatcher
         {
-            get
+            get => _usePollingFileWatcher ?? false;
+            set
             {
                 if (_fileWatcher != null)
                 {
                     throw new InvalidOperationException($"Cannot modify {nameof(UsePollingFileWatcher)} once file watcher has been initialized.");
                 }
-
                 if (_usePollingFileWatcher == null)
                 {
                     ReadPollingEnvironmentVariables();
                 }
-
-                return _usePollingFileWatcher.Value;
+                _usePollingFileWatcher = value;
             }
-            set => _usePollingFileWatcher = value;
         }
 
         /// <summary>

--- a/src/FileProviders/Physical/src/PhysicalFileProvider.cs
+++ b/src/FileProviders/Physical/src/PhysicalFileProvider.cs
@@ -86,11 +86,15 @@ namespace Microsoft.Extensions.FileProviders
         {
             get
             {
+                if (_fileWatcher != null)
+                {
+                    return false;
+                }
                 if (_usePollingFileWatcher == null)
                 {
                     ReadPollingEnvironmentVariables();
                 }
-                return _usePollingFileWatcher ?? false;;
+                return _usePollingFileWatcher ?? false;
             }
             set
             {

--- a/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
+++ b/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
@@ -1379,6 +1379,63 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
+        public void UsePollingFileWatcher_FileWatcherNull_SetsSuccessfully()
+        {
+            // Arrange
+            using (var root = new DisposableFileSystem())
+            {
+                using (var provider = new PhysicalFileProvider(root.RootPath))
+                {
+                    Assert.False(provider.UsePollingFileWatcher);
+
+                    // Act / Assert
+                    provider.UsePollingFileWatcher = true;
+                    Assert.True(provider.UsePollingFileWatcher);
+                }
+            }
+        }
+
+        [Fact]
+        public void UsePollingFileWatcher_FileWatcherNotNull_SetterThrows()
+        {
+            // Arrange
+            using (var root = new DisposableFileSystem())
+            {
+                using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
+                {
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    {
+                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
+                        {
+                            // Act / Assert
+                            Assert.Throws<InvalidOperationException>(() => { provider.UsePollingFileWatcher = true; });
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void UsePollingFileWatcher_FileWatcherNotNull_GetterEfzUp()
+        {
+            // Arrange
+            using (var root = new DisposableFileSystem())
+            {
+                using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
+                {
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    {
+                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
+                        {
+                            // Act / Assert
+                            Assert.False(provider.UsePollingFileWatcher);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public void CreateFileWatcher_CreatesWatcherWithPollingAndActiveFlags()
         {
             // Arrange

--- a/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
+++ b/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
@@ -1416,6 +1416,26 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
+        public void UsePollingFileWatcher_FileWatcherNotNull_ReturnsFalse()
+        {
+            // Arrange
+            using (var root = new DisposableFileSystem())
+            {
+                using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
+                {
+                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
+                    {
+                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
+                        {
+                            // Act / Assert
+                            Assert.False(provider.UsePollingFileWatcher);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public void CreateFileWatcher_CreatesWatcherWithPollingAndActiveFlags()
         {
             // Arrange

--- a/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
+++ b/src/FileProviders/Physical/test/PhysicalFileProviderTests.cs
@@ -1416,26 +1416,6 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
-        public void UsePollingFileWatcher_FileWatcherNotNull_GetterEfzUp()
-        {
-            // Arrange
-            using (var root = new DisposableFileSystem())
-            {
-                using (var fileSystemWatcher = new MockFileSystemWatcher(root.RootPath))
-                {
-                    using (var physicalFilesWatcher = new PhysicalFilesWatcher(root.RootPath + Path.DirectorySeparatorChar, fileSystemWatcher, pollForChanges: false))
-                    {
-                        using (var provider = new PhysicalFileProvider(root.RootPath) { FileWatcher = physicalFilesWatcher })
-                        {
-                            // Act / Assert
-                            Assert.False(provider.UsePollingFileWatcher);
-                        }
-                    }
-                }
-            }
-        }
-
-        [Fact]
         public void CreateFileWatcher_CreatesWatcherWithPollingAndActiveFlags()
         {
             // Arrange


### PR DESCRIPTION
Getters on properties shouldn't throw exceptions.

 - Moves exception to setter for UsePollingFileWatcher

Addresses #561

cc: @anurse 