### PR TITLE
Making 'AddHttpClient()' register default client in DI as 'HttpClient'

### DIFF
--- a/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Extensions.DependencyInjection
             // because we access it by reaching into the service collection.
             services.TryAddSingleton(new HttpClientMappingRegistry());
 
+            //Register default client as HttpClient
+            services.AddTransient(s =>
+            {
+                return s.GetRequiredService<IHttpClientFactory>().CreateClient(string.Empty);
+            });
+
             return services;
         }
 

--- a/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/HttpClientFactory/Http/test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -62,6 +62,22 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.NotNull(handler);
         }
 
+        [Fact] // Verifies that AddHttpClient registers a default client
+        public void AddHttpClient_RegistersDefaultClientAsHttpClient()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act
+            serviceCollection.AddHttpClient();
+
+            var services = serviceCollection.BuildServiceProvider();
+            var client = services.GetRequiredService<HttpClient>();
+
+            // Assert
+            Assert.NotNull(client);
+        }
+
         [Fact]
         public void AddHttpClient_WithDefaultName_ConfiguresDefaultClient()
         {


### PR DESCRIPTION
AddHttpClient() now registers a default client in DI as HttpClient by default.
Added test.

Addresses #2023
