### PR TITLE
Fix build break by using API that's available across net472 and netcoreapp3.0

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/DotNetDispatcherTest.cs
@@ -250,7 +250,7 @@ namespace Microsoft.JSInterop
             DotNetDispatcher.EndInvoke(argsJson);
 
             // Assert
-            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCompleted && task.Status == TaskStatus.RanToCompletion);
             var result = task.Result;
             Assert.Equal(testDTO.StringVal, result.StringVal);
             Assert.Equal(testDTO.IntVal, result.IntVal);
@@ -597,7 +597,7 @@ namespace Microsoft.JSInterop
 
             DotNetDispatcher.ParseEndInvokeArguments(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, {{\"intVal\": 7}}]");
 
-            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCompleted && task.Status == TaskStatus.RanToCompletion);
             Assert.Equal(7, task.Result.IntVal);
         }
 
@@ -609,7 +609,7 @@ namespace Microsoft.JSInterop
 
             DotNetDispatcher.ParseEndInvokeArguments(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, [1, 2, 3]]");
 
-            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCompleted && task.Status == TaskStatus.RanToCompletion);
             Assert.Equal(new[] { 1, 2, 3 }, task.Result);
         }
 
@@ -621,7 +621,7 @@ namespace Microsoft.JSInterop
 
             DotNetDispatcher.ParseEndInvokeArguments(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, null]");
 
-            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCompleted && task.Status == TaskStatus.RanToCompletion);
             Assert.Null(task.Result);
         }
 

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.JSInterop
 
             runtime.EndInvokeJS(2, succeeded: true, ref reader);
 
-            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCompleted && task.Status == TaskStatus.RanToCompletion);
         }
 
         [Fact]


### PR DESCRIPTION
Fixing break by #2090. I'm not sure why the original PR built cleanly though.