### PR TITLE
Update documentation for IHttpClientFactory

### DIFF
--- a/src/HttpClientFactory/Http/src/IHttpClientFactory.cs
+++ b/src/HttpClientFactory/Http/src/IHttpClientFactory.cs
@@ -25,12 +25,8 @@ namespace System.Net.Http
         /// <remarks>
         /// <para>
         /// Each call to <see cref="CreateClient(string)"/> is guaranteed to return a new <see cref="HttpClient"/>
-        /// instance. Callers may cache the returned <see cref="HttpClient"/> instance indefinitely or surround
-        /// its use in a <langword>using</langword> block to dispose it when desired.
-        /// </para>
-        /// <para>
-        /// The default <see cref="IHttpClientFactory"/> implementation may cache the underlying
-        /// <see cref="HttpMessageHandler"/> instances to improve performance.
+        /// instance. It is generally not necessary to dispose of the <see cref="HttpClient"/> as the
+        /// <see cref="IHttpClientFactory"/> tracks and disposes resources used by the <see cref="HttpClient"/>.
         /// </para>
         /// <para>
         /// Callers are also free to mutate the returned <see cref="HttpClient"/> instance's public properties


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - IHttpClientFactory XML docs don't match documentation suggestions
 - Change incorporates suggestions in documentation