### PR TITLE
Fix unintended breaking change

### DIFF
--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-
+    <NuspecProperty Include="AssemblyName=$(AssemblyName)" />
     <NuspecProperty Include="OutputBinary=$(OutputPath)**\$(AssemblyName).dll" />
     <NuspecProperty Include="OutputSymbol=$(OutputPath)**\$(AssemblyName).pdb" />
     <NuspecProperty Include="OutputDocumentation=$(OutputPath)**\$(AssemblyName).xml" />


### PR DESCRIPTION
- blocking aspnet/AspNetCore#1293 dependency update PR
- commit 3ec8c35e450c lost `AssemblyName` substitution
  - tasks assembly in package incorrectly named ".Manifest.Task.dll"