### PR TITLE
Remove internal new() constraints from options infrastructure

### DIFF
--- a/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
+++ b/src/Options/Options/ref/Microsoft.Extensions.Options.netstandard2.0.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Options
         string Name { get; }
         Microsoft.Extensions.Primitives.IChangeToken GetChangeToken();
     }
-    public partial interface IOptionsFactory<TOptions> where TOptions : class, new()
+    public partial interface IOptionsFactory<TOptions> where TOptions : class
     {
         TOptions Create(string name);
     }
@@ -120,11 +120,11 @@ namespace Microsoft.Extensions.Options
         TOptions Get(string name);
         System.IDisposable OnChange(System.Action<TOptions, string> listener);
     }
-    public partial interface IOptionsSnapshot<out TOptions> : Microsoft.Extensions.Options.IOptions<TOptions> where TOptions : class, new()
+    public partial interface IOptionsSnapshot<out TOptions> : Microsoft.Extensions.Options.IOptions<TOptions> where TOptions : class
     {
         TOptions Get(string name);
     }
-    public partial interface IOptions<out TOptions> where TOptions : class, new()
+    public partial interface IOptions<out TOptions> where TOptions : class
     {
         TOptions Value { get; }
     }
@@ -139,7 +139,7 @@ namespace Microsoft.Extensions.Options
     public static partial class Options
     {
         public static readonly string DefaultName;
-        public static Microsoft.Extensions.Options.IOptions<TOptions> Create<TOptions>(TOptions options) where TOptions : class, new() { throw null; }
+        public static Microsoft.Extensions.Options.IOptions<TOptions> Create<TOptions>(TOptions options) where TOptions : class { throw null; }
     }
     public partial class OptionsBuilder<TOptions> where TOptions : class
     {
@@ -179,13 +179,14 @@ namespace Microsoft.Extensions.Options
         public virtual bool TryAdd(string name, TOptions options) { throw null; }
         public virtual bool TryRemove(string name) { throw null; }
     }
-    public partial class OptionsFactory<TOptions> : Microsoft.Extensions.Options.IOptionsFactory<TOptions> where TOptions : class, new()
+    public partial class OptionsFactory<TOptions> : Microsoft.Extensions.Options.IOptionsFactory<TOptions> where TOptions : class
     {
         public OptionsFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IConfigureOptions<TOptions>> setups, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IPostConfigureOptions<TOptions>> postConfigures) { }
         public OptionsFactory(System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IConfigureOptions<TOptions>> setups, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IPostConfigureOptions<TOptions>> postConfigures, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IValidateOptions<TOptions>> validations) { }
         public TOptions Create(string name) { throw null; }
+        protected virtual TOptions CreateInstance(string name) { throw null; }
     }
-    public partial class OptionsManager<TOptions> : Microsoft.Extensions.Options.IOptions<TOptions>, Microsoft.Extensions.Options.IOptionsSnapshot<TOptions> where TOptions : class, new()
+    public partial class OptionsManager<TOptions> : Microsoft.Extensions.Options.IOptions<TOptions>, Microsoft.Extensions.Options.IOptionsSnapshot<TOptions> where TOptions : class
     {
         public OptionsManager(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory) { }
         public TOptions Value { get { throw null; } }
@@ -195,7 +196,7 @@ namespace Microsoft.Extensions.Options
     {
         public static System.IDisposable OnChange<TOptions>(this Microsoft.Extensions.Options.IOptionsMonitor<TOptions> monitor, System.Action<TOptions> listener) { throw null; }
     }
-    public partial class OptionsMonitor<TOptions> : Microsoft.Extensions.Options.IOptionsMonitor<TOptions>, System.IDisposable where TOptions : class, new()
+    public partial class OptionsMonitor<TOptions> : Microsoft.Extensions.Options.IOptionsMonitor<TOptions>, System.IDisposable where TOptions : class
     {
         public OptionsMonitor(Microsoft.Extensions.Options.IOptionsFactory<TOptions> factory, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IOptionsChangeTokenSource<TOptions>> sources, Microsoft.Extensions.Options.IOptionsMonitorCache<TOptions> cache) { }
         public TOptions CurrentValue { get { throw null; } }
@@ -211,7 +212,7 @@ namespace Microsoft.Extensions.Options
         public string OptionsName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Type OptionsType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    public partial class OptionsWrapper<TOptions> : Microsoft.Extensions.Options.IOptions<TOptions> where TOptions : class, new()
+    public partial class OptionsWrapper<TOptions> : Microsoft.Extensions.Options.IOptions<TOptions> where TOptions : class
     {
         public OptionsWrapper(TOptions options) { }
         public TOptions Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Options/Options/src/IOptions.cs
+++ b/src/Options/Options/src/IOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Used to retrieve configured <typeparamref name="TOptions"/> instances.
     /// </summary>
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    public interface IOptions<out TOptions> where TOptions : class, new()
+    public interface IOptions<out TOptions> where TOptions : class
     {
         /// <summary>
         /// The default configured <typeparamref name="TOptions"/> instance

--- a/src/Options/Options/src/IOptionsFactory.cs
+++ b/src/Options/Options/src/IOptionsFactory.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Used to create <typeparamref name="TOptions"/> instances.
     /// </summary>
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    public interface IOptionsFactory<TOptions> where TOptions : class, new()
+    public interface IOptionsFactory<TOptions> where TOptions : class
     {
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given name.

--- a/src/Options/Options/src/IOptionsSnapshot.cs
+++ b/src/Options/Options/src/IOptionsSnapshot.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Used to access the value of <typeparamref name="TOptions"/> for the lifetime of a request.
     /// </summary>
     /// <typeparam name="TOptions">Options type.</typeparam>
-    public interface IOptionsSnapshot<out TOptions> : IOptions<TOptions> where TOptions : class, new()
+    public interface IOptionsSnapshot<out TOptions> : IOptions<TOptions> where TOptions : class
     {
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given name.

--- a/src/Options/Options/src/Options.cs
+++ b/src/Options/Options/src/Options.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Options
         /// <typeparam name="TOptions">Options type.</typeparam>
         /// <param name="options">Options object.</param>
         /// <returns>Wrapped options object.</returns>
-        public static IOptions<TOptions> Create<TOptions>(TOptions options) where TOptions : class, new()
+        public static IOptions<TOptions> Create<TOptions>(TOptions options) where TOptions : class
         {
             return new OptionsWrapper<TOptions>(options);
         }

--- a/src/Options/Options/src/OptionsFactory.cs
+++ b/src/Options/Options/src/OptionsFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Options
@@ -9,7 +10,7 @@ namespace Microsoft.Extensions.Options
     /// Implementation of <see cref="IOptionsFactory{TOptions}"/>.
     /// </summary>
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    public class OptionsFactory<TOptions> : IOptionsFactory<TOptions> where TOptions : class, new()
+    public class OptionsFactory<TOptions> : IOptionsFactory<TOptions> where TOptions : class
     {
         private readonly IEnumerable<IConfigureOptions<TOptions>> _setups;
         private readonly IEnumerable<IPostConfigureOptions<TOptions>> _postConfigures;
@@ -41,7 +42,7 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         public TOptions Create(string name)
         {
-            var options = new TOptions();
+            var options = CreateInstance(name);
             foreach (var setup in _setups)
             {
                 if (setup is IConfigureNamedOptions<TOptions> namedSetup)
@@ -76,6 +77,14 @@ namespace Microsoft.Extensions.Options
             }
 
             return options;
+        }
+
+        /// <summary>
+        /// Creates a new instance of options type
+        /// </summary>
+        protected virtual TOptions CreateInstance(string name)
+        {
+            return Activator.CreateInstance<TOptions>();
         }
     }
 }

--- a/src/Options/Options/src/OptionsManager.cs
+++ b/src/Options/Options/src/OptionsManager.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Implementation of <see cref="IOptions{TOptions}"/> and <see cref="IOptionsSnapshot{TOptions}"/>.
     /// </summary>
     /// <typeparam name="TOptions">Options type.</typeparam>
-    public class OptionsManager<TOptions> : IOptions<TOptions>, IOptionsSnapshot<TOptions> where TOptions : class, new()
+    public class OptionsManager<TOptions> : IOptions<TOptions>, IOptionsSnapshot<TOptions> where TOptions : class
     {
         private readonly IOptionsFactory<TOptions> _factory;
         private readonly OptionsCache<TOptions> _cache = new OptionsCache<TOptions>(); // Note: this is a private cache

--- a/src/Options/Options/src/OptionsMonitor.cs
+++ b/src/Options/Options/src/OptionsMonitor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Options
     /// Implementation of <see cref="IOptionsMonitor{TOptions}"/>.
     /// </summary>
     /// <typeparam name="TOptions">Options type.</typeparam>
-    public class OptionsMonitor<TOptions> : IOptionsMonitor<TOptions>, IDisposable where TOptions : class, new()
+    public class OptionsMonitor<TOptions> : IOptionsMonitor<TOptions>, IDisposable where TOptions : class
     {
         private readonly IOptionsMonitorCache<TOptions> _cache;
         private readonly IOptionsFactory<TOptions> _factory;

--- a/src/Options/Options/src/OptionsWrapper.cs
+++ b/src/Options/Options/src/OptionsWrapper.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.Options
     /// <see cref="IOptions{TOptions}"/> wrapper that returns the options instance.
     /// </summary>
     /// <typeparam name="TOptions">Options type.</typeparam>
-    public class OptionsWrapper<TOptions> : IOptions<TOptions> where TOptions : class, new()
+    public class OptionsWrapper<TOptions> : IOptions<TOptions> where TOptions : class
     {
         /// <summary>
         /// Intializes the wrapper with the options instance to return.

--- a/src/Options/test/OptionsTest.cs
+++ b/src/Options/test/OptionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -359,6 +360,19 @@ namespace Microsoft.Extensions.Options.Tests
             var optionsWithoutDefaultCtor = sp.GetRequiredService<IOptionsMonitor<OptionsWithoutDefaultCtor>>().Get("Named");
             Assert.Equal("Initial value", optionsWithoutDefaultCtor.Message);
             Assert.Equal("Named", optionsWithoutDefaultCtor.Name);
+        }
+
+        [Fact]
+        public void Options_WithoutDefaultCtor_ThrowDuringResolution()
+        {
+            var services = new ServiceCollection();
+            services.Configure<OptionsWithoutDefaultCtor>("Named", options =>
+            {
+                options.Message = "Initial value";
+            });
+
+            var sp = services.BuildServiceProvider();
+            Assert.Throws<MissingMethodException>(() => sp.GetRequiredService<IOptionsMonitor<OptionsWithoutDefaultCtor>>().Get("Named"));
         }
 
         private class OptionsWithoutDefaultCtor

--- a/src/Options/test/OptionsTest.cs
+++ b/src/Options/test/OptionsTest.cs
@@ -343,5 +343,45 @@ namespace Microsoft.Extensions.Options.Tests
             var sp = services.BuildServiceProvider();
             Assert.Equal("Override", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
         }
+
+        [Fact]
+        public void Options_CanCreateInstancesWithoutDefaultCtor()
+        {
+            var services = new ServiceCollection();
+            services.Configure<OptionsWithoutDefaultCtor>("Named", options =>
+            {
+                options.Message = "Initial value";
+            });
+
+            services.AddSingleton<IOptionsFactory<OptionsWithoutDefaultCtor>, CustomOptionsFactory>();
+
+            var sp = services.BuildServiceProvider();
+            var optionsWithoutDefaultCtor = sp.GetRequiredService<IOptionsMonitor<OptionsWithoutDefaultCtor>>().Get("Named");
+            Assert.Equal("Initial value", optionsWithoutDefaultCtor.Message);
+            Assert.Equal("Named", optionsWithoutDefaultCtor.Name);
+        }
+
+        private class OptionsWithoutDefaultCtor
+        {
+            public string Name { get; }
+            public string Message { get; set; }
+
+            public OptionsWithoutDefaultCtor(string name)
+            {
+                Name = name;
+            }
+        }
+
+        private class CustomOptionsFactory: OptionsFactory<OptionsWithoutDefaultCtor>
+        {
+            public CustomOptionsFactory(IEnumerable<IConfigureOptions<OptionsWithoutDefaultCtor>> setups, IEnumerable<IPostConfigureOptions<OptionsWithoutDefaultCtor>> postConfigures, IEnumerable<IValidateOptions<OptionsWithoutDefaultCtor>> validations) : base(setups, postConfigures, validations)
+            {
+            }
+
+            protected override OptionsWithoutDefaultCtor CreateInstance(string name)
+            {
+                return new OptionsWithoutDefaultCtor(name);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation:

Currently it's very hard to use Options with option types that do not have a default constructor, doing so requires copying and modifying both OptionManger and OptionFactory source which is quite painful. I think this limitation is artificial side effect of the implementation and could be relaxed.

Examples of usages that would benefit from this adjustment:
https://github.com/microsoft/ApplicationInsights-aspnetcore/blob/04b5485d4a8aa498b2d99c60bdf8ca59bc9103fc/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptions.cs (note how it's not even a correct implementation, it misses IPostConfigureOptions and IValidateOptions calls)

https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Microsoft.Extensions.Azure/src/Internal/ClientOptionsFactory.cs

This PR removes internal new() constraints and adds a virtual `OptionsFactory<T>.CreateInstance` method that allows to inheriting and overriding the instance creation logic.

### Breaking change:

This is not a hard breaking change because constraints are being relaxed. Using IOptions<T> where T is NOT `new()`  without providing custom factory would still result in exception but it would move from DI service tree building time (throws when closing generic) to `CreateInstance` method call inside the `OptionsFactory`.

### Performance considerations:

Compiler generates the same code for Activator.CreateInstance<T>() and new(): https://sharplab.io/#v2:EYLgHgbALANALiAlgGwD4AEBMBGAsAKHQGYACLEgYRIG8CT6zT0oSBZAHgBUA+ACgEoadBiICCAYziIAbgEM4AewBOAOgpKApvI0BJAHYBnOLL3iNXPvwDcw+gF9bJR8TItW2CwJIB3ABYbNEk4QEj0NbwFHWnwRETDvIIEbGIYHfDsgA===

### 3.0

I know it's kind of late but can this go into 3.0? 