### PR TITLE
Special case Disposing DotNetObjectReferences

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -66,7 +66,11 @@ module DotNet {
     }
   }
 
-  function invokePossibleInstanceMethodAsync<T>(assemblyName: string | null, methodIdentifier: string, dotNetObjectId: number | null, args: any[]): Promise<T> {
+  function invokePossibleInstanceMethodAsync<T>(assemblyName: string | null, methodIdentifier: string, dotNetObjectId: number | null, ...args: any[]): Promise<T> {
+    if (assemblyName && dotNetObjectId) {
+      throw new Error(`For instance method calls, assemblyName should be null. Received '${assemblyName}'.`) ;
+    }
+
     const asyncCallId = nextAsyncCallId++;
     const resultPromise = new Promise<T>((resolve, reject) => {
       pendingAsyncCalls[asyncCallId] = { resolve, reject };
@@ -269,10 +273,7 @@ module DotNet {
     }
 
     public dispose() {
-      const promise = invokeMethodAsync<any>(
-        'Microsoft.JSInterop',
-        'DotNetDispatcher.ReleaseDotNetObject',
-        this._id);
+      const promise = invokePossibleInstanceMethodAsync<any>(null, '__Dispose', this._id);
       promise.catch(error => console.error(error));
     }
 

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netcoreapp3.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netcoreapp3.0.cs
@@ -8,8 +8,6 @@ namespace Microsoft.JSInterop
         public static void BeginInvoke(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson) { }
         public static void EndInvoke(string arguments) { }
         public static string Invoke(string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson) { throw null; }
-        [Microsoft.JSInterop.JSInvokableAttribute("DotNetDispatcher.ReleaseDotNetObject")]
-        public static void ReleaseDotNetObject(long dotNetObjectId) { }
     }
     public static partial class DotNetObjectRef
     {
@@ -18,7 +16,7 @@ namespace Microsoft.JSInterop
     public sealed partial class DotNetObjectRef<TValue> : System.IDisposable where TValue : class
     {
         internal DotNetObjectRef() { }
-        public TValue Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TValue Value { get { throw null; } }
         public void Dispose() { }
     }
     public partial interface IJSInProcessRuntime : Microsoft.JSInterop.IJSRuntime

--- a/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
+++ b/src/JSInterop/Microsoft.JSInterop/ref/Microsoft.JSInterop.netstandard2.0.cs
@@ -8,8 +8,6 @@ namespace Microsoft.JSInterop
         public static void BeginInvoke(string callId, string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson) { }
         public static void EndInvoke(string arguments) { }
         public static string Invoke(string assemblyName, string methodIdentifier, long dotNetObjectId, string argsJson) { throw null; }
-        [Microsoft.JSInterop.JSInvokableAttribute("DotNetDispatcher.ReleaseDotNetObject")]
-        public static void ReleaseDotNetObject(long dotNetObjectId) { }
     }
     public static partial class DotNetObjectRef
     {
@@ -18,7 +16,7 @@ namespace Microsoft.JSInterop
     public sealed partial class DotNetObjectRef<TValue> : System.IDisposable where TValue : class
     {
         internal DotNetObjectRef() { }
-        public TValue Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public TValue Value { get { throw null; } }
         public void Dispose() { }
     }
     public partial interface IJSInProcessRuntime : Microsoft.JSInterop.IJSRuntime

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetDispatcher.cs
@@ -38,7 +38,7 @@ namespace Microsoft.JSInterop
             // the targeted method has [JSInvokable]. It is not itself subject to that restriction,
             // because there would be nobody to police that. This method *is* the police.
 
-            var targetInstance = (object)null;
+            IDotNetObjectRef targetInstance = default;
             if (dotNetObjectId != default)
             {
                 targetInstance = DotNetObjectRefManager.Current.FindDotNetObject(dotNetObjectId);
@@ -78,7 +78,7 @@ namespace Microsoft.JSInterop
             // original stack traces.
             object syncResult = null;
             ExceptionDispatchInfo syncException = null;
-            object targetInstance = null;
+            IDotNetObjectRef targetInstance = null;
 
             try
             {
@@ -127,22 +127,30 @@ namespace Microsoft.JSInterop
             }
         }
 
-        private static object InvokeSynchronously(string assemblyName, string methodIdentifier, object targetInstance, string argsJson)
+        private static object InvokeSynchronously(string assemblyName, string methodIdentifier, IDotNetObjectRef objectReference, string argsJson)
         {
             AssemblyKey assemblyKey;
-            if (targetInstance != null)
+            if (objectReference is null)
+            {
+                assemblyKey = new AssemblyKey(assemblyName);
+            }
+            else
             {
                 if (assemblyName != null)
                 {
                     throw new ArgumentException($"For instance method calls, '{nameof(assemblyName)}' should be null. Value received: '{assemblyName}'.");
                 }
 
-                assemblyKey = new AssemblyKey(targetInstance.GetType().Assembly);
+                if (string.Equals("__Dispose", methodIdentifier, StringComparison.Ordinal))
+                {
+                    // The client executed dotNetObjectReference.dispose(). Dispose the reference and exit.
+                    objectReference.Dispose();
+                    return default;
+                }
+
+                assemblyKey = new AssemblyKey(objectReference.Value.GetType().Assembly);
             }
-            else
-            {
-                assemblyKey = new AssemblyKey(assemblyName);
-            }
+
 
             var (methodInfo, parameterTypes) = GetCachedMethodInfo(assemblyKey, methodIdentifier);
 
@@ -150,7 +158,7 @@ namespace Microsoft.JSInterop
 
             try
             {
-                return methodInfo.Invoke(targetInstance, suppliedArgs);
+                return methodInfo.Invoke(objectReference?.Value, suppliedArgs);
             }
             catch (TargetInvocationException tie) // Avoid using exception filters for AOT runtime support
             {
@@ -278,22 +286,6 @@ namespace Microsoft.JSInterop
             {
                 throw new JsonException("Invalid JSON");
             }
-        }
-
-        /// <summary>
-        /// Releases the reference to the specified .NET object. This allows the .NET runtime
-        /// to garbage collect that object if there are no other references to it.
-        ///
-        /// To avoid leaking memory, the JavaScript side code must call this for every .NET
-        /// object it obtains a reference to. The exception is if that object is used for
-        /// the entire lifetime of a given user's session, in which case it is released
-        /// automatically when the JavaScript runtime is disposed.
-        /// </summary>
-        /// <param name="dotNetObjectId">The identifier previously passed to JavaScript code.</param>
-        [JSInvokable(nameof(DotNetDispatcher) + "." + nameof(ReleaseDotNetObject))]
-        public static void ReleaseDotNetObject(long dotNetObjectId)
-        {
-            DotNetObjectRefManager.Current.ReleaseDotNetObject(dotNetObjectId);
         }
 
         private static (MethodInfo, Type[]) GetCachedMethodInfo(AssemblyKey assemblyKey, string methodIdentifier)

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectRef.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectRef.cs
@@ -15,8 +15,7 @@ namespace Microsoft.JSInterop
         /// <returns>An instance of <see cref="DotNetObjectRef{TValue}" />.</returns>
         public static DotNetObjectRef<TValue> Create<TValue>(TValue value) where TValue : class
         {
-            var objectId = DotNetObjectRefManager.Current.TrackObject(value);
-            return new DotNetObjectRef<TValue>(objectId, value);
+            return new DotNetObjectRef<TValue>(DotNetObjectRefManager.Current, value);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectRefManager.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectRefManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.JSInterop
     internal class DotNetObjectRefManager
     {
         private long _nextId = 0; // 0 signals no object, but we increment prior to assignment. The first tracked object should have id 1
-        private readonly ConcurrentDictionary<long, object> _trackedRefsById = new ConcurrentDictionary<long, object>();
+        private readonly ConcurrentDictionary<long, IDotNetObjectRef> _trackedRefsById = new ConcurrentDictionary<long, IDotNetObjectRef>();
 
         public static DotNetObjectRefManager Current
         {
@@ -25,7 +25,7 @@ namespace Microsoft.JSInterop
             }
         }
 
-        public long TrackObject(object dotNetObjectRef)
+        public long TrackObject(IDotNetObjectRef dotNetObjectRef)
         {
             var dotNetObjectId = Interlocked.Increment(ref _nextId);
             _trackedRefsById[dotNetObjectId] = dotNetObjectRef;
@@ -33,7 +33,7 @@ namespace Microsoft.JSInterop
             return dotNetObjectId;
         }
 
-        public object FindDotNetObject(long dotNetObjectId)
+        public IDotNetObjectRef FindDotNetObject(long dotNetObjectId)
         {
             return _trackedRefsById.TryGetValue(dotNetObjectId, out var dotNetObjectRef)
                 ? dotNetObjectRef

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceJsonConverter.cs
@@ -40,8 +40,8 @@ namespace Microsoft.JSInterop
                 throw new JsonException($"Required property {DotNetObjectRefKey} not found.");
             }
 
-            var value = (TValue)DotNetObjectRefManager.Current.FindDotNetObject(dotNetObjectId);
-            return new DotNetObjectRef<TValue>(dotNetObjectId, value);
+            var referenceManager = DotNetObjectRefManager.Current;
+            return (DotNetObjectRef<TValue>)referenceManager.FindDotNetObject(dotNetObjectId);
         }
 
         public override void Write(Utf8JsonWriter writer, DotNetObjectRef<TValue> value, JsonSerializerOptions options)

--- a/src/JSInterop/Microsoft.JSInterop/src/IDotNetObjectRef.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IDotNetObjectRef.cs
@@ -7,5 +7,6 @@ namespace Microsoft.JSInterop
 {
     internal interface IDotNetObjectRef : IDisposable
     {
+        object Value { get; }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/test/DotNetObjectRefTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/DotNetObjectRefTest.cs
@@ -24,10 +24,11 @@ namespace Microsoft.JSInterop
             var objRef = DotNetObjectRef.Create(new object());
 
             // Act
+            Assert.Equal(1, objRef.ObjectId);
             objRef.Dispose();
 
             // Assert
-            var ex = Assert.Throws<ArgumentException>(() => jsRuntime.ObjectRefManager.FindDotNetObject(objRef.ObjectId));
+            var ex = Assert.Throws<ArgumentException>(() => jsRuntime.ObjectRefManager.FindDotNetObject(1));
             Assert.StartsWith("There is no tracked object with id '1'.", ex.Message);
         });
     }

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessRuntimeBaseTest.cs
@@ -60,9 +60,9 @@ namespace Microsoft.JSInterop.Tests
             Assert.Equal("[{\"__dotNetObject\":1},{\"obj2\":{\"__dotNetObject\":2},\"obj3\":{\"__dotNetObject\":3}}]", call.ArgsJson);
 
             // Assert: Objects were tracked
-            Assert.Same(obj1, runtime.ObjectRefManager.FindDotNetObject(1));
-            Assert.Same(obj2, runtime.ObjectRefManager.FindDotNetObject(2));
-            Assert.Same(obj3, runtime.ObjectRefManager.FindDotNetObject(3));
+            Assert.Same(obj1, runtime.ObjectRefManager.FindDotNetObject(1).Value);
+            Assert.Same(obj2, runtime.ObjectRefManager.FindDotNetObject(2).Value);
+            Assert.Same(obj3, runtime.ObjectRefManager.FindDotNetObject(3).Value);
         }
 
         [Fact]

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeBaseTest.cs
@@ -282,10 +282,10 @@ namespace Microsoft.JSInterop
             Assert.Equal("[{\"__dotNetObject\":1},{\"obj2\":{\"__dotNetObject\":3},\"obj3\":{\"__dotNetObject\":4},\"obj1SameRef\":{\"__dotNetObject\":1},\"obj1DifferentRef\":{\"__dotNetObject\":2}}]", call.ArgsJson);
 
             // Assert: Objects were tracked
-            Assert.Same(obj1, runtime.ObjectRefManager.FindDotNetObject(1));
-            Assert.Same(obj1, runtime.ObjectRefManager.FindDotNetObject(2));
-            Assert.Same(obj2, runtime.ObjectRefManager.FindDotNetObject(3));
-            Assert.Same(obj3, runtime.ObjectRefManager.FindDotNetObject(4));
+            Assert.Same(obj1, runtime.ObjectRefManager.FindDotNetObject(1).Value);
+            Assert.Same(obj1, runtime.ObjectRefManager.FindDotNetObject(2).Value);
+            Assert.Same(obj2, runtime.ObjectRefManager.FindDotNetObject(3).Value);
+            Assert.Same(obj3, runtime.ObjectRefManager.FindDotNetObject(4).Value);
         }
 
         [Fact]


### PR DESCRIPTION
This removes a public JSInvokable method required for disposing DotNetObjectReferences

