### PR TITLE
Backport source build patches

### DIFF
--- a/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
+++ b/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
@@ -17,6 +17,8 @@
     <PackageTags>analyzers;async</PackageTags>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <!-- This project is not included in the shared framework -->
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/src/Logging/Logging.Analyzers/src/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -10,6 +10,8 @@
     <IsPackable>true</IsPackable>
     <!-- This is currently an experimental, internal-only analyzer. -->
     <IsShipping>false</IsShipping>
+    <!-- This project is not included in the shared framework -->
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
+++ b/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <!-- This project is not included in the shared framework -->
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 
     <!-- Subject to change: see https://github.com/dotnet/designs/pull/50 -->


### PR DESCRIPTION
- Skip packages not needed in source build. Bringing changes from https://github.com/dotnet/source-build/pull/1049/files back to our repo.
