### PR TITLE
Add switch to enable expected and unexpected arguments in any order

### DIFF
--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -13,14 +13,23 @@ namespace Microsoft.Extensions.CommandLineUtils
 {
     internal class CommandLineApplication
     {
-        // Indicates whether the parser should throw an exception when it runs into an unexpected argument.
-        // If this field is set to false, the parser will stop parsing when it sees an unexpected argument, and all
-        // remaining arguments, including the first unexpected argument, will be stored in RemainingArguments property.
+        // Indicates whether the parser should throw an exception when it runs into an unexpected argument. If this is
+        // set to true (the default), the parser will throw on the first unexpected argument. Otherwise, all unexpected
+        // arguments (including the first) are added to RemainingArguments.
         private readonly bool _throwOnUnexpectedArg;
 
-        public CommandLineApplication(bool throwOnUnexpectedArg = true)
+        // Indicates whether the parser should check remaining arguments for command or option matches after
+        // encountering an unexpected argument. Ignored if _throwOnUnexpectedArg is true (the default). If
+        // _throwOnUnexpectedArg and this are both false, the first unexpected argument and all remaining arguments are
+        // added to RemainingArguments. If _throwOnUnexpectedArg is false and this is true, only unexpected arguments
+        // are added to RemainingArguments -- allowing a mix of expected and unexpected arguments, commands and
+        // options.
+        private readonly bool _continueAfterUnexpectedArg;
+
+        public CommandLineApplication(bool throwOnUnexpectedArg = true, bool continueAfterUnexpectedArg = false)
         {
             _throwOnUnexpectedArg = throwOnUnexpectedArg;
+            _continueAfterUnexpectedArg = continueAfterUnexpectedArg;
             Options = new List<CommandOption>();
             Arguments = new List<CommandArgument>();
             Commands = new List<CommandLineApplication>();
@@ -145,6 +154,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                     {
                         shortOption = arg.Substring(1).Split(new[] { ':', '=' }, 2);
                     }
+
                     if (longOption != null)
                     {
                         processed = true;
@@ -153,24 +163,40 @@ namespace Microsoft.Extensions.CommandLineUtils
 
                         if (option == null)
                         {
-                            if (string.IsNullOrEmpty(longOptionName) && !command._throwOnUnexpectedArg  && AllowArgumentSeparator)
+                            var ignoreContinueAfterUnexpectedArg = false;
+                            if (string.IsNullOrEmpty(longOptionName) &&
+                                !command._throwOnUnexpectedArg &&
+                                AllowArgumentSeparator)
                             {
-                                // skip over the '--' argument separator
+                                // Skip over the '--' argument separator then consume all remaining arguments. All
+                                // remaining arguments are unconditionally stored for further use.
                                 index++;
+                                ignoreContinueAfterUnexpectedArg = true;
                             }
 
-                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                            if (HandleUnexpectedArg(
+                                command,
+                                args,
+                                index,
+                                argTypeName: "option",
+                                ignoreContinueAfterUnexpectedArg))
+                            {
+                                continue;
+                            }
+
                             break;
                         }
 
                         // If we find a help/version option, show information and stop parsing
                         if (command.OptionHelp == option)
                         {
+                            arguments?.Dispose();
                             command.ShowHelp();
                             return 0;
                         }
                         else if (command.OptionVersion == option)
                         {
+                            arguments?.Dispose();
                             command.ShowVersion();
                             return 0;
                         }
@@ -191,6 +217,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                             option = null;
                         }
                     }
+
                     if (shortOption != null)
                     {
                         processed = true;
@@ -204,18 +231,24 @@ namespace Microsoft.Extensions.CommandLineUtils
 
                         if (option == null)
                         {
-                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                            if (HandleUnexpectedArg(command, args, index, argTypeName: "option"))
+                            {
+                                continue;
+                            }
+
                             break;
                         }
 
                         // If we find a help/version option, show information and stop parsing
                         if (command.OptionHelp == option)
                         {
+                            arguments?.Dispose();
                             command.ShowHelp();
                             return 0;
                         }
                         else if (command.OptionVersion == option)
                         {
+                            arguments?.Dispose();
                             command.ShowVersion();
                             return 0;
                         }
@@ -268,6 +301,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                         processed = true;
                     }
                 }
+
                 if (!processed)
                 {
                     if (arguments == null)
@@ -280,9 +314,14 @@ namespace Microsoft.Extensions.CommandLineUtils
                         arguments.Current.Values.Add(arg);
                     }
                 }
+
                 if (!processed)
                 {
-                    HandleUnexpectedArg(command, args, index, argTypeName: "command or argument");
+                    if (HandleUnexpectedArg(command, args, index, argTypeName: "command or argument"))
+                    {
+                        continue;
+                    }
+
                     break;
                 }
             }
@@ -293,6 +332,7 @@ namespace Microsoft.Extensions.CommandLineUtils
                 throw new CommandParsingException(command, $"Missing value for option '{option.LongName}'");
             }
 
+            arguments?.Dispose();
             return command.Invoke();
         }
 
@@ -490,17 +530,29 @@ namespace Microsoft.Extensions.CommandLineUtils
             Out.WriteLine();
         }
 
-        private void HandleUnexpectedArg(CommandLineApplication command, string[] args, int index, string argTypeName)
+        private bool HandleUnexpectedArg(
+            CommandLineApplication command,
+            string[] args,
+            int index,
+            string argTypeName,
+            bool ignoreContinueAfterUnexpectedArg = false)
         {
             if (command._throwOnUnexpectedArg)
             {
                 command.ShowHint();
                 throw new CommandParsingException(command, $"Unrecognized {argTypeName} '{args[index]}'");
             }
+            else if (_continueAfterUnexpectedArg && !ignoreContinueAfterUnexpectedArg)
+            {
+                // Store argument for further use.
+                command.RemainingArguments.Add(args[index]);
+                return true;
+            }
             else
             {
-                // All remaining arguments are stored for further use
+                // Store all remaining arguments for later use.
                 command.RemainingArguments.AddRange(new ArraySegment<string>(args, index, args.Length - index));
+                return false;
             }
         }
 

--- a/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
+++ b/src/Shared/src/CommandLineUtils/CommandLine/CommandLineApplication.cs
@@ -190,13 +190,11 @@ namespace Microsoft.Extensions.CommandLineUtils
                         // If we find a help/version option, show information and stop parsing
                         if (command.OptionHelp == option)
                         {
-                            arguments?.Dispose();
                             command.ShowHelp();
                             return 0;
                         }
                         else if (command.OptionVersion == option)
                         {
-                            arguments?.Dispose();
                             command.ShowVersion();
                             return 0;
                         }
@@ -242,13 +240,11 @@ namespace Microsoft.Extensions.CommandLineUtils
                         // If we find a help/version option, show information and stop parsing
                         if (command.OptionHelp == option)
                         {
-                            arguments?.Dispose();
                             command.ShowHelp();
                             return 0;
                         }
                         else if (command.OptionVersion == option)
                         {
-                            arguments?.Dispose();
                             command.ShowVersion();
                             return 0;
                         }
@@ -332,7 +328,6 @@ namespace Microsoft.Extensions.CommandLineUtils
                 throw new CommandParsingException(command, $"Missing value for option '{option.LongName}'");
             }
 
-            arguments?.Dispose();
             return command.Invoke();
         }
 


### PR DESCRIPTION
- unblocks work on aspnet/AspNetCore#4923
  - arguments for inside and outside men of service reference doc gen tool are mixed by default
  - users may add either argument type to the end of the outside man's command line
- e.g. "command --unexpected unexpectedValue --expected" can now set the "expected" option
  - only "--unexpected" and "unexpectedValue" are added to RemainingArguments in that case

- default behaviour of the command-line parser is unchanged to avoid breaking existing applications
- new switch is supported only when calling `CommandLineApplication` constructor for top-level commands
  - `dotnet-getdocument` (the outside man) has no (sub)commands and expanding scope would increase churn

nits: take VS suggestions in changed files