### PR TITLE
Make JsonConfigurationFileParser public

### DIFF
--- a/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs
+++ b/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 
 namespace Microsoft.Extensions.Configuration.Json
 {
-    internal class JsonConfigurationFileParser
+    public class JsonConfigurationFileParser
     {
         private JsonConfigurationFileParser() { }
 


### PR DESCRIPTION
The JSON config code depends on the fact that the JSON is coming from a file. This is not always the case and making this file public makes it easy for others to parse JSON which is not file based and use it as config.

Summary of the changes (Less than 80 chars)
 - Make JsonConfigurationFileParser public

Addresses #bugnumber (in this specific format)
