### PR TITLE
Update ref pack targets to specify netcoreapp5.0 TFM

### DIFF
--- a/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/build/Microsoft.Internal.Extensions.Refs.props
+++ b/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/build/Microsoft.Internal.Extensions.Refs.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftInternalExtensionsRefsPath>$(MSBuildThisFileDirectory)..\ref\netcoreapp3.0\</MicrosoftInternalExtensionsRefsPath>
+    <MicrosoftInternalExtensionsRefsPath>$(MSBuildThisFileDirectory)..\ref\netcoreapp5.0\</MicrosoftInternalExtensionsRefsPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is breaking our AspNetCore builds https://github.com/aspnet/AspNetCore/pull/13548 since reference assemblies from extensions are not found. Note that we'll need to make a similar change in 3.1 when we update the TFM cc @dougbu 