### PR TITLE
Fix packing on *nix systems

### DIFF
--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
@@ -27,9 +27,7 @@
 
   <ItemGroup>
     <NuspecProperty Include="AssemblyName=$(AssemblyName)" />
-    <NuspecProperty Include="OutputBinary=$(OutputPath)**\$(AssemblyName).dll" />
-    <NuspecProperty Include="OutputSymbol=$(OutputPath)**\$(AssemblyName).pdb" />
-    <NuspecProperty Include="OutputDocumentation=$(OutputPath)**\$(AssemblyName).xml" />
+    <NuspecProperty Include="OutputPath=$(OutputPath)" />
     <NuspecProperty Include="TaskAssemblyNetStandard=$(ArtifactsDir)bin\$(AssemblyName).Manifest.Task\$(Configuration)\netstandard2.0\$(AssemblyName).Manifest.Task.dll"/>
     <NuspecProperty Include="TaskSymbolNetStandard=$(ArtifactsDir)bin\$(AssemblyName).Manifest.Task\$(Configuration)\netstandard2.0\$(AssemblyName).Manifest.Task.pdb" Condition="'$(DebugType)'!='embedded'"/>
   </ItemGroup>

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
@@ -13,9 +13,9 @@
   </metadata>
 
   <files>
-    <file src="$OutputBinary$" target="lib\" />
-    <file src="$OutputSymbol$" target="lib\" />
-    <file src="$OutputDocumentation$" target="lib\" />
+    <file src="$OutputPath$**\$AssemblyName$.dll" target="lib\" />
+    <file src="$OutputPath$**\$AssemblyName$.pdb" target="lib\" />
+    <file src="$OutputPath$**\$AssemblyName$.xml" target="lib\" />
     <file src="build\**\*" target="build\" />
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting\" />
     <file src="$TaskAssemblyNetStandard$" target="tasks\netstandard2.0\$AssemblyName$.Manifest.Task.dll" />

--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp.nuspec
+++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp.nuspec
@@ -10,9 +10,9 @@
   </metadata>
 
   <files>
-    <file src="$OutputBinary$" target="lib\" />
-    <file src="$OutputSymbol$" target="lib\" />
-    <file src="$OutputDocumentation$" target="lib\" />
+    <file src="$OutputPath$**\$AssemblyName$.dll" target="lib\" />
+    <file src="$OutputPath$**\$AssemblyName$.pdb" target="lib\" />
+    <file src="$OutputPath$**\$AssemblyName$.xml" target="lib\" />
     <file src="build\**\*" target="build\" />
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting\" />
     <file src="$TaskAssemblyNetStandard$" target="tasks\netstandard2.0\$AssemblyName$.Manifest.Task.dll" />


### PR DESCRIPTION
Without this the nupkgs packed on *nix systems will be missing files. It seems like the globbing pattern `**` doesn't work correctly in MSbuild on *nix so I'm moving the globbing into the nuspec. This is required to fix source-build. Keeping this as a draft until I get positive confirmation that this fixes the issue.