### PR TITLE
Add a perf scenario for DotNetDispatcher

### DIFF
--- a/Extensions.sln
+++ b/Extensions.sln
@@ -317,6 +317,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hostin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hosting.IntegrationTesting", "src\Hosting\IntegrationTesting\src\Microsoft.Extensions.Hosting.IntegrationTesting.csproj", "{60313ECC-7C20-4509-B41B-C0F69F5162E7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.JSInterop.Performance", "src\JSInterop\Microsoft.JSInterop\perf\Microsoft.JSInterop.Performance.csproj", "{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1899,6 +1901,18 @@ Global
 		{60313ECC-7C20-4509-B41B-C0F69F5162E7}.Release|x64.Build.0 = Release|Any CPU
 		{60313ECC-7C20-4509-B41B-C0F69F5162E7}.Release|x86.ActiveCfg = Release|Any CPU
 		{60313ECC-7C20-4509-B41B-C0F69F5162E7}.Release|x86.Build.0 = Release|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Debug|x64.Build.0 = Debug|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Debug|x86.Build.0 = Debug|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Release|x64.ActiveCfg = Release|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Release|x64.Build.0 = Release|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Release|x86.ActiveCfg = Release|Any CPU
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2042,6 +2056,7 @@ Global
 		{1DF2C30F-4A33-4711-B198-6163C931FAC8} = {6868A014-43FD-4047-B536-30D5D159D9D4}
 		{C7204C14-0FA5-4EE6-B538-CAAEB7854E98} = {1DF2C30F-4A33-4711-B198-6163C931FAC8}
 		{60313ECC-7C20-4509-B41B-C0F69F5162E7} = {6868A014-43FD-4047-B536-30D5D159D9D4}
+		{D2F0A5E3-F24C-4273-B277-3FD49DC4513E} = {6A293FDC-A13B-4137-87F9-C9225CF3542B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {814BFC88-0867-451F-AC8F-20FE107809B4}

--- a/src/JSInterop/JSInterop.slnf
+++ b/src/JSInterop/JSInterop.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src\\JSInterop\\Microsoft.JSInterop\\src\\Microsoft.JSInterop.csproj",
       "src\\JSInterop\\Microsoft.JSInterop\\test\\Microsoft.JSInterop.Tests.csproj",
+      "src\\JSInterop\\Microsoft.JSInterop\\perf\\Microsoft.JSInterop.Performance.csproj",
       "src\\JSInterop\\Mono.WebAssembly.Interop\\src\\Mono.WebAssembly.Interop.csproj",
     ]
   }

--- a/src/JSInterop/Microsoft.JSInterop/perf/AssemblyInfo.cs
+++ b/src/JSInterop/Microsoft.JSInterop/perf/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: BenchmarkDotNet.Attributes.AspNetCoreBenchmark]

--- a/src/JSInterop/Microsoft.JSInterop/perf/DotNetDispatcherBenchmark.cs
+++ b/src/JSInterop/Microsoft.JSInterop/perf/DotNetDispatcherBenchmark.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.JSInterop.Infrastructure;
+
+namespace Microsoft.JSInterop.Performance
+{
+    public class DotNetDispatcherBenchmark
+    {
+        private JSRuntime jsRuntime;
+        private string assemblyName;
+        private string argsJson;
+
+        [GlobalSetup]
+        public void SetUp()
+        {
+            jsRuntime = new TestJSRuntime();
+            assemblyName = "Microsoft.JSInterop.Performance";
+            argsJson = "[1, \"test\"]";
+        }
+
+        [Benchmark]
+        public void Invoke()
+        {
+            DotNetDispatcher.Invoke(jsRuntime, new DotNetInvocationInfo(assemblyName, nameof(TestType.InvocableStaticVoid), default, default), argsJson);
+        }
+
+        public class TestType
+        {
+            [JSInvokable]
+            public static void InvocableStaticVoid(int a, string b)
+            {
+            }
+        }
+
+        public class TestJSRuntime : JSRuntime
+        {
+            protected override void BeginInvokeJS(long taskId, string identifier, string argsJson)
+            {
+            }
+
+            protected override void EndInvokeDotNet(DotNetInvocationInfo invocationInfo, in DotNetInvocationResult invocationResult)
+            {
+            }
+        }
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/perf/Microsoft.JSInterop.Performance.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/perf/Microsoft.JSInterop.Performance.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.JSInterop" />
+    <Reference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)BenchmarkRunner\**\*.cs">
+      <Link>Shared\%(FileName)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/ObjectMethodExecutor.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/ObjectMethodExecutor.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.JSInterop.Infrastructure
+{
+    internal static class ObjectMethodExecutor
+    {
+        public static Func<object, object[], object> GetExecutor(MethodInfo methodInfo, Type targetType)
+        {
+            // Parameters to executor
+            var targetParameter = Expression.Parameter(typeof(object), "target");
+            var parametersParameter = Expression.Parameter(typeof(object[]), "parameters");
+
+            // Build parameter list
+            var parameters = new List<Expression>();
+            var paramInfos = methodInfo.GetParameters();
+            for (var i = 0; i < paramInfos.Length; i++)
+            {
+                var paramInfo = paramInfos[i];
+                var valueObj = Expression.ArrayIndex(parametersParameter, Expression.Constant(i));
+                var valueCast = Expression.Convert(valueObj, paramInfo.ParameterType);
+
+                // valueCast is "(Ti) parameters[i]"
+                parameters.Add(valueCast);
+            }
+
+            // Call method
+            var instance = targetType is null ?
+                null :
+                Expression.Convert(targetParameter, targetType);
+            var methodCall = Expression.Call(instance, methodInfo, parameters);
+
+            // methodCall is "((Ttarget) target) method((T0) parameters[0], (T1) parameters[1], ...)"
+            // Create function
+            if (methodCall.Type == typeof(void))
+            {
+                var lambda = Expression.Lambda<Action<object, object[]>>(methodCall, targetParameter, parametersParameter);
+                var voidExecutor = lambda.Compile();
+                return WrapVoidAction(voidExecutor);
+            }
+            else
+            {
+                var castMethodCall = Expression.Convert(methodCall, typeof(object));
+                var lambda = Expression.Lambda<Func<object, object[], object>>(castMethodCall, targetParameter, parametersParameter);
+                return lambda.Compile();
+            }
+
+            static Func<object, object[], object> WrapVoidAction(Action<object, object[]> executor)
+            {
+                return delegate (object target, object[] parameters)
+                {
+                    executor(target, parameters);
+                    return null;
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
I tried playing around with using `ObjectResultExecutor` to avoid the reflection invoke in `DotNetDispatcher`. It does seem like a good change. We could consider a strategy where it does a reflection invoke the first few times around, but produces a compiled delegate if it's more frequently called. I recall DI has (❓) a pattern like this. 

# Vanilla benchmark

 Method |     Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
------- |---------:|----------:|----------:|----------:|-------:|----------:|
 Baseline | 1.220 us | 0.0103 us | 0.0080 us | 820,004.1 | 0.0057 |     240 B |
 Invoke | 1.002 us | 0.0064 us | 0.0060 us | 998,215.6 | 0.0038 |     200 B |
 
 
# 5000 operations per invoke
 Method |     Mean |    Error |   StdDev |        Op/s |   Gen 0 | Allocated |
------- |---------:|---------:|---------:|------------:|--------:|----------:|
 Baseline | 1.197 us | 0.0099 us | 0.0093 us | 835,661.3 | 31.2500 |   1.14 MB | 
 Invoke | 964.1 ns | 11.89 ns | 11.12 ns | 1,037,280.3 | 23.4375 | 976.56 KB |
 