### PR TITLE
Updating the documentation for SourceName

### DIFF
--- a/src/Logging/Logging.EventLog/src/EventLogSettings.cs
+++ b/src/Logging/Logging.EventLog/src/EventLogSettings.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Logging.EventLog
         public string LogName { get; set; }
 
         /// <summary>
-        /// Name of the event log source. If <c>null</c> or not specified, "Application" is the default.
+        /// Name of the event log source. If <c>null</c> or not specified, ".NET Runtime" is the default.
         /// </summary>
         public string SourceName { get; set; }
 


### PR DESCRIPTION
Updated the default event source name documentation to be **.NET Runtime** instead of **Application** to match the code execution
