### PR TITLE
Fixing a typo in ChainedBuilderExtensions

### DIFF
--- a/src/Configuration/Config/src/ChainedBuilderExtensions.cs
+++ b/src/Configuration/Config/src/ChainedBuilderExtensions.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
-    /// IConfigurationBuilder extension methods for the chaind configuration provider.
+    /// Extension methods for adding <see cref="IConfiguration"/> to a <see cref="IConfigurationBuilder"/>.
     /// </summary>
     public static class ChainedBuilderExtensions
     {

--- a/src/Configuration/Config/src/ChainedBuilderExtensions.cs
+++ b/src/Configuration/Config/src/ChainedBuilderExtensions.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
-    /// Extension methods for adding <see cref="IConfiguration"/> to a <see cref="IConfigurationBuilder"/>.
+    /// Extension methods for adding <see cref="IConfiguration"/> to an <see cref="IConfigurationBuilder"/>.
     /// </summary>
     public static class ChainedBuilderExtensions
     {


### PR DESCRIPTION
The class description comment had a typo, so I cleaned that up and added some more details to what the extension methods are fore.
