### PR TITLE
Move pinned Microsoft.Netcore.App down

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,10 +58,6 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0" Pinned="true">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
-    </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.
@@ -73,6 +69,11 @@
     <Dependency Name="NETStandard.Library.Ref" Version="2.1.0">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>d34d1570bfdf669ed94b4c939b2f39a1650e2320</Sha>
+    </Dependency>
+    <!-- Keep this dependency at the bottom of ProductDependencies, else it will be picked as the parent for CoherentParentDependencies -->
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0" Pinned="true">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Move the pinned dependency on `Microsoft.Netcore.App` to the bottom of versions.details.xml to prevent it being picked for CoherentParentDependencies

CC @mmitche @dougbu - we think this will fix https://github.com/aspnet/EntityFrameworkCore/pull/18207/