### PR TITLE
Add disposable singleton test cases

### DIFF
--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             public void Dispose()
             {
-                this.IsDisposed = true;
+                IsDisposed = true;
             }
         }
 

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -346,6 +346,52 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 exception.Message);
         }
 
+        [Fact]
+        public void SingletonServiceCreatedFromFactoryIsDisposedWhenContainerIsDisposed()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddSingleton(_ => new TestDisposable());
+            var provider = this.CreateServiceProvider(collection);
+
+            // Act
+            var service = provider.GetService<TestDisposable>();
+            ((IDisposable)provider).Dispose();
+
+            // Assert
+            Assert.True(service.IsDisposed);
+        }
+
+        [Fact]
+        public void SingletonServiceCreatedFromInstanceIsNotDisposedWhenContainerIsDisposed()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddSingleton(new TestDisposable());
+            var provider = this.CreateServiceProvider(collection);
+
+            // Act
+            var service = provider.GetService<TestDisposable>();
+            ((IDisposable)provider).Dispose();
+
+            // Assert
+            Assert.False(service.IsDisposed);
+        }
+
+        internal class TestDisposable : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                this.IsDisposed = true;
+            }
+        }
+
+        internal class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+        {
+        }
+
         private class FakeMultipleServiceWithIEnumerableDependency: IFakeMultipleService
         {
             public FakeMultipleServiceWithIEnumerableDependency(IEnumerable<IFakeService> fakeServices)

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -350,13 +350,13 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void SingletonServiceCreatedFromFactoryIsDisposedWhenContainerIsDisposed()
         {
             // Arrange
-            var collection = new TestServiceCollection();
-            collection.AddSingleton(_ => new TestDisposable());
-            var provider = this.CreateServiceProvider(collection);
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(_ => new FakeDisposable());
+            var serviceProvider = CreateServiceProvider(serviceCollection);
 
             // Act
-            var service = provider.GetService<TestDisposable>();
-            ((IDisposable)provider).Dispose();
+            var service = serviceProvider.GetService<FakeDisposable>();
+            ((IDisposable)serviceProvider).Dispose();
 
             // Assert
             Assert.True(service.IsDisposed);
@@ -366,19 +366,19 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void SingletonServiceCreatedFromInstanceIsNotDisposedWhenContainerIsDisposed()
         {
             // Arrange
-            var collection = new TestServiceCollection();
-            collection.AddSingleton(new TestDisposable());
-            var provider = this.CreateServiceProvider(collection);
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(new FakeDisposable());
+            var serviceProvider = CreateServiceProvider(serviceCollection);
 
             // Act
-            var service = provider.GetService<TestDisposable>();
-            ((IDisposable)provider).Dispose();
+            var service = serviceProvider.GetService<FakeDisposable>();
+            ((IDisposable)serviceProvider).Dispose();
 
             // Assert
             Assert.False(service.IsDisposed);
         }
 
-        internal class TestDisposable : IDisposable
+        private class FakeDisposable : IDisposable
         {
             public bool IsDisposed { get; private set; }
 
@@ -386,10 +386,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 this.IsDisposed = true;
             }
-        }
-
-        internal class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
-        {
         }
 
         private class FakeMultipleServiceWithIEnumerableDependency: IFakeMultipleService


### PR DESCRIPTION
Added two test cases that check whether or not disposable singletons are disposed as expected after dependency injection and disposal.

Addresses #1799

NOTE: All credit for this idea and code go to @peter-perot.  I merely submitted the PR, since the issue was opened 4 months ago and has since had the help-wanted label added.  If @peter-perot would like to submit this PR and have this one deleted, that's fine too.
