### PR TITLE
DI: Fix IL builder's undefined behavior for defaulted value types.

### DIFF
--- a/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DependencyInjection/DI/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -185,6 +185,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected override object VisitConstant(ConstantCallSite constantCallSite, ILEmitResolverBuilderContext argument)
         {
             AddConstant(argument, constantCallSite.DefaultValue);
+
+            if (constantCallSite.ServiceType.IsValueType)
+            {
+                argument.Generator.Emit(OpCodes.Unbox_Any, constantCallSite.ServiceType);
+            }
+
             return null;
         }
 

--- a/src/DependencyInjection/DI/test/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
+++ b/src/DependencyInjection/DI/test/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
@@ -8,7 +8,16 @@ namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {
     public class ClassWithServiceAndOptionalArgsCtorWithStructs
     {
+        public DateTime DateTime { get; }
         public DateTime DateTimeDefault { get; }
+        public TimeSpan TimeSpan { get; }
+        public TimeSpan TimeSpanDefault { get; }
+        public DateTimeOffset DateTimeOffset { get; }
+        public DateTimeOffset DateTimeOffsetDefault { get; }
+        public Guid Guid { get; }
+        public Guid GuidDefault { get; }
+        public CustomStruct CustomStructValue { get; }
+        public CustomStruct CustomStructDefault { get; }
 
         public ClassWithServiceAndOptionalArgsCtorWithStructs(IFakeService fake,
             DateTime dateTime = new DateTime(),
@@ -23,7 +32,16 @@ namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
             CustomStruct customStructDefault = default(CustomStruct)
         )
         {
+            DateTime = dateTime;
             DateTimeDefault = dateTimeDefault;
+            TimeSpan = timeSpan;
+            TimeSpanDefault = timeSpanDefault;
+            DateTimeOffset = dateTimeOffset;
+            DateTimeOffsetDefault = dateTimeOffsetDefault;
+            Guid = guid;
+            GuidDefault = guidDefault;
+            CustomStructValue = customStruct;
+            CustomStructDefault = customStructDefault;
         }
 
         public struct CustomStruct { }

--- a/src/DependencyInjection/DI/test/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
+++ b/src/DependencyInjection/DI/test/Fakes/ClassWithOptionalArgsCtorWithStructs.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 {
     public class ClassWithServiceAndOptionalArgsCtorWithStructs
     {
+        public DateTime DateTimeDefault { get; }
+
         public ClassWithServiceAndOptionalArgsCtorWithStructs(IFakeService fake,
             DateTime dateTime = new DateTime(),
             DateTime dateTimeDefault = default(DateTime),
@@ -21,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
             CustomStruct customStructDefault = default(CustomStruct)
         )
         {
+            DateTimeDefault = dateTimeDefault;
         }
 
         public struct CustomStruct { }

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -121,11 +121,17 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<IFakeService, FakeService>();
-            serviceCollection.AddSingleton<ClassWithServiceAndOptionalArgsCtorWithStructs>();
+            serviceCollection.AddTransient<ClassWithServiceAndOptionalArgsCtorWithStructs>();
 
             var provider = CreateServiceProvider(serviceCollection);
-            var service = provider.GetService<ClassWithServiceAndOptionalArgsCtorWithStructs>();
-            Assert.NotNull(service);
+
+            for (int i = 0; i < 100; i++)
+            {
+                var service = provider.GetService<ClassWithServiceAndOptionalArgsCtorWithStructs>();
+
+                Assert.NotNull(service);
+                Assert.Equal(default, service.DateTimeDefault);
+            }
         }
 
         [Fact]

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var provider = CreateServiceProvider(serviceCollection);
 
+            // Repeatedly resolve and re-check to ensure dynamically generated code properly initializes the values types.
             for (int i = 0; i < 100; i++)
             {
                 var service = provider.GetService<ClassWithServiceAndOptionalArgsCtorWithStructs>();

--- a/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
+++ b/src/DependencyInjection/DI/test/ServiceProviderContainerTests.cs
@@ -121,6 +121,18 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<IFakeService, FakeService>();
+            serviceCollection.AddSingleton<ClassWithServiceAndOptionalArgsCtorWithStructs>();
+
+            var provider = CreateServiceProvider(serviceCollection);
+            var service = provider.GetService<ClassWithServiceAndOptionalArgsCtorWithStructs>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        public void ResolvesServiceMixedServiceAndOptionalStructConstructorArgumentsReliably()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IFakeService, FakeService>();
             serviceCollection.AddTransient<ClassWithServiceAndOptionalArgsCtorWithStructs>();
 
             var provider = CreateServiceProvider(serviceCollection);
@@ -130,7 +142,16 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 var service = provider.GetService<ClassWithServiceAndOptionalArgsCtorWithStructs>();
 
                 Assert.NotNull(service);
-                Assert.Equal(default, service.DateTimeDefault);
+                Assert.Equal(new DateTime(), service.DateTime);
+                Assert.Equal(default(DateTime), service.DateTimeDefault);
+                Assert.Equal(new TimeSpan(), service.TimeSpan);
+                Assert.Equal(default(TimeSpan), service.TimeSpanDefault);
+                Assert.Equal(new DateTimeOffset(), service.DateTimeOffset);
+                Assert.Equal(default(DateTimeOffset), service.DateTimeOffsetDefault);
+                Assert.Equal(new Guid(), service.Guid);
+                Assert.Equal(default(Guid), service.GuidDefault);
+                Assert.Equal(new ClassWithServiceAndOptionalArgsCtorWithStructs.CustomStruct(), service.CustomStructValue);
+                Assert.Equal(default(ClassWithServiceAndOptionalArgsCtorWithStructs.CustomStruct), service.CustomStructDefault);
             }
         }
 


### PR DESCRIPTION
If a service contains a constructor that has value types that are assigned default values, ILEmitResolverBuilder will produce IL with undefined behavior.  At runtime, this causes the value to sometimes resolve as the correct value and other times resolve as a random (uninitialized) value.

Addresses #2431
