### PR TITLE
Update SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "5.0.100-alpha1-014696"
+    "version": "5.0.100-alpha1-015536"
   },
   "tools": {
-    "dotnet": "5.0.100-alpha1-014696",
+    "dotnet": "5.0.100-alpha1-015536",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRuntimeVersion)"


### PR DESCRIPTION
Should fix the "Could not load file or assembly 'NuGet.Common, Version=5.3.0.4," issue on ci builds.

Same thing as https://github.com/aspnet/AspNetCore/pull/16753