### PR TITLE
Adding Optional Serialize / Deserialize Capability | Options Class

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -31,5 +31,15 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         {
             get { return this; }
         }
+        
+        /// <summary>
+        /// Optional function to serialize/deserialize the data before storing it in redis.
+        /// </summary>
+        public System.Func<byte[], string> Serialize { get; set; }
+        
+         /// <summary>
+        /// Optional function to proccess the data when retriving it in redis.
+        /// </summary>
+        public System.Func<string, byte[]> Deserialize { get; set; }
     }
 }


### PR DESCRIPTION
Adding these two functions to support serializing and deserializing the data before storing it in redis, and when retrieving it. The main reason is we experienced issue when we tried to store specific (byte[]) data in redis. it seems that it was binary-safe issue.
