### PR TITLE
Adding Optional Serialize / Deserialize Capability | RedisCache Class

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -95,13 +95,17 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
 
+            RedisValue updatedValue = value;
+            if (_options.Serialize != null)
+                updatedValue = _options.Serialize.Invoke(value);
+
             var result = _cache.ScriptEvaluate(SetScript, new RedisKey[] { _instance + key },
                 new RedisValue[]
                 {
                         absoluteExpiration?.Ticks ?? NotPresent,
                         options.SlidingExpiration?.Ticks ?? NotPresent,
                         GetExpirationInSeconds(creationTime, absoluteExpiration, options) ?? NotPresent,
-                        value
+                        updatedValue
                 });
         }
 
@@ -130,13 +134,17 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
 
+            RedisValue updatedValue = value;
+            if (_options.Serialize != null)
+                updatedValue = _options.Serialize.Invoke(value);
+
             await _cache.ScriptEvaluateAsync(SetScript, new RedisKey[] { _instance + key },
                 new RedisValue[]
                 {
                         absoluteExpiration?.Ticks ?? NotPresent,
                         options.SlidingExpiration?.Ticks ?? NotPresent,
                         GetExpirationInSeconds(creationTime, absoluteExpiration, options) ?? NotPresent,
-                        value
+                        updatedValue
                 });
         }
 
@@ -253,6 +261,9 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             if (results.Length >= 3 && results[2].HasValue)
             {
+               if (_options.Deserialize != null)
+                    return _options.Deserialize.Invoke(results[2]);
+
                 return results[2];
             }
 
@@ -291,6 +302,9 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             if (results.Length >= 3 && results[2].HasValue)
             {
+                if (_options.Deserialize != null)
+                    return _options.Deserialize.Invoke(results[2]);
+
                 return results[2];
             }
 


### PR DESCRIPTION
Adding these two functions to support serializing and deserializing the data before storing it in redis, and when retrieving it. The main reason is we experienced issue when we tried to store specific (byte[]) data in redis. it seems that it was binary-safe issue.
