### PR TITLE
Adding Optional Serialization / Deserialization Capability

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -95,13 +95,17 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
 
+            RedisValue updatedValue = value;
+            if (_options.Serialize != null)
+                updatedValue = _options.Serialize.Invoke(value);
+
             var result = _cache.ScriptEvaluate(SetScript, new RedisKey[] { _instance + key },
                 new RedisValue[]
                 {
                         absoluteExpiration?.Ticks ?? NotPresent,
                         options.SlidingExpiration?.Ticks ?? NotPresent,
                         GetExpirationInSeconds(creationTime, absoluteExpiration, options) ?? NotPresent,
-                        value
+                        updatedValue
                 });
         }
 
@@ -130,13 +134,17 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
 
+            RedisValue updatedValue = value;
+            if (_options.Serialize != null)
+                updatedValue = _options.Serialize.Invoke(value);
+
             await _cache.ScriptEvaluateAsync(SetScript, new RedisKey[] { _instance + key },
                 new RedisValue[]
                 {
                         absoluteExpiration?.Ticks ?? NotPresent,
                         options.SlidingExpiration?.Ticks ?? NotPresent,
                         GetExpirationInSeconds(creationTime, absoluteExpiration, options) ?? NotPresent,
-                        value
+                        updatedValue
                 });
         }
 
@@ -253,6 +261,9 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             if (results.Length >= 3 && results[2].HasValue)
             {
+                   if (_options.Deserialize != null)
+                    return _options.Deserialize.Invoke(results[2]);
+
                 return results[2];
             }
 
@@ -291,6 +302,9 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             if (results.Length >= 3 && results[2].HasValue)
             {
+                   if (_options.Deserialize != null)
+                    return _options.Deserialize.Invoke(results[2]);
+
                 return results[2];
             }
 

--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -31,5 +31,15 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         {
             get { return this; }
         }
+        
+        /// <summary>
+        /// Optional function to serialize data before storing it in redis.
+        /// </summary>
+        public System.Func<byte[], string> Serialize { get; set; }
+        
+        /// <summary>
+        /// Optional function to deserialize data after fetching it from redis.
+        /// </summary>
+        public System.Func<string, byte[]> Deserialize { get; set; }
     }
 }


### PR DESCRIPTION
Adding two functions (Serialize / Deserialize) to support processing data before and after storing inside redis. I implemented this solution in my project as saving byte[] binary data could cause issues related to the replication. while this could binary-unsafe issue related to the replication module.

Usage : This is very simple example of using Base64 encoding for the binary data used in Startup.cs

```
services.AddStackExchangeRedisCache(options =>
            {
                options.Configuration = "127.0.0.1";
                options.InstanceName = "redisdb";
                 // Optional functions
                options.Serialize = (input) => { return Convert.ToBase64String(input); };
                options.Deserialize = (input) => { return Convert.FromBase64String(input); };
            });