### PR TITLE
doc improvements

### DIFF
--- a/src/DependencyInjection/DI/src/DefaultServiceProviderFactory.cs
+++ b/src/DependencyInjection/DI/src/DefaultServiceProviderFactory.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Initializes a new instance of the <see cref="DefaultServiceProviderFactory"/> class
         /// with default options.
         /// </summary>
-        /// <seealso cref="ServiceProviderOptions.Default"/>
         public DefaultServiceProviderFactory() : this(ServiceProviderOptions.Default)
         {
 

--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Http
     /// <para>
     /// To adapt an existing non-generic <see cref="IAsyncPolicy"/>, use code like the following:
     /// <example>
-    /// Converting a non-generic <code>IAsyncPolicy policy</code> to <see cref="IAsyncPolicy{HttpResponseMessage}"/>.
+    /// Converting a non-generic <c>IAsyncPolicy policy</c> to <see cref="IAsyncPolicy{HttpResponseMessage}"/>.
     /// <code>
     /// policy.AsAsyncPolicy&lt;HttpResponseMessage&gt;()
     /// </code>


### PR DESCRIPTION
- \<code> tag is causing weird formatting on docs because \<code> is for code blocks and \<c> is for inline code
https://docs.microsoft.com/en-us/dotnet/api/Microsoft.Extensions.Http.PolicyHttpMessageHandler?view=dotnet-plat-ext-3.0#remarks
- Link to internal API causes broken links in docs
https://docs.microsoft.com/en-us/dotnet/api/Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory.-ctor?view=dotnet-plat-ext-3.0