### PR TITLE
Write flaky test logs to a Flaky directory

### DIFF
--- a/src/Logging/Logging.Testing/src/AssemblyTestLog.cs
+++ b/src/Logging/Logging.Testing/src/AssemblyTestLog.cs
@@ -209,13 +209,14 @@ namespace Microsoft.Extensions.Logging.Testing
             return new AssemblyTestLog(loggerFactory, logger, baseDirectory, assembly, serviceProvider);
         }
 
-        public static AssemblyTestLog ForAssembly(Assembly assembly)
+        public static AssemblyTestLog ForAssembly(Assembly assembly, Func<string, string> baseDirectoryDelegate = null)
         {
             lock (_lock)
             {
                 if (!_logs.TryGetValue(assembly, out var log))
                 {
                     var baseDirectory = TestFileOutputContext.GetOutputDirectory(assembly);
+                    baseDirectory = baseDirectoryDelegate?.Invoke(baseDirectory);
 
                     log = Create(assembly, baseDirectory);
                     _logs[assembly] = log;

--- a/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
+++ b/src/Logging/Logging.Testing/src/LoggedTest/LoggedTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -63,12 +64,17 @@ namespace Microsoft.Extensions.Logging.Testing
                 var logLevelAttribute = methodInfo.GetCustomAttribute<LogLevelAttribute>()
                                         ?? methodInfo.DeclaringType.GetCustomAttribute<LogLevelAttribute>()
                                         ?? methodInfo.DeclaringType.Assembly.GetCustomAttribute<LogLevelAttribute>();
+                var flakyAttribute = methodInfo.GetCustomAttribute<FlakyAttribute>()
+                                        ?? methodInfo.DeclaringType.GetCustomAttribute<FlakyAttribute>()
+                                        ?? methodInfo.DeclaringType.Assembly.GetCustomAttribute<FlakyAttribute>();
 
                 // internal for testing
                 ResolvedTestClassName = context.FileOutput.TestClassName;
 
                 _testLog = AssemblyTestLog
-                    .ForAssembly(classType.GetTypeInfo().Assembly)
+                    .ForAssembly(
+                        classType.GetTypeInfo().Assembly,
+                        baseDirectory => flakyAttribute == null ? baseDirectory : Path.Combine(baseDirectory, "Flaky"))
                     .StartTestLog(
                         TestOutputHelper,
                         context.FileOutput.TestClassName,


### PR DESCRIPTION
A quick fix to parts of https://github.com/aspnet/AspNetCore/issues/17243. The changes are not exactly extensible to anything other than `Flaky` attributes but it should be sufficient for now.