### PR TITLE
Specify user secret directory with environment variable DOTNET_USER_SECRETS_DIR

### DIFF
--- a/src/Configuration/Config.UserSecrets/src/PathHelper.cs
+++ b/src/Configuration/Config.UserSecrets/src/PathHelper.cs
@@ -42,9 +42,13 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
 
             const string userSecretsFallbackDir = "DOTNET_USER_SECRETS_FALLBACK_DIR";
 
+            var root = Environment.GetEnvironmentVariable("DOTNET_USER_SECRETS_DIR"); // Allow setting a user secret directory with an environment variable. This can be used for development teams to share secrets projected by windows security
+            if (!string.IsNullOrEmpty(root))
+                return Path.Combine(root, userSecretsId, SecretsFileName);
+
             // For backwards compat, this checks env vars first before using Env.GetFolderPath
             var appData = Environment.GetEnvironmentVariable("APPDATA");
-            var root = appData                                                                   // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
+            root = appData                                                                       // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
                        ?? Environment.GetEnvironmentVariable("HOME")                             // On Mac/Linux it goes to ~/.microsoft/usersecrets/
                        ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) 
                        ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)


### PR DESCRIPTION
Provide the possibilty to specify the user secret directory with the environment variable DOTNET_USER_SECRETS_DIR. 
This can be used for development teams to store the secrets in a shared folder and protect them with the windows security.