### PR TITLE
Better MaxOsVersion tests, more WindowsVersions

### DIFF
--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.net46.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.net46.cs
@@ -326,9 +326,11 @@ namespace Microsoft.AspNetCore.Testing
     public static partial class WindowsVersions
     {
         public const string Win10 = "10.0";
+        public const string Win10_19H1 = "10.0.18362";
         public const string Win10_19H2 = "10.0.18363";
-        public const string Win10_20H1 = "10.0.18990";
+        public const string Win10_20H1 = "10.0.19033";
         public const string Win10_RS4 = "10.0.17134";
+        public const string Win10_RS5 = "10.0.17763";
         public const string Win2008R2 = "6.1";
         public const string Win7 = "6.1";
         public const string Win8 = "6.2";

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.netstandard2.0.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.netstandard2.0.cs
@@ -326,9 +326,11 @@ namespace Microsoft.AspNetCore.Testing
     public static partial class WindowsVersions
     {
         public const string Win10 = "10.0";
+        public const string Win10_19H1 = "10.0.18362";
         public const string Win10_19H2 = "10.0.18363";
-        public const string Win10_20H1 = "10.0.18990";
+        public const string Win10_20H1 = "10.0.19033";
         public const string Win10_RS4 = "10.0.17134";
+        public const string Win10_RS5 = "10.0.17763";
         public const string Win2008R2 = "6.1";
         public const string Win7 = "6.1";
         public const string Win8 = "6.2";

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MaximumOSVersionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MaximumOSVersionAttribute.cs
@@ -34,7 +34,8 @@ namespace Microsoft.AspNetCore.Testing
             _targetOS = targetOS;
             _maxVersion = maxVersion;
             _currentOS = currentOS;
-            _currentVersion = currentVersion;
+            // We drop the 4th field because it is not significant and it messes up the comparisons.
+            _currentVersion = new Version(currentVersion.Major, currentVersion.Minor, currentVersion.Build);
 
             // Do not skip other OS's, Use OSSkipConditionAttribute or a separate MaximumOsVersionAttribute for that.
             _skip = _targetOS == _currentOS && _maxVersion < _currentVersion;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WindowsVersions.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WindowsVersions.cs
@@ -24,13 +24,23 @@ namespace Microsoft.AspNetCore.Testing
         public const string Win10_RS4 = "10.0.17134";
 
         /// <summary>
+        /// 1809, RS5, 17763
+        /// </summary>
+        public const string Win10_RS5 = "10.0.17763";
+
+        /// <summary>
+        /// 1903, 19H1, 18362
+        /// </summary>
+        public const string Win10_19H1 = "10.0.18362";
+
+        /// <summary>
         /// 1909, 19H2, 18363
         /// </summary>
         public const string Win10_19H2 = "10.0.18363";
 
         /// <summary>
-        /// _, 20H2, 18990
+        /// 2004, 20H1, 19033
         /// </summary>
-        public const string Win10_20H1 = "10.0.18990";
+        public const string Win10_20H1 = "10.0.19033";
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionAttributeTest.cs
@@ -31,9 +31,9 @@ namespace Microsoft.AspNetCore.Testing
         {
             var osSkipAttribute = new MaximumOSVersionAttribute(
                 OperatingSystems.Windows,
-                new Version("2.5"),
+                new Version("2.5.9"),
                 OperatingSystems.Windows,
-                new Version("2.0"));
+                new Version("2.0.10.12"));
 
             Assert.True(osSkipAttribute.IsMet);
         }
@@ -43,9 +43,9 @@ namespace Microsoft.AspNetCore.Testing
         {
             var osSkipAttribute = new MaximumOSVersionAttribute(
                 OperatingSystems.Windows,
-                new Version("2.5"),
+                new Version("2.5.10"),
                 OperatingSystems.Windows,
-                new Version("2.5"));
+                new Version("2.5.10.12"));
 
             Assert.True(osSkipAttribute.IsMet);
         }
@@ -55,9 +55,9 @@ namespace Microsoft.AspNetCore.Testing
         {
             var osSkipAttribute = new MaximumOSVersionAttribute(
                 OperatingSystems.Windows,
-                new Version("2.5"),
+                new Version("2.5.11"),
                 OperatingSystems.Windows,
-                new Version("3.0"));
+                new Version("3.0.10.12"));
 
             Assert.False(osSkipAttribute.IsMet);
         }
@@ -67,9 +67,9 @@ namespace Microsoft.AspNetCore.Testing
         {
             var osSkipAttribute = new MaximumOSVersionAttribute(
                 OperatingSystems.Windows,
-                new Version("2.5"),
+                new Version("2.5.10.12"),
                 OperatingSystems.Linux,
-                new Version("2.5"));
+                new Version("2.5.10.12"));
 
             Assert.True(osSkipAttribute.IsMet);
         }


### PR DESCRIPTION
Fixed an issue with MaxiumumOSVersion to ignore the last field when doing comparisons. It's an unstable field and not relevant for our purposes.

I also added more WindowsVersions.