### PR TITLE
Build implementation projects against ref assemblies

### DIFF
--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -54,11 +54,11 @@
     <UseProjectReferences Condition=" '$(UseProjectReferences)' == '' ">false</UseProjectReferences>
 
     <!-- Specifies if reference assembly projects should be resolved for Reference items -->
-    <ReferenceReferenceAssemblies Condition=" '$(ReferenceReferenceAssemblies)' == '' AND ('$(IsReferenceAssemblyProject)' == 'true' OR '$(IsImplementationAssemblyProject)' == 'true')">true</ReferenceReferenceAssemblies>
+    <ReferenceReferenceAssemblies Condition=" '$(ReferenceReferenceAssemblies)' == '' AND ('$(IsReferenceAssemblyProject)' == 'true' OR '$(IsImplementationProject)' == 'true')">true</ReferenceReferenceAssemblies>
     <ReferenceReferenceAssemblies Condition=" '$(ReferenceReferenceAssemblies)' == '' ">false</ReferenceReferenceAssemblies>
 
     <!-- Specifies if implementation assembly projects should be resolved for Reference items -->
-    <ReferenceImplementationAssemblies Condition=" '$(ReferenceImplementationAssemblies)' == '' AND '$(IsReferenceAssemblyProject)' != 'true' AND '$(IsImplementationAssemblyProject)' != 'true'">true</ReferenceImplementationAssemblies>
+    <ReferenceImplementationAssemblies Condition=" '$(ReferenceImplementationAssemblies)' == '' AND '$(IsReferenceAssemblyProject)' != 'true' AND '$(IsImplementationProject)' != 'true'">true</ReferenceImplementationAssemblies>
     <ReferenceImplementationAssemblies Condition=" '$(ReferenceImplementationAssemblies)' == '' ">false</ReferenceImplementationAssemblies>
   </PropertyGroup>
 

--- a/src/Configuration/Config.Ini/test/Microsoft.Extensions.Configuration.Ini.Tests.csproj
+++ b/src/Configuration/Config.Ini/test/Microsoft.Extensions.Configuration.Ini.Tests.csproj
@@ -14,6 +14,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <Reference Include="Microsoft.Extensions.Configuration.Ini" />
     <Reference Include="Microsoft.Extensions.Configuration" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/Config.Json/test/Microsoft.Extensions.Configuration.Json.Tests.csproj
+++ b/src/Configuration/Config.Json/test/Microsoft.Extensions.Configuration.Json.Tests.csproj
@@ -15,6 +15,7 @@
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Configuration/Config.KeyPerFile/test/Microsoft.Extensions.Configuration.KeyPerFile.Tests.csproj
+++ b/src/Configuration/Config.KeyPerFile/test/Microsoft.Extensions.Configuration.KeyPerFile.Tests.csproj
@@ -15,6 +15,7 @@
     <Reference Include="Microsoft.Extensions.Configuration.KeyPerFile" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 

--- a/src/Configuration/Config.NewtonsoftJson/test/Microsoft.Extensions.Configuration.NewtonsoftJson.Tests.csproj
+++ b/src/Configuration/Config.NewtonsoftJson/test/Microsoft.Extensions.Configuration.NewtonsoftJson.Tests.csproj
@@ -15,6 +15,7 @@
     <Reference Include="Microsoft.Extensions.Configuration.NewtonsoftJson" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Configuration/Config.UserSecrets/test/Microsoft.Extensions.Configuration.UserSecrets.Tests.csproj
+++ b/src/Configuration/Config.UserSecrets/test/Microsoft.Extensions.Configuration.UserSecrets.Tests.csproj
@@ -10,6 +10,9 @@
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <Reference Include="Microsoft.Extensions.Configuration" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
 
     <Reference Include="Newtonsoft.Json" Condition="'$(TargetFramework)' == 'net472'"/>
   </ItemGroup>

--- a/src/Configuration/Config.Xml/test/Microsoft.Extensions.Configuration.Xml.Tests.csproj
+++ b/src/Configuration/Config.Xml/test/Microsoft.Extensions.Configuration.Xml.Tests.csproj
@@ -14,6 +14,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <Reference Include="Microsoft.Extensions.Configuration.Xml" />
     <Reference Include="Microsoft.Extensions.Configuration" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/Configuration/test/Config.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
+++ b/src/Configuration/test/Config.FunctionalTests/Microsoft.Extensions.Configuration.FunctionalTests.csproj
@@ -21,6 +21,7 @@
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 

--- a/src/Configuration/testassets/Test.Common/Microsoft.Extensions.Configuration.Test.Common.csproj
+++ b/src/Configuration/testassets/Test.Common/Microsoft.Extensions.Configuration.Test.Common.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/HealthChecks/HealthChecks/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests.csproj
+++ b/src/HealthChecks/HealthChecks/test/Microsoft.Extensions.Diagnostics.HealthChecks.Tests.csproj
@@ -17,6 +17,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hosting/Hosting/test/Microsoft.Extensions.Hosting.Tests.csproj
+++ b/src/Hosting/Hosting/test/Microsoft.Extensions.Hosting.Tests.csproj
@@ -11,20 +11,31 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
+    <Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Reference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging.Configuration" />
+    <Reference Include="Microsoft.Extensions.Logging.Console" />
+    <Reference Include="Microsoft.Extensions.Logging.Debug" />
+    <Reference Include="Microsoft.Extensions.Logging.EventLog" />
+    <Reference Include="Microsoft.Extensions.Logging.EventSource" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/Systemd/test/Microsoft.Extensions.Hosting.Systemd.Tests.csproj
+++ b/src/Hosting/Systemd/test/Microsoft.Extensions.Hosting.Systemd.Tests.csproj
@@ -5,11 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Hosting.Systemd" />
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/WindowsServices/test/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
+++ b/src/Hosting/WindowsServices/test/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
@@ -5,11 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/test/FunctionalTests/Microsoft.Extensions.Hosting.FunctionalTests.csproj
+++ b/src/Hosting/test/FunctionalTests/Microsoft.Extensions.Hosting.FunctionalTests.csproj
@@ -13,10 +13,15 @@
   <ItemGroup>
     <ProjectReference Include="..\..\IntegrationTesting\src\Microsoft.Extensions.Hosting.IntegrationTesting.csproj" />
 
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
+    <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Hosting/test/testassets/Microsoft.Extensions.Hosting.TestApp/Microsoft.Extensions.Hosting.TestApp.csproj
+++ b/src/Hosting/test/testassets/Microsoft.Extensions.Hosting.TestApp/Microsoft.Extensions.Hosting.TestApp.csproj
@@ -6,7 +6,30 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Workaround missing entries in deps files. Still under investigation -->
+    <RuntimeHostConfigurationOption
+      Include="Microsoft.NETCore.DotNetHostPolicy.SetAppPaths"
+      Value="true" />
+
+  	<Reference Include="Microsoft.Extensions.Configuration" />
+  	<Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+  	<Reference Include="Microsoft.Extensions.Configuration.Binder" />
+  	<Reference Include="Microsoft.Extensions.Configuration.CommandLine" />
+  	<Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+  	<Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+  	<Reference Include="Microsoft.Extensions.DependencyInjection" />
+  	<Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  	<Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+  	<Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging.Configuration" />
+    <Reference Include="Microsoft.Extensions.Logging.Console" />
+    <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpClientFactory/Http/test/Microsoft.Extensions.Http.Tests.csproj
+++ b/src/HttpClientFactory/Http/test/Microsoft.Extensions.Http.Tests.csproj
@@ -11,6 +11,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HttpClientFactory/Polly/test/Microsoft.Extensions.Http.Polly.Tests.csproj
+++ b/src/HttpClientFactory/Polly/test/Microsoft.Extensions.Http.Polly.Tests.csproj
@@ -11,6 +11,8 @@
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Http.Polly" />
     <Reference Include="Microsoft.Extensions.Http" />
+    <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/Logging.AzureAppServices/test/Microsoft.Extensions.Logging.AzureAppServices.Tests.csproj
+++ b/src/Logging/Logging.AzureAppServices/test/Microsoft.Extensions.Logging.AzureAppServices.Tests.csproj
@@ -6,14 +6,23 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+    <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.AzureAppServices" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/Logging.EventSource/test/Microsoft.Extensions.Logging.EventSource.Tests.csproj
+++ b/src/Logging/Logging.EventSource/test/Microsoft.Extensions.Logging.EventSource.Tests.csproj
@@ -10,6 +10,8 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.EventSource" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Primitives" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Logging/test/Microsoft.Extensions.Logging.Tests.csproj
+++ b/src/Logging/test/Microsoft.Extensions.Logging.Tests.csproj
@@ -6,11 +6,13 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
@@ -19,6 +21,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Testing" />
     <Reference Include="Microsoft.Extensions.Logging.TraceSource" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>

--- a/src/WebEncoders/test/Microsoft.Extensions.WebEncoders.Tests.csproj
+++ b/src/WebEncoders/test/Microsoft.Extensions.WebEncoders.Tests.csproj
@@ -8,6 +8,7 @@
     <Reference Include="Microsoft.Extensions.WebEncoders" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The previous PR for this (https://github.com/aspnet/Extensions/pull/2483) had a typo, replacing `IsImplementationProject` with `IsImplementationAssemblyProject`. This meant that Implementation projects were not being built against refs, which causing some assembly load errors upstream in AspNetCore. Local build confirms that implementation projects now reference 3.0.0.0 versions of their Extensions references.

@JunTaoLuo @dougbu PTAL