### PR TITLE
Fix MaxOsVersion on Ubuntu

### DIFF
--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MaximumOSVersionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/MaximumOSVersionAttribute.cs
@@ -35,7 +35,10 @@ namespace Microsoft.AspNetCore.Testing
             _maxVersion = maxVersion;
             _currentOS = currentOS;
             // We drop the 4th field because it is not significant and it messes up the comparisons.
-            _currentVersion = new Version(currentVersion.Major, currentVersion.Minor, currentVersion.Build);
+            _currentVersion = new Version(currentVersion.Major, currentVersion.Minor,
+                // Major and Minor are required by the parser, but if Build isn't specified then it returns -1
+                // which the constructor rejects.
+                currentVersion.Build == -1 ? 0 : currentVersion.Build);
 
             // Do not skip other OS's, Use OSSkipConditionAttribute or a separate MaximumOsVersionAttribute for that.
             _skip = _targetOS == _currentOS && _maxVersion < _currentVersion;

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionAttributeTest.cs
@@ -27,6 +27,18 @@ namespace Microsoft.AspNetCore.Testing
         }
 
         [Fact]
+        public void DoesNotSkip_ShortVersions()
+        {
+            var osSkipAttribute = new MaximumOSVersionAttribute(
+                OperatingSystems.Windows,
+                new Version("2.5"),
+                OperatingSystems.Windows,
+                new Version("2.0"));
+
+            Assert.True(osSkipAttribute.IsMet);
+        }
+
+        [Fact]
         public void DoesNotSkip_EarlierVersions()
         {
             var osSkipAttribute = new MaximumOSVersionAttribute(

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/MaximumOSVersionTest.cs
@@ -72,4 +72,19 @@ namespace Microsoft.AspNetCore.Testing
                 "Test should only be running on Win7 or Win2008R2.");
         }
     }
+
+    // Let this one run cross plat just to check the constructor logic.
+    [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win7)]
+    public class OSMaxVersionCrossPlatTest
+    {
+        [ConditionalFact]
+        public void TestSkipClass_Win7DoesRunOnWin7()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.True(Environment.OSVersion.Version.ToString().StartsWith("6.1"),
+                    "Test should only be running on Win7 or Win2008R2.");
+            }
+        }
+    }
 }


### PR DESCRIPTION
Found a bug in my last MaximumOSVersionAttribute change that copied a Version object. Apparently the value for unspecified segments is -1, which the constructor refuses. We didn't find this before because the tests were all skipped on Ubuntu which returns a two field version (16.04).
https://github.com/aspnet/AspNetCore/pull/17529#issuecomment-560567402.
