### PR TITLE
[release/3.1] Use Microsoft.NETCore.App.Internal for runtime version (#2497)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -74,6 +74,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="3.1.1-servicing.19576.9">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>f3f2dd583fffa254015fc21ff0e45784b333256d</Sha>
+    </Dependency>
     <!-- Keep this dependency at the bottom of ProductDependencies, else it will be picked as the parent for CoherentParentDependencies -->
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,6 +56,7 @@
     <!-- Packages from dotnet/core-setup -->
     <MicrosoftNETCoreAppRefPackageVersion>3.1.0</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>3.1.1-servicing.19576.9</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>3.1.1-servicing.19576.9</MicrosoftNETCoreAppInternalPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
     <!-- Packages from dotnet/corefx -->
     <MicrosoftBclAsyncInterfacesPackageVersion>1.1.0</MicrosoftBclAsyncInterfacesPackageVersion>

--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
     "dotnet": "3.1.100-preview1-014024",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimeVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ]
     }
   },


### PR DESCRIPTION
* Use Microsoft.NETCore.App.Internal for runtime version
For stable builds, core-setup is now publishing its artifacts to a suffixed directory (e.g. 3.0.1-servicing-19510-13) instead of 3.0.1. This ensures we don't have to overwrite outputs when we rebuild stable versions. Within that directory, it publishes the same set of files with the final file names as well as suffixed file names:
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-win-x64.msi
- https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.0.1-servicing-19510-13/dotnet-apphost-pack-3.0.1-servicing-19510-13-win-x64.msi

Downstream repos should install the runtime using the full suffixed version.