### PR TITLE
Remove version checks from OSSkipCondition

### DIFF
--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.net46.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.net46.cs
@@ -193,6 +193,8 @@ namespace Microsoft.AspNetCore.Testing
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
     public partial class OSSkipConditionAttribute : System.Attribute, Microsoft.AspNetCore.Testing.ITestCondition
     {
+        public OSSkipConditionAttribute(Microsoft.AspNetCore.Testing.OperatingSystems operatingSystem) { }
+        [System.ObsoleteAttribute("Use the Minimum/MaximumOSVersionAttribute for version checks.", true)]
         public OSSkipConditionAttribute(Microsoft.AspNetCore.Testing.OperatingSystems operatingSystem, params string[] versions) { }
         public bool IsMet { get { throw null; } }
         public string SkipReason { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
@@ -331,6 +333,7 @@ namespace Microsoft.AspNetCore.Testing
         public const string Win10_20H1 = "10.0.19033";
         public const string Win10_RS4 = "10.0.17134";
         public const string Win10_RS5 = "10.0.17763";
+        [System.ObsoleteAttribute("Use Win7 instead.", true)]
         public const string Win2008R2 = "6.1";
         public const string Win7 = "6.1";
         public const string Win8 = "6.2";

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.netstandard2.0.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/ref/Microsoft.AspNetCore.Testing.netstandard2.0.cs
@@ -193,6 +193,8 @@ namespace Microsoft.AspNetCore.Testing
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
     public partial class OSSkipConditionAttribute : System.Attribute, Microsoft.AspNetCore.Testing.ITestCondition
     {
+        public OSSkipConditionAttribute(Microsoft.AspNetCore.Testing.OperatingSystems operatingSystem) { }
+        [System.ObsoleteAttribute("Use the Minimum/MaximumOSVersionAttribute for version checks.", true)]
         public OSSkipConditionAttribute(Microsoft.AspNetCore.Testing.OperatingSystems operatingSystem, params string[] versions) { }
         public bool IsMet { get { throw null; } }
         public string SkipReason { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
@@ -331,6 +333,7 @@ namespace Microsoft.AspNetCore.Testing
         public const string Win10_20H1 = "10.0.19033";
         public const string Win10_RS4 = "10.0.17134";
         public const string Win10_RS5 = "10.0.17763";
+        [System.ObsoleteAttribute("Use Win7 instead.", true)]
         public const string Win2008R2 = "6.1";
         public const string Win7 = "6.1";
         public const string Win8 = "6.2";

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/OSSkipConditionAttribute.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/OSSkipConditionAttribute.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Testing
@@ -12,46 +10,31 @@ namespace Microsoft.AspNetCore.Testing
     public class OSSkipConditionAttribute : Attribute, ITestCondition
     {
         private readonly OperatingSystems _excludedOperatingSystem;
-        private readonly IEnumerable<string> _excludedVersions;
         private readonly OperatingSystems _osPlatform;
-        private readonly string _osVersion;
 
-        public OSSkipConditionAttribute(OperatingSystems operatingSystem, params string[] versions) :
-            this(
-                operatingSystem,
-                GetCurrentOS(),
-                GetCurrentOSVersion(),
-                versions)
+        public OSSkipConditionAttribute(OperatingSystems operatingSystem) :
+            this(operatingSystem, GetCurrentOS())
+        {
+        }
+
+        [Obsolete("Use the Minimum/MaximumOSVersionAttribute for version checks.", error: true)]
+        public OSSkipConditionAttribute(OperatingSystems operatingSystem,  params string[] versions) :
+            this(operatingSystem, GetCurrentOS())
         {
         }
 
         // to enable unit testing
-        internal OSSkipConditionAttribute(
-            OperatingSystems operatingSystem, OperatingSystems osPlatform, string osVersion, params string[] versions)
+        internal OSSkipConditionAttribute(OperatingSystems operatingSystem, OperatingSystems osPlatform)
         {
             _excludedOperatingSystem = operatingSystem;
-            _excludedVersions = versions ?? Enumerable.Empty<string>();
             _osPlatform = osPlatform;
-            _osVersion = osVersion;
         }
 
         public bool IsMet
         {
             get
             {
-                var currentOSInfo = new OSInfo()
-                {
-                    OperatingSystem = _osPlatform,
-                    Version = _osVersion,
-                };
-
-                var skip = (_excludedOperatingSystem & currentOSInfo.OperatingSystem) == currentOSInfo.OperatingSystem;
-                if (_excludedVersions.Any())
-                {
-                    skip = skip
-                        && _excludedVersions.Any(ex => _osVersion.StartsWith(ex, StringComparison.OrdinalIgnoreCase));
-                }
-
+                var skip = (_excludedOperatingSystem & _osPlatform) == _osPlatform;
                 // Since a test would be excuted only if 'IsMet' is true, return false if we want to skip
                 return !skip;
             }
@@ -74,26 +57,6 @@ namespace Microsoft.AspNetCore.Testing
                 return OperatingSystems.MacOSX;
             }
             throw new PlatformNotSupportedException();
-        }
-
-        static private string GetCurrentOSVersion()
-        {
-            // currently not used on other OS's
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return Environment.OSVersion.Version.ToString();
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
-
-        private class OSInfo
-        {
-            public OperatingSystems OperatingSystem { get; set; }
-
-            public string Version { get; set; }
         }
     }
 }

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WindowsVersions.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/WindowsVersions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Testing
 {
     /// <summary>
@@ -10,6 +12,7 @@ namespace Microsoft.AspNetCore.Testing
     {
         public const string Win7 = "6.1";
 
+        [Obsolete("Use Win7 instead.", error: true)]
         public const string Win2008R2 = Win7;
 
         public const string Win8 = "6.2";

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionAttributeTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionAttributeTest.cs
@@ -10,13 +10,12 @@ namespace Microsoft.AspNetCore.Testing
     public class OSSkipConditionAttributeTest
     {
         [Fact]
-        public void Skips_WhenOnlyOperatingSystemIsSupplied()
+        public void Skips_WhenOperatingSystemMatches()
         {
             // Act
             var osSkipAttribute = new OSSkipConditionAttribute(
                 OperatingSystems.Windows,
-                OperatingSystems.Windows,
-                "2.5");
+                OperatingSystems.Windows);
 
             // Assert
             Assert.False(osSkipAttribute.IsMet);
@@ -28,77 +27,18 @@ namespace Microsoft.AspNetCore.Testing
             // Act
             var osSkipAttribute = new OSSkipConditionAttribute(
                 OperatingSystems.Linux,
-                OperatingSystems.Windows,
-                "2.5");
+                OperatingSystems.Windows);
 
             // Assert
             Assert.True(osSkipAttribute.IsMet);
-        }
-
-        [Fact]
-        public void DoesNotSkip_WhenVersionsDoNotMatch()
-        {
-            // Act
-            var osSkipAttribute = new OSSkipConditionAttribute(
-                OperatingSystems.Windows,
-                OperatingSystems.Windows,
-                "2.5",
-                "10.0");
-
-            // Assert
-            Assert.True(osSkipAttribute.IsMet);
-        }
-
-        [Fact]
-        public void DoesNotSkip_WhenOnlyVersionsMatch()
-        {
-            // Act
-            var osSkipAttribute = new OSSkipConditionAttribute(
-                OperatingSystems.Linux,
-                OperatingSystems.Windows,
-                "2.5",
-                "2.5");
-
-            // Assert
-            Assert.True(osSkipAttribute.IsMet);
-        }
-
-        [Theory]
-        [InlineData("2.5", "2.5")]
-        [InlineData("blue", "Blue")]
-        public void Skips_WhenVersionsMatches(string currentOSVersion, string skipVersion)
-        {
-            // Act
-            var osSkipAttribute = new OSSkipConditionAttribute(
-                OperatingSystems.Windows,
-                OperatingSystems.Windows,
-                currentOSVersion,
-                skipVersion);
-
-            // Assert
-            Assert.False(osSkipAttribute.IsMet);
-        }
-
-        [Fact]
-        public void Skips_WhenVersionsMatchesOutOfMultiple()
-        {
-            // Act
-            var osSkipAttribute = new OSSkipConditionAttribute(
-                OperatingSystems.Windows,
-                OperatingSystems.Windows,
-                "2.5",
-                "10.0", "3.4", "2.5");
-
-            // Assert
-            Assert.False(osSkipAttribute.IsMet);
         }
 
         [Fact]
         public void Skips_BothMacOSXAndLinux()
         {
             // Act
-            var osSkipAttributeLinux = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.MacOSX, OperatingSystems.Linux, string.Empty);
-            var osSkipAttributeMacOSX = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.MacOSX, OperatingSystems.MacOSX, string.Empty);
+            var osSkipAttributeLinux = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.MacOSX, OperatingSystems.Linux);
+            var osSkipAttributeMacOSX = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.MacOSX, OperatingSystems.MacOSX);
 
             // Assert
             Assert.False(osSkipAttributeLinux.IsMet);
@@ -109,8 +49,8 @@ namespace Microsoft.AspNetCore.Testing
         public void Skips_BothMacOSXAndWindows()
         {
             // Act
-            var osSkipAttribute = new OSSkipConditionAttribute(OperatingSystems.Windows | OperatingSystems.MacOSX, OperatingSystems.Windows, string.Empty);
-            var osSkipAttributeMacOSX = new OSSkipConditionAttribute(OperatingSystems.Windows | OperatingSystems.MacOSX, OperatingSystems.MacOSX, string.Empty);
+            var osSkipAttribute = new OSSkipConditionAttribute(OperatingSystems.Windows | OperatingSystems.MacOSX, OperatingSystems.Windows);
+            var osSkipAttributeMacOSX = new OSSkipConditionAttribute(OperatingSystems.Windows | OperatingSystems.MacOSX, OperatingSystems.MacOSX);
 
             // Assert
             Assert.False(osSkipAttribute.IsMet);
@@ -121,8 +61,8 @@ namespace Microsoft.AspNetCore.Testing
         public void Skips_BothWindowsAndLinux()
         {
             // Act
-            var osSkipAttribute = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.Windows, OperatingSystems.Windows, string.Empty);
-            var osSkipAttributeLinux = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.Windows, OperatingSystems.Linux, string.Empty);
+            var osSkipAttribute = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.Windows, OperatingSystems.Windows);
+            var osSkipAttributeLinux = new OSSkipConditionAttribute(OperatingSystems.Linux | OperatingSystems.Windows, OperatingSystems.Linux);
 
             // Assert
             Assert.False(osSkipAttribute.IsMet);

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionTest.cs
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/test/OSSkipConditionTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -25,16 +24,6 @@ namespace Microsoft.AspNetCore.Testing
             Assert.False(
                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX),
                 "Test should not be running on MacOSX.");
-        }
-
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2)]
-        public void RunTest_DoesNotRunOnWin7OrWin2008R2()
-        {
-            Assert.False(
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                Environment.OSVersion.Version.ToString().StartsWith("6.1"),
-                "Test should not be running on Win7 or Win2008R2.");
         }
 
         [ConditionalFact]


### PR DESCRIPTION
OSSkipCondition's version checking logic is both outdated and redundant with Minimum/MaximumOSVersionAttribute. It was also weird to have version fields when OSSkipCondition supports specifying multiple OSs at at time (`OperatingSystems.Linux | OperatingSystems.MacOSX`).