### PR TITLE
[Release/3.0] Set IsShipping=false for all TestingUtils projects

### DIFF
--- a/src/TestingUtils/Directory.Build.props
+++ b/src/TestingUtils/Directory.Build.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <!-- These projects depend on a 3rd party source -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/TestingUtils/Internal.AspNetCore.Analyzers/src/Internal.AspNetCore.Analyzers.csproj
+++ b/src/TestingUtils/Internal.AspNetCore.Analyzers/src/Internal.AspNetCore.Analyzers.csproj
@@ -15,7 +15,6 @@
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj
@@ -10,7 +10,6 @@
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
     <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/TestingUtils/Microsoft.AspNetCore.Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -9,7 +9,6 @@
     <!-- This is actually a library for test projects, not a test project. -->
     <IsUnitTestProject>false</IsUnitTestProject>
     <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
     <HasReferenceAssembly>true</HasReferenceAssembly>
     <GenerateFrameworkReferenceAssembly>true</GenerateFrameworkReferenceAssembly>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->


### PR DESCRIPTION
Without this, the ref project(s) in this dir get the default value of `IsShipping=true` from Arcade: https://github.com/dotnet/arcade/blob/0c9b0442f2ce607a90615a7bfad4ead069150bc6/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets#L18. This means that other projects which compile against ref projects in this folder (i.e., `Microsoft.Extensions.Logging.Testing` compiles against `Microsoft.AspNetCore.Testing`) will get non-suffixed versions for their dependencies. When we ship stable, `Microsoft.Extensions.Logging.Testing` lists a dependency on a stable version of `Microsoft.AspNetCore.Testing`, which does not exist.

We should think of a better way to resolve this issue - for example, AspNetCore calculates a global default for `IsShipping`, which would prevent this type of issue: https://github.com/aspnet/AspNetCore/blob/20fc1adf2ada01a4a1fc7934706d2b641acbb9f4/Directory.Build.props#L23

It's also worth noting that `Microsoft.AspNetCore.Testing` is unique in that it is a non-shipping project that has a ref assembly. We should understand why that ref assembly is needed, and decide if it can be removed (removing it caused some errors that seemed non-trivial to fix). The ref assembly was added in this PR: https://github.com/aspnet/Extensions/pull/2483

CC @dougbu @JunTaoLuo @mmitche 