### PR TITLE
[release/3.0] Move Microsoft.NET.Platforms above pinned

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -70,6 +70,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>b7dd5aff44d496b8cc46c613fa686540200e226a</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>e14c43ea3f727d1ed8844014aae8b168cc608b22</Sha>
+    </Dependency>
     <!-- Keep this dependency at the bottom of ProductDependencies, else it will be picked as the parent for CoherentParentDependencies -->
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>
@@ -92,10 +96,6 @@
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19607.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4d80b9cfa53e309c8f685abff3512f60c3d8a3d1</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>e14c43ea3f727d1ed8844014aae8b168cc608b22</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.3.1-beta4-19462-11">
       <Uri>https://github.com/dotnet/roslyn</Uri>


### PR DESCRIPTION
I think this is still causing CPD problems in upstack updates. While this isn't technically a product dependency, it's tied to a product dependency (core-setup)