### PR TITLE
[release/3.1] Move Microsoft.NET.Platforms above pinned

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -74,6 +74,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>f3f2dd583fffa254015fc21ff0e45784b333256d</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.1.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+    </Dependency>
     <!-- Keep this dependency at the bottom of ProductDependencies, else it will be picked as the parent for CoherentParentDependencies -->
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.1.0" Pinned="true">
       <Uri>https://github.com/dotnet/core-setup</Uri>
@@ -96,10 +100,6 @@
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19607.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4d80b9cfa53e309c8f685abff3512f60c3d8a3d1</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.1.0" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.4.0-beta4-19569-03">
       <Uri>https://github.com/dotnet/roslyn</Uri>


### PR DESCRIPTION
I think this is still causing CPD problems in upstack updates. While this isn't technically a product dependency, it's tied to a product dependency (core-setup)