### PR TITLE
Allow ExecuteAsync cancellation propagation

### DIFF
--- a/src/Hosting/Abstractions/src/BackgroundService.cs
+++ b/src/Hosting/Abstractions/src/BackgroundService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting
     public abstract class BackgroundService : IHostedService, IDisposable
     {
         private Task _executingTask;
-        private readonly CancellationTokenSource _stoppingCts = new CancellationTokenSource();
+        private CancellationTokenSource _stoppingCts;
 
         /// <summary>
         /// This method is called when the <see cref="IHostedService"/> starts. The implementation should return a task that represents
@@ -29,6 +29,9 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
+            // Create linked token
+            _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
             // Store the task we're executing
             _executingTask = ExecuteAsync(_stoppingCts.Token);
 

--- a/src/Hosting/Abstractions/src/BackgroundService.cs
+++ b/src/Hosting/Abstractions/src/BackgroundService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
-            // Create linked token
+            // Create linked token to allow cancelling executing task from provided token
             _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // Store the task we're executing
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.Hosting
 
         public virtual void Dispose()
         {
-            _stoppingCts.Cancel();
+            _stoppingCts?.Cancel();
         }
     }
 }

--- a/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
+++ b/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
@@ -120,6 +120,14 @@ namespace Microsoft.Extensions.Hosting.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(() => service.ExecutingTask);
         }
 
+        [Fact]
+        public void CreateAndDisposeShouldNotThrow()
+        {
+            var service = new WaitForCancelledTokenService();
+
+            service.Dispose();
+        }
+
         private class WaitForCancelledTokenService : BackgroundService
         {
             public Task ExecutingTask { get; private set; }

--- a/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
+++ b/src/Hosting/Hosting/test/BackgroundHostedServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -106,11 +106,28 @@ namespace Microsoft.Extensions.Hosting.Tests
             service.Dispose();
         }
 
+        [Fact]
+        public async Task StartAsyncThenCancelShouldCancelExecutingTask()
+        {
+            var tokenSource = new CancellationTokenSource();
+
+            var service = new WaitForCancelledTokenService();
+
+            await service.StartAsync(tokenSource.Token);
+
+            tokenSource.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => service.ExecutingTask);
+        }
+
         private class WaitForCancelledTokenService : BackgroundService
         {
+            public Task ExecutingTask { get; private set; }
+
             protected override Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                return Task.Delay(Timeout.Infinite, stoppingToken);
+                ExecutingTask = Task.Delay(Timeout.Infinite, stoppingToken);
+                return ExecutingTask;
             }
         }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Add test
 - Link the token provided to ```StartAsync``` to the one provided to the ```_executingTask ```

fixes #2811 
